### PR TITLE
SkBee - 1.17.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.shanebeestudios</groupId>
     <artifactId>SkBee</artifactId>
-    <version>1.16.2</version>
+    <version>1.17.0-Beta1</version>
 
     <properties>
         <maven.compiler.source>16</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.SkriptLang</groupId>
             <artifactId>Skript</artifactId>
-            <version>2.6.1</version>
+            <version>2.6.2</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -138,6 +138,7 @@ public class SkBee extends JavaPlugin {
         loadStatisticElements();
         loadVillagerElements();
         loadAdvancementElements();
+        loadWorldBorderElements();
     }
 
     private void loadCommands() {
@@ -404,6 +405,20 @@ public class SkBee extends JavaPlugin {
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.advancement");
             Util.logLoading("&5Advancement Elements &asuccessfully loaded");
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            pm.disablePlugin(this);
+        }
+    }
+
+    private void loadWorldBorderElements() {
+        if (!this.config.ELEMENTS_WORLD_BORDER) {
+            Util.logLoading("&5World Border Elements &cdisabled via config");
+            return;
+        }
+        try {
+            addon.loadClasses("com.shanebeestudios.skbee.elements.worldborder");
+            Util.logLoading("&5World Border Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -59,6 +59,7 @@ public class SkBee extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Let's get this party started...
         long start = System.currentTimeMillis();
         instance = this;
         this.config = new Config(this);
@@ -66,14 +67,11 @@ public class SkBee extends JavaPlugin {
         this.pm = Bukkit.getPluginManager();
         this.skriptPlugin = pm.getPlugin("Skript");
 
+        // Check if SkriptAddon can actually load
         if (!canLoadPlugin()) {
             pm.disablePlugin(this);
             return;
         }
-
-        addon = Skript.registerAddon(this);
-        addon.setLanguageFileDirectory("lang");
-        this.nbtApi = new NBTApi();
 
         loadSkriptElements();
         loadCommands();
@@ -89,9 +87,11 @@ public class SkBee extends JavaPlugin {
         UpdateChecker.checkForUpdate(version);
         Util.log("&aSuccessfully enabled v%s&7 in &b%.2f seconds", version, (float) (System.currentTimeMillis() - start) / 1000);
 
+        // Load custom worlds if enabled in config
         if (this.beeWorldConfig != null && this.config.AUTO_LOAD_WORLDS) {
             this.beeWorldConfig.loadCustomWorlds();
         }
+        // Looks like we made it after all
     }
 
     private boolean canLoadPlugin() {
@@ -122,6 +122,10 @@ public class SkBee extends JavaPlugin {
     }
 
     private void loadSkriptElements() {
+        addon = Skript.registerAddon(this);
+        addon.setLanguageFileDirectory("lang");
+        this.nbtApi = new NBTApi();
+
         loadNBTElements();
         loadRecipeElements();
         loadScoreboardElements();

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -11,6 +11,7 @@ import com.shanebeestudios.skbee.api.listener.EntityListener;
 import com.shanebeestudios.skbee.api.listener.NBTListener;
 import com.shanebeestudios.skbee.api.structure.StructureBeeManager;
 import com.shanebeestudios.skbee.api.util.LoggerBee;
+import com.shanebeestudios.skbee.api.util.UpdateChecker;
 import com.shanebeestudios.skbee.api.util.Util;
 import com.shanebeestudios.skbee.config.Config;
 import com.shanebeestudios.skbee.elements.bound.config.BoundConfig;
@@ -121,6 +122,7 @@ public class SkBee extends JavaPlugin {
         }
 
         loadMetrics();
+        UpdateChecker.checkForUpdate(version);
         Util.log("&aSuccessfully enabled v%s&7 in &b%.2f seconds", version, (float) (System.currentTimeMillis() - start) / 1000);
 
         if (this.beeWorldConfig != null && this.config.AUTO_LOAD_WORLDS) {

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -148,6 +148,7 @@ public class SkBee extends JavaPlugin {
     private void loadCommands() {
         //noinspection ConstantConditions
         getCommand("skbee").setExecutor(new SkBeeInfo(this));
+        pm.registerEvents(new UpdateChecker(this), this);
     }
 
     private void loadNBTElements() {

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -110,6 +110,7 @@ public class SkBee extends JavaPlugin {
         loadBossBarElements();
         loadStatisticElements();
         loadVillagerElements();
+        loadAdvancementElements();
 
         //noinspection ConstantConditions
         getCommand("skbee").setExecutor(new SkBeeInfo(this));
@@ -375,6 +376,20 @@ public class SkBee extends JavaPlugin {
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.villager");
             Util.logLoading("&5Villager Elements &asuccessfully loaded");
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            pm.disablePlugin(this);
+        }
+    }
+
+    private void loadAdvancementElements() {
+        if (!this.config.ELEMENTS_ADVANCEMENT) {
+            Util.logLoading("&5Advancement Elements &cdisabled via config");
+            return;
+        }
+        try {
+            addon.loadClasses("com.shanebeestudios.skbee.elements.advancement");
+            Util.logLoading("&5Advancement Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -5,6 +5,7 @@ import ch.njol.skript.SkriptAddon;
 import ch.njol.skript.registrations.Classes;
 import com.github.goingoffskript.skriptvariabledump.SkriptToYaml;
 import com.shanebeestudios.skbee.api.NBT.NBTApi;
+import com.shanebeestudios.skbee.api.command.SkBeeInfo;
 import com.shanebeestudios.skbee.api.listener.BoundBorderListener;
 import com.shanebeestudios.skbee.api.listener.EntityListener;
 import com.shanebeestudios.skbee.api.listener.NBTListener;
@@ -26,7 +27,6 @@ import org.bukkit.Statistic;
 import org.bukkit.boss.BossBar;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scoreboard.Team;
@@ -60,8 +60,6 @@ public class SkBee extends JavaPlugin {
         this.config = new Config(this);
         MinecraftVersion.replaceLogger(LoggerBee.getLogger());
         this.pm = Bukkit.getPluginManager();
-        PluginDescriptionFile desc = getDescription();
-
         this.skriptPlugin = pm.getPlugin("Skript");
 
         if (skriptPlugin == null) {
@@ -111,14 +109,18 @@ public class SkBee extends JavaPlugin {
         loadBossBarElements();
         loadStatisticElements();
 
+        //noinspection ConstantConditions
+        getCommand("skbee").setExecutor(new SkBeeInfo(this));
+
         // Beta check + notice
-        if (desc.getVersion().contains("-")) {
+        String version = getDescription().getVersion();
+        if (version.contains("-")) {
             Util.log("&eThis is a BETA build, things may not work as expected, please report any bugs on GitHub");
             Util.log("&ehttps://github.com/ShaneBeee/SkBee/issues");
         }
 
         loadMetrics();
-        Util.log("&aSuccessfully enabled v%s&7 in &b%.2f seconds", desc.getVersion(), (float) (System.currentTimeMillis() - start) / 1000);
+        Util.log("&aSuccessfully enabled v%s&7 in &b%.2f seconds", version, (float) (System.currentTimeMillis() - start) / 1000);
 
         if (this.beeWorldConfig != null && this.config.AUTO_LOAD_WORLDS) {
             this.beeWorldConfig.loadCustomWorlds();
@@ -127,15 +129,15 @@ public class SkBee extends JavaPlugin {
 
     private void loadNBTElements() {
         if (!this.config.ELEMENTS_NBT) {
-            Util.log("&5NBT Elements &cdisabled via config");
+            Util.logLoading("&5NBT Elements &cdisabled via config");
             return;
         }
         if (!this.nbtApi.isEnabled()) {
             String ver = Skript.getMinecraftVersion().toString();
-            Util.log("&5NBT Elements &cDISABLED!");
-            Util.log(" - Your server version [&b" + ver + "&7] is not currently supported by the NBT-API");
-            Util.log(" - This is not a bug!");
-            Util.log(" - NBT elements will resume once the API is updated to work with [&b" + ver + "&7]");
+            Util.logLoading("&5NBT Elements &cDISABLED!");
+            Util.logLoading(" - Your server version [&b" + ver + "&7] is not currently supported by the NBT-API");
+            Util.logLoading(" - This is not a bug!");
+            Util.logLoading(" - NBT elements will resume once the API is updated to work with [&b" + ver + "&7]");
             return;
         }
         try {
@@ -148,7 +150,7 @@ public class SkBee extends JavaPlugin {
             if (NBTApi.SUPPORTS_BLOCK_NBT) {
                 pm.registerEvents(new NBTListener(), this);
             }
-            Util.log("&5NBT Elements &asuccessfully loaded");
+            Util.logLoading("&5NBT Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -157,12 +159,12 @@ public class SkBee extends JavaPlugin {
 
     private void loadRecipeElements() {
         if (!this.config.ELEMENTS_RECIPE) {
-            Util.log("&5Recipe Elements &cdisabled via config");
+            Util.logLoading("&5Recipe Elements &cdisabled via config");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.recipe");
-            Util.log("&5Recipe Elements &asuccessfully loaded");
+            Util.logLoading("&5Recipe Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -171,13 +173,13 @@ public class SkBee extends JavaPlugin {
 
     private void loadScoreboardElements() {
         if (!this.config.ELEMENTS_BOARD) {
-            Util.log("&5Scoreboard Elements &cdisabled via config");
+            Util.logLoading("&5Scoreboard Elements &cdisabled via config");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.scoreboard");
             pm.registerEvents(new BoardManager(), this);
-            Util.log("&5Scoreboard Elements &asuccessfully loaded");
+            Util.logLoading("&5Scoreboard Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -186,18 +188,18 @@ public class SkBee extends JavaPlugin {
 
     private void loadTeamElements() {
         if (!this.config.ELEMENTS_TEAM) {
-            Util.log("&5Team Elements &cdisabled via config");
+            Util.logLoading("&5Team Elements &cdisabled via config");
             return;
         }
         if (Classes.getClassInfoNoError("team") != null || Classes.getExactClassInfo(Team.class) != null) {
-            Util.log("&5Team Elements &cdisabled");
-            Util.log("&7It appears another Skript addon may have registered Team syntax.");
-            Util.log("&7To use SkBee Teams, please remove the addon which has registered Teams already.");
+            Util.logLoading("&5Team Elements &cdisabled");
+            Util.logLoading("&7It appears another Skript addon may have registered Team syntax.");
+            Util.logLoading("&7To use SkBee Teams, please remove the addon which has registered Teams already.");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.team");
-            Util.log("&5Team Elements &asuccessfully loaded");
+            Util.logLoading("&5Team Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -206,14 +208,14 @@ public class SkBee extends JavaPlugin {
 
     private void loadBoundElements() {
         if (!this.config.ELEMENTS_BOUND) {
-            Util.log("&5Bound Elements &cdisabled via config");
+            Util.logLoading("&5Bound Elements &cdisabled via config");
             return;
         }
         try {
             this.boundConfig = new BoundConfig(this);
             pm.registerEvents(new BoundBorderListener(this), this);
             addon.loadClasses("com.shanebeestudios.skbee.elements.bound");
-            Util.log("&5Bound Elements &asuccessfully loaded");
+            Util.logLoading("&5Bound Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -222,12 +224,12 @@ public class SkBee extends JavaPlugin {
 
     private void loadTextElements() {
         if (!this.config.ELEMENTS_TEXT_COMPONENT) {
-            Util.log("&5Text Component Elements &cdisabled via config");
+            Util.logLoading("&5Text Component Elements &cdisabled via config");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.text");
-            Util.log("&5Text Component Elements &asuccessfully loaded");
+            Util.logLoading("&5Text Component Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -236,12 +238,12 @@ public class SkBee extends JavaPlugin {
 
     private void loadPathElements() {
         if (!this.config.ELEMENTS_PATHFINDING) {
-            Util.log("&5Pathfinding Elements &cdisabled via config");
+            Util.logLoading("&5Pathfinding Elements &cdisabled via config");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.path");
-            Util.log("&5Pathfinding Elements &asuccessfully loaded");
+            Util.logLoading("&5Pathfinding Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -250,14 +252,14 @@ public class SkBee extends JavaPlugin {
 
     private void loadStructureElements() {
         if (!this.config.ELEMENTS_STRUCTURE) {
-            Util.log("&5Structure Elements &cdisabled via config");
+            Util.logLoading("&5Structure Elements &cdisabled via config");
             return;
         }
 
         this.structureBeeManager = new StructureBeeManager();
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.structure");
-            Util.log("&5Structure Elements &asuccessfully loaded");
+            Util.logLoading("&5Structure Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -265,23 +267,18 @@ public class SkBee extends JavaPlugin {
     }
 
     private void loadVirtualFurnaceElements() {
-        if (Skript.classExists("org.bukkit.persistence.PersistentDataContainer")) {
-            if (!this.config.ELEMENTS_VIRTUAL_FURNACE) {
-                Util.log("&5Virtual Furnace Elements &cdisabled via config");
-                return;
-            }
-            try {
-                this.virtualFurnaceAPI = new VirtualFurnaceAPI(this, true);
-                pm.registerEvents(new VirtualFurnaceListener(), this);
-                addon.loadClasses("com.shanebeestudios.skbee.elements.virtualfurnace");
-                Util.log("&5Virtual Furnace Elements &asuccessfully loaded");
-            } catch (IOException e) {
-                e.printStackTrace();
-                pm.disablePlugin(this);
-            }
-        } else {
-            Util.log("&5Virtual Furnace Elements &cdisabled");
-            Util.log("&7 - Virtual Furnace elements are only available on 1.14+");
+        if (!this.config.ELEMENTS_VIRTUAL_FURNACE) {
+            Util.logLoading("&5Virtual Furnace Elements &cdisabled via config");
+            return;
+        }
+        try {
+            this.virtualFurnaceAPI = new VirtualFurnaceAPI(this, true);
+            pm.registerEvents(new VirtualFurnaceListener(), this);
+            addon.loadClasses("com.shanebeestudios.skbee.elements.virtualfurnace");
+            Util.logLoading("&5Virtual Furnace Elements &asuccessfully loaded");
+        } catch (IOException e) {
+            e.printStackTrace();
+            pm.disablePlugin(this);
         }
     }
 
@@ -289,7 +286,7 @@ public class SkBee extends JavaPlugin {
         try {
             pm.registerEvents(new EntityListener(), this);
             addon.loadClasses("com.shanebeestudios.skbee.elements.other");
-            Util.log("&5Other Elements &asuccessfully loaded");
+            Util.logLoading("&5Other Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -298,13 +295,13 @@ public class SkBee extends JavaPlugin {
 
     private void loadWorldCreatorElements() {
         if (!this.config.ELEMENTS_WORLD_CREATOR) {
-            Util.log("&5World Creator Elements &cdisabled via config");
+            Util.logLoading("&5World Creator Elements &cdisabled via config");
             return;
         }
         try {
             this.beeWorldConfig = new BeeWorldConfig(this);
             addon.loadClasses("com.shanebeestudios.skbee.elements.worldcreator");
-            Util.log("&5World Creator Elements &asuccessfully loaded");
+            Util.logLoading("&5World Creator Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -313,12 +310,12 @@ public class SkBee extends JavaPlugin {
 
     private void loadGameEventElements() {
         if (!this.config.ELEMENTS_GAME_EVENT) {
-            Util.log("&5Game Event Elements &cdisabled via config");
+            Util.logLoading("&5Game Event Elements &cdisabled via config");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.gameevent");
-            Util.log("&5Game Event Elements &asuccessfully loaded");
+            Util.logLoading("&5Game Event Elements &asuccessfully loaded");
         } catch (IOException e) {
             e.printStackTrace();
             pm.disablePlugin(this);
@@ -328,18 +325,18 @@ public class SkBee extends JavaPlugin {
 
     private void loadBossBarElements() {
         if (!this.config.ELEMENTS_BOSS_BAR) {
-            Util.log("&5BossBar Elements &cdisabled via config");
+            Util.logLoading("&5BossBar Elements &cdisabled via config");
             return;
         }
         if (Classes.getClassInfoNoError("bossbar") != null || Classes.getExactClassInfo(BossBar.class) != null) {
-            Util.log("&5BossBar Elements &cdisabled");
-            Util.log("&7It appears another Skript addon may have registered BossBar syntax.");
-            Util.log("&7To use SkBee BossBars, please remove the addon which has registered BossBars already.");
+            Util.logLoading("&5BossBar Elements &cdisabled");
+            Util.logLoading("&7It appears another Skript addon may have registered BossBar syntax.");
+            Util.logLoading("&7To use SkBee BossBars, please remove the addon which has registered BossBars already.");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.bossbar");
-            Util.log("&5BossBar Elements &asuccessfully loaded");
+            Util.logLoading("&5BossBar Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);
@@ -349,18 +346,18 @@ public class SkBee extends JavaPlugin {
 
     private void loadStatisticElements() {
         if (!this.config.ELEMENTS_STATISTIC) {
-            Util.log("&5Statistic Elements &cdisabled via config");
+            Util.logLoading("&5Statistic Elements &cdisabled via config");
             return;
         }
         if (Classes.getClassInfoNoError("statistic") != null || Classes.getExactClassInfo(Statistic.class) != null) {
-            Util.log("&5Statistic Elements &cdisabled");
-            Util.log("&7It appears another Skript addon may have registered Statistic syntax.");
-            Util.log("&7To use SkBee Statistics, please remove the addon which has registered Statistic already.");
+            Util.logLoading("&5Statistic Elements &cdisabled");
+            Util.logLoading("&7It appears another Skript addon may have registered Statistic syntax.");
+            Util.logLoading("&7To use SkBee Statistics, please remove the addon which has registered Statistic already.");
             return;
         }
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.statistic");
-            Util.log("&5Statistic Elements &asuccessfully loaded");
+            Util.logLoading("&5Statistic Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -108,6 +108,7 @@ public class SkBee extends JavaPlugin {
         loadGameEventElements();
         loadBossBarElements();
         loadStatisticElements();
+        loadVillagerElements();
 
         //noinspection ConstantConditions
         getCommand("skbee").setExecutor(new SkBeeInfo(this));
@@ -358,6 +359,20 @@ public class SkBee extends JavaPlugin {
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.statistic");
             Util.logLoading("&5Statistic Elements &asuccessfully loaded");
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            pm.disablePlugin(this);
+        }
+    }
+
+    private void loadVillagerElements() {
+        if (!this.config.ELEMENTS_VILLAGER) {
+            Util.logLoading("&5Villager Elements &cdisabled via config");
+            return;
+        }
+        try {
+            addon.loadClasses("com.shanebeestudios.skbee.elements.villager");
+            Util.logLoading("&5Villager Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pm.disablePlugin(this);

--- a/src/main/java/com/shanebeestudios/skbee/SkBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/SkBee.java
@@ -22,6 +22,7 @@ import com.shanebeestudios.vf.api.VirtualFurnaceAPI;
 import de.tr7zw.changeme.nbtapi.NBTContainer;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import org.bukkit.Bukkit;
+import org.bukkit.Statistic;
 import org.bukkit.boss.BossBar;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.plugin.Plugin;
@@ -108,6 +109,7 @@ public class SkBee extends JavaPlugin {
         loadWorldCreatorElements();
         loadGameEventElements();
         loadBossBarElements();
+        loadStatisticElements();
 
         // Beta check + notice
         if (desc.getVersion().contains("Beta")) {
@@ -343,6 +345,26 @@ public class SkBee extends JavaPlugin {
             pm.disablePlugin(this);
         }
 
+    }
+
+    private void loadStatisticElements() {
+        if (!this.config.ELEMENTS_STATISTIC) {
+            Util.log("&5Statistic Elements &cdisabled via config");
+            return;
+        }
+        if (Classes.getClassInfoNoError("statistic") != null || Classes.getExactClassInfo(Statistic.class) != null) {
+            Util.log("&5Statistic Elements &cdisabled");
+            Util.log("&7It appears another Skript addon may have registered Statistic syntax.");
+            Util.log("&7To use SkBee Statistics, please remove the addon which has registered Statistic already.");
+            return;
+        }
+        try {
+            addon.loadClasses("com.shanebeestudios.skbee.elements.statistic");
+            Util.log("&5Statistic Elements &asuccessfully loaded");
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            pm.disablePlugin(this);
+        }
     }
 
     private void loadMetrics() { //6719

--- a/src/main/java/com/shanebeestudios/skbee/api/command/SkBeeInfo.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/command/SkBeeInfo.java
@@ -1,0 +1,58 @@
+package com.shanebeestudios.skbee.api.command;
+
+import ch.njol.skript.Skript;
+import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.shanebeestudios.skbee.api.util.Util.sendColMsg;
+
+public class SkBeeInfo implements TabExecutor {
+
+    private final PluginDescriptionFile desc;
+
+    public SkBeeInfo(SkBee plugin) {
+        this.desc = plugin.getDescription();
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length > 0 && args[0].equalsIgnoreCase("info")) {
+            sendColMsg(sender, "&7--- [&bSkBee Loading Info&7] ---");
+            Util.getDebugs().forEach(debug -> sendColMsg(sender, "- " + debug));
+            sendColMsg(sender, " ");
+            sendColMsg(sender, "&7--- [&bServer Info&7] ---");
+            sendColMsg(sender, "&7Server Version: &b" + Bukkit.getVersion());
+            sendColMsg(sender, "&7Skript Version: &b" + Skript.getVersion());
+            sendColMsg(sender, "&7Skript Addons:");
+            Skript.getAddons().forEach(addon -> {
+                String name = addon.getName();
+                if (!name.contains("SkBee")) {
+                    sendColMsg(sender, "&7- &b" + name + " v" + addon.plugin.getDescription().getVersion());
+                }
+            });
+            sendColMsg(sender, "&7SkBee Version: &b" + desc.getVersion());
+            sendColMsg(sender, "&7SkBee Website: &b" + desc.getWebsite());
+        }
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length == 1) {
+            return StringUtil.copyPartialMatches(args[0], List.of("info"), new ArrayList<>());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/api/command/SkBeeInfo.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/command/SkBeeInfo.java
@@ -29,7 +29,7 @@ public class SkBeeInfo implements TabExecutor {
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length > 0 && args[0].equalsIgnoreCase("info")) {
             sendColMsg(sender, "&7--- [&bSkBee Loading Info&7] ---");
-            Util.getDebugs().forEach(debug -> sendColMsg(sender, "- " + debug));
+            Util.getDebugs().forEach(debug -> sendColMsg(sender, "- &7" + debug));
             sendColMsg(sender, " ");
             sendColMsg(sender, "&7--- [&bServer Info&7] ---");
             sendColMsg(sender, "&7Server Version: &b" + Bukkit.getVersion());

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -55,7 +55,6 @@ public class ParticleUtil {
 
                 if (!PARTICLE.toString().contains("LEGACY")) {
                     PARTICLES.put(KEY, PARTICLE);
-                    Util.log("&7Particle: &b%s&7, Key: &a%s", PARTICLE, KEY);
                 }
             }
         } catch (NoSuchFieldException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -4,6 +4,7 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.util.StringUtils;
 import com.shanebeestudios.skbee.api.reflection.ReflectionConstants;
 import com.shanebeestudios.skbee.api.reflection.ReflectionUtils;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -54,6 +55,7 @@ public class ParticleUtil {
 
                 if (!PARTICLE.toString().contains("LEGACY")) {
                     PARTICLES.put(KEY, PARTICLE);
+                    Util.log("&7Particle: &b%s&7, Key: &a%s", PARTICLE, KEY);
                 }
             }
         } catch (NoSuchFieldException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
@@ -121,7 +123,10 @@ public class ParticleUtil {
             return "dust-transition";
         } else if (dataType == Vibration.class) {
             return "vibration";
-
+        } else if (dataType == Integer.class) {
+            return "number(int)";
+        } else if (dataType == Float.class) {
+            return "number(float)";
         }
         // For future particle data additions that haven't been added here yet
         return "UNKNOWN";
@@ -150,9 +155,12 @@ public class ParticleUtil {
         Class<?> dataType = particle.getDataType();
         if (dataType == Void.class) {
             return null;
-        }
-        if (dataType == ItemStack.class && data instanceof ItemType) {
-            return ((ItemType) data).getRandom();
+        } else if (dataType == Float.class && data instanceof Number number) {
+            return number.floatValue();
+        } else if (dataType == Integer.class && data instanceof Number number) {
+            return number.intValue();
+        } else if (dataType == ItemStack.class && data instanceof ItemType itemType) {
+            return itemType.getRandom();
         } else if (dataType == Particle.DustOptions.class && data instanceof Particle.DustOptions) {
             return data;
         } else if (dataType == Particle.DustTransition.class && data instanceof Particle.DustTransition) {
@@ -162,8 +170,8 @@ public class ParticleUtil {
         } else if (dataType == BlockData.class) {
             if (data instanceof BlockData) {
                 return data;
-            } else if (data instanceof ItemType) {
-                Material material = ((ItemType) data).getMaterial();
+            } else if (data instanceof ItemType itemType) {
+                Material material = itemType.getMaterial();
                 if (material.isBlock()) {
                     return material.createBlockData();
                 }

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -127,8 +127,7 @@ public class ParticleUtil {
         return "UNKNOWN";
     }
 
-    public static void spawnParticle(@Nullable Player[] players, Particle particle, Location location, int count, Object data, Vector offset, double extra) {
-        if (offset == null) return;
+    public static void spawnParticle(@Nullable Player[] players, Particle particle, Location location, int count, Object data, Vector offset, double extra, boolean force) {
         Object particleData = getData(particle, data);
         if (particle.getDataType() != Void.class && particleData == null) return;
 
@@ -138,47 +137,11 @@ public class ParticleUtil {
         if (players == null) {
             World world = location.getWorld();
             if (world == null) return;
-            world.spawnParticle(particle, location, count, x, y, z, extra, particleData);
+            world.spawnParticle(particle, location, count, x, y, z, extra, particleData, force);
         } else {
             for (Player player : players) {
                 assert player != null;
                 player.spawnParticle(particle, location, count, x, y, z, extra, particleData);
-            }
-        }
-    }
-
-    public static void spawnParticle(@Nullable Player[] players, Particle particle, Location location, int count, Object data, Vector offset) {
-        if (offset == null) return;
-        Object particleData = getData(particle, data);
-        if (particle.getDataType() != Void.class && particleData == null) return;
-
-        double x = offset.getX();
-        double y = offset.getY();
-        double z = offset.getZ();
-        if (players == null) {
-            World world = location.getWorld();
-            if (world == null) return;
-            world.spawnParticle(particle, location, count, x, y, z, particleData);
-        } else {
-            for (Player player : players) {
-                assert player != null;
-                player.spawnParticle(particle, location, count, x, y, z, particleData);
-            }
-        }
-    }
-
-    public static void spawnParticle(@Nullable Player[] players, Particle particle, Location location, int count, Object data) {
-        Object particleData = getData(particle, data);
-        if (particle.getDataType() != Void.class && particleData == null) return;
-
-        if (players == null) {
-            World world = location.getWorld();
-            if (world == null) return;
-            world.spawnParticle(particle, location, count, particleData);
-        } else {
-            for (Player player : players) {
-                assert player != null;
-                player.spawnParticle(particle, location, count, particleData);
             }
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/api/util/LoggerBee.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/LoggerBee.java
@@ -21,7 +21,7 @@ public class LoggerBee extends Logger {
     @Override
     public void info(String msg) {
         String prefix = msg.replace("[NBTAPI]", "&7[&bNBT&3API&7]");
-        Util.log(prefix);
+        Util.logLoading(prefix);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/api/util/UpdateChecker.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/UpdateChecker.java
@@ -13,11 +13,13 @@ public class UpdateChecker {
 
     public static void checkForUpdate(String pluginVersion) {
         Util.log("Checking for update...");
+        if (pluginVersion.contains("-")) {
+            Util.logLoading("&eYou're running a beta version, no need to check for an update!");
+            return;
+        }
         getVersion(version -> {
             if (version.equalsIgnoreCase(pluginVersion)) {
                 Util.logLoading("&aPlugin is up to date!");
-            } else if (pluginVersion.contains("-")) {
-                Util.logLoading("&eYou're running a beta version, no need to check for an update!");
             } else {
                 Util.logLoading("&cPlugin is not up to date!");
                 Util.logLoading(" - Current version: &cv" + pluginVersion);

--- a/src/main/java/com/shanebeestudios/skbee/api/util/UpdateChecker.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/UpdateChecker.java
@@ -1,0 +1,40 @@
+package com.shanebeestudios.skbee.api.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.function.Consumer;
+
+public class UpdateChecker {
+
+    public static void checkForUpdate(String pluginVersion) {
+        Util.log("Checking for update...");
+        getVersion(version -> {
+            if (version.equalsIgnoreCase(pluginVersion)) {
+                Util.logLoading("&aPlugin is up to date!");
+            } else if (pluginVersion.contains("-")) {
+                Util.logLoading("&eYou're running a beta version, no need to check for an update!");
+            } else {
+                Util.logLoading("&cPlugin is not up to date!");
+                Util.logLoading(" - Current version: &cv" + pluginVersion);
+                Util.logLoading(" - Available update: &av" + version);
+            }
+        });
+    }
+
+    private static void getVersion(final Consumer<String> consumer) {
+        try {
+            URL url = new URL("https://api.github.com/repos/ShaneBeee/SkBee/releases/latest");
+            BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()));
+            JsonObject jsonObject = new Gson().fromJson(reader, JsonObject.class);
+            String tag_name = jsonObject.get("tag_name").getAsString();
+            consumer.accept(tag_name);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/shanebeestudios/skbee/api/util/UpdateChecker.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/UpdateChecker.java
@@ -2,6 +2,12 @@ package com.shanebeestudios.skbee.api.util;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.shanebeestudios.skbee.SkBee;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -9,7 +15,9 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.function.Consumer;
 
-public class UpdateChecker {
+public class UpdateChecker implements Listener {
+
+    private static String UPDATE_VERSION;
 
     public static void checkForUpdate(String pluginVersion) {
         Util.log("Checking for update...");
@@ -24,6 +32,7 @@ public class UpdateChecker {
                 Util.logLoading("&cPlugin is not up to date!");
                 Util.logLoading(" - Current version: &cv" + pluginVersion);
                 Util.logLoading(" - Available update: &av" + version);
+                UPDATE_VERSION = version;
             }
         });
     }
@@ -39,4 +48,24 @@ public class UpdateChecker {
             throw new RuntimeException(e);
         }
     }
+
+    private final SkBee PLUGIN;
+
+    public UpdateChecker(SkBee plugin) {
+        this.PLUGIN = plugin;
+    }
+
+    @EventHandler
+    private void onJoin(PlayerJoinEvent event) {
+        if (UPDATE_VERSION == null) return;
+
+        Player player = event.getPlayer();
+        if (!player.hasPermission("skbee.update.check")) return;
+
+        Bukkit.getScheduler().runTaskLater(PLUGIN, bukkitTask -> {
+            Util.sendColMsg(player, "&7[&bSk&3Bee&7] update available: &a" + UPDATE_VERSION);
+            Util.sendColMsg(player, "&7[&bSk&3Bee&7] download at &bhttps://github.com/ShaneBeee/SkBee/releases");
+        }, 60);
+    }
+
 }

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -5,7 +5,10 @@ import ch.njol.skript.log.ErrorQuality;
 import com.shanebeestudios.skbee.SkBee;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,6 +36,10 @@ public class Util {
         return ChatColor.translateAlternateColorCodes('&', string);
     }
 
+    public static void sendColMsg(CommandSender receiver, String format, Object... objects) {
+        receiver.sendMessage(getColString(String.format(format, objects)));
+    }
+
     public static void log(String log) {
         Bukkit.getConsoleSender().sendMessage(getColString(PREFIX + log));
     }
@@ -57,6 +64,18 @@ public class Util {
 
     public static void debug(String format, Object... objects) {
         debug(String.format(format, objects));
+    }
+
+    private static final List<String> DEBUGS = new ArrayList<>();
+
+    public static void logLoading(String format, Object... objects) {
+        String form = String.format(format, objects);
+        DEBUGS.add(form);
+        log(form);
+    }
+
+    public static List<String> getDebugs() {
+        return DEBUGS;
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -30,6 +30,7 @@ public class Config {
     public boolean ELEMENTS_BOSS_BAR;
     public boolean ELEMENTS_STATISTIC;
     public boolean ELEMENTS_VILLAGER;
+    public boolean ELEMENTS_ADVANCEMENT;
     public boolean AUTO_LOAD_WORLDS;
     public String RECIPE_NAMESPACE;
 
@@ -98,6 +99,7 @@ public class Config {
         this.ELEMENTS_BOSS_BAR = getElement("boss-bar");
         this.ELEMENTS_STATISTIC = getElement("statistic");
         this.ELEMENTS_VILLAGER = getElement("villager");
+        this.ELEMENTS_ADVANCEMENT = getElement("advancement");
         this.AUTO_LOAD_WORLDS = getElement("auto-load-custom-worlds");
         String namespace = this.config.getString("recipe.namespace");
         if (namespace == null) {

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -28,6 +28,7 @@ public class Config {
     public boolean ELEMENTS_WORLD_CREATOR;
     public boolean ELEMENTS_GAME_EVENT;
     public boolean ELEMENTS_BOSS_BAR;
+    public boolean ELEMENTS_STATISTIC;
     public boolean AUTO_LOAD_WORLDS;
     public String RECIPE_NAMESPACE;
 
@@ -94,6 +95,7 @@ public class Config {
         this.ELEMENTS_WORLD_CREATOR = getElement("world-creator");
         this.ELEMENTS_GAME_EVENT = getElement("game-event");
         this.ELEMENTS_BOSS_BAR = getElement("boss-bar");
+        this.ELEMENTS_STATISTIC = getElement("statistic");
         this.AUTO_LOAD_WORLDS = getElement("auto-load-custom-worlds");
         String namespace = this.config.getString("recipe.namespace");
         if (namespace == null) {

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -29,6 +29,7 @@ public class Config {
     public boolean ELEMENTS_GAME_EVENT;
     public boolean ELEMENTS_BOSS_BAR;
     public boolean ELEMENTS_STATISTIC;
+    public boolean ELEMENTS_VILLAGER;
     public boolean AUTO_LOAD_WORLDS;
     public String RECIPE_NAMESPACE;
 
@@ -96,6 +97,7 @@ public class Config {
         this.ELEMENTS_GAME_EVENT = getElement("game-event");
         this.ELEMENTS_BOSS_BAR = getElement("boss-bar");
         this.ELEMENTS_STATISTIC = getElement("statistic");
+        this.ELEMENTS_VILLAGER = getElement("villager");
         this.AUTO_LOAD_WORLDS = getElement("auto-load-custom-worlds");
         String namespace = this.config.getString("recipe.namespace");
         if (namespace == null) {

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -31,6 +31,7 @@ public class Config {
     public boolean ELEMENTS_STATISTIC;
     public boolean ELEMENTS_VILLAGER;
     public boolean ELEMENTS_ADVANCEMENT;
+    public boolean ELEMENTS_WORLD_BORDER;
     public boolean AUTO_LOAD_WORLDS;
     public String RECIPE_NAMESPACE;
 
@@ -100,6 +101,7 @@ public class Config {
         this.ELEMENTS_STATISTIC = getElement("statistic");
         this.ELEMENTS_VILLAGER = getElement("villager");
         this.ELEMENTS_ADVANCEMENT = getElement("advancement");
+        this.ELEMENTS_WORLD_BORDER = getElement("world-border");
         this.AUTO_LOAD_WORLDS = getElement("auto-load-custom-worlds");
         String namespace = this.config.getString("recipe.namespace");
         if (namespace == null) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/conditions/CondAdvancementDone.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/conditions/CondAdvancementDone.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 @Name("Advancement - Done")
 @Description("Check if the advancement progress is done.")
 @Examples("if advancement progress of {_advancement} of player is done:")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class CondAdvancementDone extends Condition {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/conditions/CondAdvancementDone.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/conditions/CondAdvancementDone.java
@@ -1,0 +1,52 @@
+package com.shanebeestudios.skbee.elements.advancement.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Advancement - Done")
+@Description("Check if the advancement progress is done.")
+@Examples("if advancement progress of {_advancement} of player is done:")
+@Since("INSERT VERSION")
+public class CondAdvancementDone extends Condition {
+
+    static {
+        Skript.registerCondition(CondAdvancementDone.class,
+                "%advancementpro% is done",
+                "%advancementpro% (isn't|is not) done");
+    }
+
+    private Expression<AdvancementProgress> progress;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        setNegated(i == 2);
+        this.progress = (Expression<AdvancementProgress>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean check(Event event) {
+        return progress.check(event, AdvancementProgress::isDone, isNegated());
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return PropertyCondition.toString(this, PropertyCondition.PropertyType.BE,
+                e, d, progress, "done");
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementCriteriaAward.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementCriteriaAward.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 @Name("Advancement - Progress Criteria")
 @Description("Award or revoke criteria of an advancement progress.")
 @Examples("TODO") // TODO
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffAdvancementCriteriaAward extends Effect {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementCriteriaAward.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementCriteriaAward.java
@@ -1,0 +1,62 @@
+package com.shanebeestudios.skbee.elements.advancement.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Advancement - Progress Criteria")
+@Description("Award or revoke criteria of an advancement progress.")
+@Examples("TODO") // TODO
+@Since("INSERT VERSION")
+public class EffAdvancementCriteriaAward extends Effect {
+
+    static {
+        Skript.registerEffect(EffAdvancementCriteriaAward.class,
+                "(award|1¦revoke) criteria %string% of %advancementpros%");
+    }
+
+    private boolean award;
+    private Expression<String> criteria;
+    private Expression<AdvancementProgress> progress;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.award = parseResult.mark == 0;
+        this.criteria = (Expression<String>) exprs[0];
+        this.progress = (Expression<AdvancementProgress>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        String criteria = this.criteria.getSingle(event);
+        if (criteria == null) return;
+
+        for (AdvancementProgress progress : this.progress.getArray(event)) {
+            if (award) {
+                progress.awardCriteria(criteria);
+            } else {
+                progress.revokeCriteria(criteria);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String award = this.award ? "award" : "revoke";
+        return award + " criteria " + this.criteria.toString(e, d) + " of " + this.progress.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementLoad.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementLoad.java
@@ -1,0 +1,75 @@
+package com.shanebeestudios.skbee.elements.advancement.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Advancement - Load")
+@Description({"Load an advancement represented by the specified string into the server.",
+        "The advancement format is governed by Minecraft and has no specified layout.",
+        "It is currently a JSON object, as described by the Minecraft Wiki: http://minecraft.gamepedia.com/Advancements.",
+        "Loaded advancements will be stored and persisted across server restarts and reloads.",
+        "NOTE: Bukkit has marked this as 'Unsafe', so please use at your own risk.",
+        "Watch console for errors when loading an advancement."})
+@Examples("¯\\_(ツ)_/¯")
+@Since("INSERT VERSION")
+public class EffAdvancementLoad extends Effect {
+
+    static {
+        Skript.registerEffect(EffAdvancementLoad.class,
+                "load advancement %string% with (key|id) %string%");
+    }
+
+    private Expression<String> advancement;
+    private Expression<String> key;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.advancement = (Expression<String>) exprs[0];
+        this.key = (Expression<String>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems", "deprecation"})
+    @Override
+    protected void execute(Event event) {
+        String key = this.key.getSingle(event);
+        String advancement = this.advancement.getSingle(event);
+        if (key == null || advancement == null) return;
+
+        NamespacedKey namespacedKey = NamespacedKey.fromString(key);
+        if (namespacedKey != null) {
+            try {
+                Bukkit.getUnsafe().loadAdvancement(namespacedKey, advancement);
+            } catch (Exception ex) {
+                if (SkBee.getPlugin().getPluginConfig().SETTINGS_DEBUG) {
+                    ex.printStackTrace();
+                } else {
+                    Util.skriptError("Unable to load advancement with key: '%s'", namespacedKey);
+                    Util.skriptError("Error: " + ex.getMessage());
+                    Util.skriptError("Enable DEBUG in SkBee config for more info!");
+                }
+            }
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "load advancement " + this.advancement.toString(e, d) + " with key " + this.key.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementLoad.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementLoad.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
         "NOTE: Bukkit has marked this as 'Unsafe', so please use at your own risk.",
         "Watch console for errors when loading an advancement."})
 @Examples("¯\\_(ツ)_/¯")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffAdvancementLoad extends Effect {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/event/SimpleEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/event/SimpleEvents.java
@@ -17,7 +17,7 @@ public class SimpleEvents {
                         "[player] advancement done")
                 .description("Called when a player has completed all criteria in an advancement.")
                 .examples("")
-                .since("INSERT VERSION");
+                .since("1.17.0");
 
         EventValues.registerEventValue(PlayerAdvancementDoneEvent.class, String.class, new Getter<>() {
             @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/event/SimpleEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/event/SimpleEvents.java
@@ -1,0 +1,37 @@
+package com.shanebeestudios.skbee.elements.advancement.event;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.util.SimpleEvent;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings("unused")
+public class SimpleEvents {
+
+    static {
+        // Player Advancement Event
+        Skript.registerEvent("Player Advancement", SimpleEvent.class, PlayerAdvancementDoneEvent.class,
+                        "[player] advancement done")
+                .description("Called when a player has completed all criteria in an advancement.")
+                .examples("")
+                .since("INSERT VERSION");
+
+        EventValues.registerEventValue(PlayerAdvancementDoneEvent.class, String.class, new Getter<>() {
+            @Override
+            public @Nullable String get(PlayerAdvancementDoneEvent event) {
+                return event.getAdvancement().getKey().toString();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(PlayerAdvancementDoneEvent.class, Advancement.class, new Getter<>() {
+            @Override
+            public @Nullable Advancement get(PlayerAdvancementDoneEvent event) {
+                return event.getAdvancement();
+            }
+        }, 0);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementAll.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementAll.java
@@ -1,0 +1,77 @@
+package com.shanebeestudios.skbee.elements.advancement.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.iterator.IteratorIterable;
+import org.bukkit.Bukkit;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Name("Advancement - All Available")
+@Description("Get a list of all available advancements currently registered on the server.")
+@Examples({"set {_a::*} to all available advancements",
+        "loop all available advancements:"})
+@Since("INSERT VERSION")
+public class ExprAdvancementAll extends SimpleExpression<Advancement> {
+
+    static {
+        Skript.registerExpression(ExprAdvancementAll.class, Advancement.class, ExpressionType.SIMPLE,
+                "[all] available advancements");
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] expr, int i, Kleenean kleenean, ParseResult parseResult) {
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable Advancement[] get(Event event) {
+        List<Advancement> advancements = new ArrayList<>();
+        Iterator<? extends Advancement> iterator = iterator(event);
+        if (iterator == null) {
+            return new Advancement[0];
+        }
+        for (Advancement advancement : new IteratorIterable<>(iterator)) {
+            advancements.add(advancement);
+        }
+        return advancements.toArray(new Advancement[0]);
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Iterator<? extends Advancement> iterator(Event event) {
+        return Bukkit.advancementIterator();
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends Advancement> getReturnType() {
+        return Advancement.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event event, boolean b) {
+        return "all available advancements";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementAll.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementAll.java
@@ -25,7 +25,7 @@ import java.util.List;
 @Description("Get a list of all available advancements currently registered on the server.")
 @Examples({"set {_a::*} to all available advancements",
         "loop all available advancements:"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprAdvancementAll extends SimpleExpression<Advancement> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementCriteria.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementCriteria.java
@@ -1,0 +1,67 @@
+package com.shanebeestudios.skbee.elements.advancement.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Advancement - Criteria")
+@Description("Get a list of the criteria for an advancement.")
+@Examples("set {_c::*} to criteria of {_advancement}")
+@Since("INSERT VERSION")
+public class ExprAdvancementCriteria extends SimpleExpression<String> {
+
+    static {
+        Skript.registerExpression(ExprAdvancementCriteria.class, String.class, ExpressionType.SIMPLE,
+                "criteria of %advancements%",
+                "%advancement%'[s] criteria");
+    }
+
+    private Expression<Advancement> advancement;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.advancement = (Expression<Advancement>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable String[] get(Event event) {
+        List<String> criteria = new ArrayList<>();
+        for (Advancement advancement : this.advancement.getArray(event)) {
+            criteria.addAll(advancement.getCriteria());
+        }
+        return criteria.toArray(new String[0]);
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends String> getReturnType() {
+        return String.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "criteria of " + this.advancement.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementCriteria.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementCriteria.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Name("Advancement - Criteria")
 @Description("Get a list of the criteria for an advancement.")
 @Examples("set {_c::*} to criteria of {_advancement}")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprAdvancementCriteria extends SimpleExpression<String> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgress.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgress.java
@@ -1,0 +1,70 @@
+package com.shanebeestudios.skbee.elements.advancement.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Advancement - Progress")
+@Description("Returns the advancement progress of a player.")
+public class ExprAdvancementProgress extends SimpleExpression<AdvancementProgress> {
+
+    static {
+        Skript.registerExpression(ExprAdvancementProgress.class, AdvancementProgress.class, ExpressionType.COMBINED,
+                "advancement progress of %advancement% (for|of) %players%");
+    }
+
+    private Expression<Advancement> advancement;
+    private Expression<Player> player;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.advancement = (Expression<Advancement>) exprs[0];
+        this.player = (Expression<Player>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable AdvancementProgress[] get(Event event) {
+        Advancement advancement = this.advancement.getSingle(event);
+        if (advancement == null) return null;
+
+        List<AdvancementProgress> progresses = new ArrayList<>();
+        for (Player player : this.player.getArray(event)) {
+            progresses.add(player.getAdvancementProgress(advancement));
+        }
+        return progresses.toArray(new AdvancementProgress[0]);
+    }
+
+    @Override
+    public boolean isSingle() {
+        return this.player.isSingle();
+    }
+
+    @Override
+    public @NotNull Class<? extends AdvancementProgress> getReturnType() {
+        return AdvancementProgress.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "advancement progress of advancement " + this.advancement.toString(e, d) + " of " +
+                this.player.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgressAwarded.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgressAwarded.java
@@ -1,0 +1,69 @@
+package com.shanebeestudios.skbee.elements.advancement.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Advancement - Progress Criteria")
+@Description("Get the awarded/remaining criteria of an advancement progress.")
+@Examples("set {_c::*} to awarded criteria of advancement progress of {_advancement} of player")
+@Since("INSERT VERSION")
+public class ExprAdvancementProgressAwarded extends SimpleExpression<String> {
+
+    static {
+        Skript.registerExpression(ExprAdvancementProgressAwarded.class, String.class, ExpressionType.SIMPLE,
+                "(awarded|1¦remaining) criteria of %advancementpro%");
+    }
+
+    private boolean awarded;
+    private Expression<AdvancementProgress> progress;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.awarded = parseResult.mark == 0;
+        this.progress = (Expression<AdvancementProgress>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable String[] get(Event event) {
+        AdvancementProgress progress = this.progress.getSingle(event);
+        if (progress == null) return null;
+
+        if (awarded) {
+            return progress.getAwardedCriteria().toArray(new String[0]);
+        } else {
+            return progress.getRemainingCriteria().toArray(new String[0]);
+        }
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends String> getReturnType() {
+        return String.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String award = awarded ? "awarded" : "remaining";
+        return award + " criteria of " + this.progress.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgressAwarded.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgressAwarded.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 @Name("Advancement - Progress Criteria")
 @Description("Get the awarded/remaining criteria of an advancement progress.")
 @Examples("set {_c::*} to awarded criteria of advancement progress of {_advancement} of player")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprAdvancementProgressAwarded extends SimpleExpression<String> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/type/Types.java
@@ -1,0 +1,101 @@
+package com.shanebeestudios.skbee.elements.advancement.type;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.classes.Serializer;
+import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.yggdrasil.Fields;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.advancement.AdvancementProgress;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.NotSerializableException;
+import java.io.StreamCorruptedException;
+
+public class Types {
+
+    static {
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Advancement.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Advancement.class, "advancement")
+                    .user("advancements?")
+                    .name("Advancement")
+                    .description("Represents an advancement. These CAN be parsed, see examples.")
+                    .examples("set {_a} to \"minecraft:nether/use_lodestone\" parsed as advancement")
+                    .since("INSERT VERSION")
+                    .parser(new Parser<>() {
+
+                        @SuppressWarnings("NullableProblems")
+                        @Override
+                        public @Nullable Advancement parse(String string, ParseContext context) {
+                            NamespacedKey namespacedKey = NamespacedKey.fromString(string);
+                            if (namespacedKey != null) {
+                                return Bukkit.getAdvancement(namespacedKey);
+                            }
+                            return null;
+                        }
+
+                        @Override
+                        public @NotNull String toString(Advancement advancement, int i) {
+                            return advancement.getKey().toString();
+                        }
+
+                        @Override
+                        public @NotNull String toVariableNameString(Advancement advancement) {
+                            return "advancement:" + toString(advancement, 0);
+                        }
+                    })
+                    .serializer(new Serializer<>() {
+                        @Override
+                        public @NotNull Fields serialize(Advancement advancement) throws NotSerializableException {
+                            Fields fields = new Fields();
+                            fields.putObject("advancement", advancement.getKey().toString());
+                            return fields;
+                        }
+
+                        @Override
+                        public void deserialize(Advancement advancement, Fields fields) {
+                        }
+
+                        @SuppressWarnings("NullableProblems")
+                        @Override
+                        protected Advancement deserialize(Fields fields) throws StreamCorruptedException {
+                            String string = fields.getObject("advancement", String.class);
+                            if (string != null) {
+                                NamespacedKey namespacedKey = NamespacedKey.fromString(string);
+                                if (namespacedKey != null) {
+                                    return Bukkit.getAdvancement(namespacedKey);
+                                }
+                            }
+                            return null;
+                        }
+
+                        @Override
+                        public boolean mustSyncDeserialization() {
+                            return false;
+                        }
+
+                        @Override
+                        protected boolean canBeInstantiated() {
+                            return false;
+                        }
+                    }));
+        }
+
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(AdvancementProgress.class) == null) {
+            Classes.registerClass(new ClassInfo<>(AdvancementProgress.class, "advancementpro")
+                    .user("advancement ?progress(es)?")
+                    .name("Advancement Progress")
+                    .description("Represents the advancement progress of a player.",
+                            "You will see `%advancementpro%` in the docs, this is due to a silly issue with Skript",
+                            "where I couldn't use `progress` in expressions.")
+                    .since("INSERT VERSION"));
+        }
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/type/Types.java
@@ -26,7 +26,7 @@ public class Types {
                     .name("Advancement")
                     .description("Represents an advancement. These CAN be parsed, see examples.")
                     .examples("set {_a} to \"minecraft:nether/use_lodestone\" parsed as advancement")
-                    .since("INSERT VERSION")
+                    .since("1.17.0")
                     .parser(new Parser<>() {
 
                         @SuppressWarnings("NullableProblems")
@@ -94,7 +94,7 @@ public class Types {
                     .description("Represents the advancement progress of a player.",
                             "You will see `%advancementpro%` in the docs, this is due to a silly issue with Skript",
                             "where I couldn't use `progress` in expressions.")
-                    .since("INSERT VERSION"));
+                    .since("1.17.0"));
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/type/Types.java
@@ -6,6 +6,7 @@ import ch.njol.skript.classes.Serializer;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.yggdrasil.Fields;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.advancement.Advancement;
@@ -84,6 +85,9 @@ public class Types {
                             return false;
                         }
                     }));
+        } else {
+            Util.logLoading("It looks like another addon registered 'advancement' already.");
+            Util.logLoading("You may have to use their advancements in SkBee's 'advancement' elements.");
         }
 
         // Only register if no other addons have registered this class
@@ -95,6 +99,9 @@ public class Types {
                             "You will see `%advancementpro%` in the docs, this is due to a silly issue with Skript",
                             "where I couldn't use `progress` in expressions.")
                     .since("1.17.0"));
+        } else {
+            Util.logLoading("It looks like another addon registered 'advancementpro' already.");
+            Util.logLoading("You may have to use their advancement progresses in SkBee's 'advancement' elements.");
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
@@ -7,6 +7,7 @@ import ch.njol.skript.registrations.Classes;
 import ch.njol.util.StringUtils;
 import org.bukkit.GameEvent;
 import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -27,11 +28,7 @@ public class Types {
                 .since("1.14.0")
                 .parser(new Parser<GameEvent>() {
 
-                    @Override
-                    public boolean canParse(ParseContext context) {
-                        return true;
-                    }
-
+                    @SuppressWarnings("NullableProblems")
                     @Nullable
                     @Override
                     public GameEvent parse(String string, ParseContext context) {
@@ -39,12 +36,12 @@ public class Types {
                     }
 
                     @Override
-                    public String toString(GameEvent gameEvent, int flags) {
+                    public @NotNull String toString(GameEvent gameEvent, int flags) {
                         return gameEvent.getKey().getKey();
                     }
 
                     @Override
-                    public String toVariableNameString(GameEvent gameEvent) {
+                    public @NotNull String toVariableNameString(GameEvent gameEvent) {
                         return "gameevent:" + gameEvent.getKey().getKey();
                     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffDropItem.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffDropItem.java
@@ -1,0 +1,57 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Drop Held Item")
+@Description({"Forces the player to drop their currently held item.",
+        "By default it will drop one of their held item, or you can optionally drop the whole stack."})
+@Examples({"make player drop all of held item",
+        "force all players to drop all of their held items"})
+@Since("INSERT VERSION")
+public class EffDropItem extends Effect {
+
+    static {
+        Skript.registerEffect(EffDropItem.class, "(make|force) %players% [to] drop (|1¦all of) [their] held item[s]");
+    }
+
+    private Expression<Player> players;
+    private boolean all;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.players = (Expression<Player>) exprs[0];
+        this.all = parseResult.mark == 1;
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        for (Player player : this.players.getArray(event)) {
+            if (player.dropItem(all)) {
+                // Appears the server doesn't update automatically
+                player.updateInventory();
+            }
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String all = this.all ? " all of" : "";
+        return "make " + this.players.toString(e, d) + " drop" + all + " held item";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffDropItem.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffDropItem.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
         "By default it will drop one of their held item, or you can optionally drop the whole stack."})
 @Examples({"make player drop all of held item",
         "force all players to drop all of their held items"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffDropItem extends Effect {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffLoadChunk.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffLoadChunk.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
         "load chunk chunk at location(1,1,1, world \"world\")",
         "load chunk at 150,150 in world \"world\"",
         "load chunk at 150,150 in world \"world\" with ticket"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffLoadChunk extends Effect {
 
     private static final SkBee PLUGIN = SkBee.getPlugin();

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffLoadChunk.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffLoadChunk.java
@@ -1,0 +1,132 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.SkBee;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Chunk - Load/Unload")
+@Description({"Load or unload a chunk. When loading you have an option to add a ticket.",
+        "This will prevent the chunk from unloading until you explicitly unload it, or the server stops.",
+        "The two numbers represent a chunk's X/Y coords, NOT a location. A chunk's X/Y coords are basically",
+        "a location divided by 16. Ex: Chunk 1/1 would be at X=16, Z=16.",
+        "NOTE: If no ticket is added, and the chunk has no players to keep it active, it will immediately unload.",
+        "NOTE: When adding a ticket, a bunch of chunks will load in a radius around said chunk."})
+@Examples({"load chunk at 1,1 in world \"world\"",
+        "unload chunk at 1,1 in world \"world\"",
+        "load chunk chunk at location(1,1,1, world \"world\")",
+        "load chunk at 150,150 in world \"world\"",
+        "load chunk at 150,150 in world \"world\" with ticket"})
+@Since("INSERT VERSION")
+public class EffLoadChunk extends Effect {
+
+    private static final SkBee PLUGIN = SkBee.getPlugin();
+
+    static {
+        Skript.registerEffect(EffLoadChunk.class,
+                "(load|1¦unload) chunk at %number%,[ ]%number% (in|of) [world] %world%",
+                "(load|1¦unload) chunk %chunk%",
+                "load chunk at %number%,[ ]%number% (in|of) [world] %world% with ticket",
+                "load chunk %chunk% with ticket");
+    }
+
+    private int pattern;
+    private boolean ticket;
+    private boolean unload;
+    private Expression<Number> one;
+    private Expression<Number> two;
+    private Expression<World> world;
+    private Expression<Chunk> chunk;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.pattern = i;
+        this.unload = parseResult.mark == 1;
+        this.ticket = i > 1;
+
+        if (i == 0 || i == 2) {
+            this.chunk = null;
+            this.one = (Expression<Number>) exprs[0];
+            this.two = (Expression<Number>) exprs[1];
+            this.world = (Expression<World>) exprs[2];
+        } else {
+            this.chunk = (Expression<Chunk>) exprs[0];
+            this.one = null;
+            this.two = null;
+            this.world = null;
+        }
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        //Chunk chunk = null;
+        if (pattern == 0 || pattern == 2) {
+            int one = 0;
+            int two = 0;
+            World world = Bukkit.getWorlds().get(0);
+
+            if (this.one != null) {
+                Number oneSingle = this.one.getSingle(event);
+                if (oneSingle != null) one = oneSingle.intValue();
+            }
+            if (this.two != null) {
+                Number twoSingle = this.two.getSingle(event);
+                if (twoSingle != null) two = twoSingle.intValue();
+            }
+            if (this.world != null) {
+                world = this.world.getSingle(event);
+            }
+            if (world == null) return;
+
+            if (unload) {
+                world.removePluginChunkTicket(one, two, PLUGIN);
+                world.unloadChunk(one, two);
+            } else {
+                world.loadChunk(one, two);
+                if (ticket) {
+                    world.addPluginChunkTicket(one, two, PLUGIN);
+                }
+            }
+        } else {
+            if (this.chunk != null) {
+                Chunk chunk = this.chunk.getSingle(event);
+                if (chunk == null) return;
+                if (unload) {
+                    chunk.removePluginChunkTicket(PLUGIN);
+                    chunk.unload();
+                } else {
+                    chunk.load(); // wouldn't the chunk already be loaded?!?!
+                    if (ticket) {
+                        chunk.addPluginChunkTicket(PLUGIN);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String load = this.unload ? "unload" : "load";
+        String chunk = (pattern == 0 || pattern == 2) ? "at " + this.one.toString(e, d) + "," +
+                this.two.toString(e,d) : this.chunk.toString(e,d);
+        String ticket = this.ticket ? " with ticket" : "";
+        return String.format("%s chunk %s %s",
+                load, chunk, ticket);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffParticle.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffParticle.java
@@ -20,10 +20,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Particle Spawn")
-@Description({"Spawn a particle. This system is more inline with how Bukkit deals with particles, hence the amount of patterns.",
-        "DO NOT USE '(spawn|play)' part of syntax, they're horribly slow at parsing and will be removed in the future, use '(lerp|draw|make)' instead.",
+@Description({"Spawn a particle. This system is more inline with how Bukkit deals with particles, hence the choices in the pattern.",
         "Some particles may be affected differently by these values, so let's break them down:",
-        "\nfirst number = count, how many particles to spawn at once.",
+        "\nfirst number = count, how many particles to spawn at once. (use '0' if you notice the particle kinda flies away.)",
         "\nparticle = the particle to spawn.",
         "\nusing = the data used for this particle (some particles like 'block', 'item' and 'dust' require more data).",
         "\nlocation = where you are going to spawn the particle.",
@@ -32,20 +31,23 @@ import org.jetbrains.annotations.Nullable;
         "\nextra = the extra data for this particle, depends on the particle used (normally speed).",
         "\nforce = whether to send the particle to players within an extended range and encourage ",
         "their client to render it regardless of settings (this only works when not using `for player[s]`) (default = false)",
+        "\nfor %players% = will only send this particle to a player, not the whole server.",
         "\nRequires Minecraft 1.13+"})
 @Examples({"make 3 of item particle using diamond at location of player",
         "make 1 of block particle using dirt at location of target block",
         "make 10 of poof at player with offset vector(2, 2, 2) with extra 0.5",
         "draw 20 of dust using dustOption(blue, 10) at location above target block",
         "draw 1 of dust_color_transition using dustTransition(blue, green, 3) at location of player",
-        "draw 1 of vibration using vibration({loc1}, {loc2}, 1 second) at {loc1} with force"})
+        "draw 1 of vibration using vibration({loc1}, {loc2}, 1 second) at {loc1} with force",
+        "make 0 of shriek using 1 above target block of player",
+        "make 1 of sculk_charge using 0.1 at {_loc} with force"})
 @Since("1.9.0")
 public class EffParticle extends Effect {
 
     static {
         Skript.registerEffect(EffParticle.class,
                 "(lerp|draw|make) %number% [of] %particle% [particle] [using %-itemtype/blockdata/dustoption/dusttransition/vibration" +
-                        "%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
+                        "/number%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
     }
 
     private Expression<Number> count;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffShowDemo.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffShowDemo.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
         "Servers can modify the text on this screen using a resource pack."})
 @Examples({"show demo screen to all players",
         "show demo screen to player"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffShowDemo extends Effect {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffShowDemo.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffShowDemo.java
@@ -1,0 +1,53 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Show Demo Screen")
+@Description({"Shows the demo screen to the player, this screen is normally only seen in the demo version of the game.",
+        "Servers can modify the text on this screen using a resource pack."})
+@Examples({"show demo screen to all players",
+        "show demo screen to player"})
+@Since("INSERT VERSION")
+public class EffShowDemo extends Effect {
+
+    static {
+        if (Skript.methodExists(Player.class, "showDemoScreen")) {
+            Skript.registerEffect(EffShowDemo.class, "show demo screen to %players%");
+        }
+    }
+
+    private Expression<Player> players;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.players = (Expression<Player>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        for (Player player : this.players.getArray(event)) {
+            player.showDemoScreen();
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "show demo screen to " + this.players.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffVillagerEffects.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffVillagerEffects.java
@@ -1,0 +1,98 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Villager - Effects")
+@Description("A few effects to make villagers do things.")
+@Examples({"zombify last spawned villager",
+        "wake up all villagers",
+        "make target entity shake his head",
+        "make target entity sleep at location(100, 64, 100, world \"world\")"})
+@Since("INSERT VERSION")
+public class EffVillagerEffects extends Effect {
+
+    private static boolean CAN_ZOMBIFY = Skript.methodExists(Villager.class, "zombify");
+    private static boolean CAN_WAKEUP = Skript.methodExists(Villager.class, "wakeup");
+
+    static {
+        Skript.registerEffect(EffVillagerEffects.class,
+                "zombify %livingentities%",
+                "wake[ ]up %livingentities%",
+                "make %livingentities% shake [(his|their)] head[s]",
+                "make %livingentities% sleep at %location%");
+    }
+
+    private Expression<LivingEntity> entities;
+    private Expression<Location> location;
+    private int pattern;
+
+    @SuppressWarnings({"unchecked", "NullableProblems"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.pattern = matchedPattern;
+        if (pattern == 0 && !CAN_ZOMBIFY) {
+            Skript.error("'zombify %villager%' is not available on your server version.");
+            return false;
+        }
+        if (pattern == 1 && !CAN_WAKEUP) {
+            Skript.error("'wakeup %villager%' is not available on your server version.");
+            return false;
+        }
+        this.entities = (Expression<LivingEntity>) exprs[0];
+        this.location = matchedPattern == 3 ? (Expression<Location>) exprs[1] : null;
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        Location location = this.location != null ? this.location.getSingle(event) : null;
+        for (LivingEntity entity : this.entities.getArray(event)) {
+            if (entity instanceof Villager villager) {
+                switch (pattern) {
+                    case 0 -> villager.zombify();
+                    case 1 -> villager.wakeup();
+                    case 2 -> villager.shakeHead();
+                    case 3 -> sleepVillager(villager, location);
+                }
+            }
+        }
+    }
+
+    private void sleepVillager(Villager villager, Location location) {
+        if (location != null) {
+            // Villager#sleep() can only happen in the same world
+            if (villager.getLocation().getWorld() != location.getWorld()) {
+                villager.teleport(location);
+            }
+            villager.sleep(location);
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String entity = this.entities.toString(e, d);
+        return switch (pattern) {
+            case 0 -> "zombify " + entity;
+            case 1 -> "wakeup " + entity;
+            case 2 -> "shake head of " + entity;
+            case 3 -> "make " + entity + " sleep at " + this.location.toString(e, d);
+            default -> "null";
+        };
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPotionEffect.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPotionEffect.java
@@ -1,0 +1,91 @@
+package com.shanebeestudios.skbee.elements.other.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityPotionEffectEvent;
+import org.bukkit.event.entity.EntityPotionEffectEvent.Action;
+import org.bukkit.event.entity.EntityPotionEffectEvent.Cause;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings({"unused", "ConstantConditions"})
+public class EvtPotionEffect extends SkriptEvent {
+
+    static {
+        Skript.registerEvent("Entity Potion Effect", EvtPotionEffect.class, EntityPotionEffectEvent.class,
+                        "[entity] potion effect added",
+                        "[entity] potion effect changed",
+                        "[entity] potion effect cleared",
+                        "[entity] potion effect removed")
+                .description("Called when a potion effect is modified on an entity.",
+                        "ADDED = When the potion effect is added because the entity didn't have it's type.",
+                        "CHANGED = When the entity already had the potion effect type, but the effect is changed.",
+                        "CLEARED = When the effect is removed due to all effects being removed.",
+                        "REMOVED = When the potion effect type is completely removed.",
+                        "event-potioneffect = new effect.",
+                        "past event-potioneffect = old effect.",
+                        "event-potioneffecttype = type of potion effect.")
+                .examples("")
+                .since("INSERT VERSION");
+
+        EventValues.registerEventValue(EntityPotionEffectEvent.class, PotionEffect.class, new Getter<>() {
+            @Override
+            public @Nullable PotionEffect get(EntityPotionEffectEvent event) {
+                return event.getOldEffect();
+            }
+        }, -1);
+
+        EventValues.registerEventValue(EntityPotionEffectEvent.class, PotionEffect.class, new Getter<>() {
+            @Override
+            public @Nullable PotionEffect get(EntityPotionEffectEvent event) {
+                return event.getNewEffect();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(EntityPotionEffectEvent.class, PotionEffectType.class, new Getter<>() {
+            @Override
+            public @Nullable PotionEffectType get(EntityPotionEffectEvent event) {
+                return event.getModifiedType();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(EntityPotionEffectEvent.class, Cause.class, new Getter<>() {
+            @Override
+            public @Nullable Cause get(EntityPotionEffectEvent event) {
+                return event.getCause();
+            }
+        }, 0);
+    }
+
+    private static final Action[] ACTIONS = new Action[]{Action.ADDED, Action.CHANGED, Action.CLEARED, Action.REMOVED};
+    private int eventAction;
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Literal<?>[] args, int matchedPattern, ParseResult parseResult) {
+        this.eventAction = matchedPattern;
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean check(Event event) {
+        if (event instanceof EntityPotionEffectEvent potionEvent) {
+            return potionEvent.getAction() == ACTIONS[this.eventAction];
+        }
+        return false;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean debug) {
+        return "entity potion effect " + ACTIONS[this.eventAction];
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPotionEffect.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPotionEffect.java
@@ -33,7 +33,7 @@ public class EvtPotionEffect extends SkriptEvent {
                         "past event-potioneffect = old effect.",
                         "event-potioneffecttype = type of potion effect.")
                 .examples("")
-                .since("INSERT VERSION");
+                .since("1.17.0");
 
         EventValues.registerEventValue(EntityPotionEffectEvent.class, PotionEffect.class, new Getter<>() {
             @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -1,20 +1,25 @@
 package com.shanebeestudios.skbee.elements.other.events;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Getter;
 import ch.njol.skript.util.slot.Slot;
 import com.shanebeestudios.skbee.api.event.EntityBlockInteractEvent;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("unused")
 public class OtherEvents {
 
     static {
@@ -106,6 +111,43 @@ public class OtherEvents {
                 .description("Called when a player shears an entity. Requires Minecraft 1.9.4+")
                 .examples("on player shear entity:")
                 .since("1.8.0");
+
+        // Entity Breed Event
+        Skript.registerEvent("Entity Breed", SimpleEvent.class, EntityBreedEvent.class,
+                        "entity breed")
+                .description("Called when one Entity breeds with another Entity.")
+                .examples("on entity breed:", "\nif breeding mother is a sheep:",
+                        "\n\nkill breeding player")
+                .since("INSERT VERSION");
+
+        EventValues.registerEventValue(EntityBreedEvent.class, Player.class, new Getter<>() {
+            @Override
+            public @Nullable Player get(EntityBreedEvent breedEvent) {
+                LivingEntity breeder = breedEvent.getBreeder();
+                if (breeder instanceof Player player) {
+                    return player;
+                }
+                return null;
+            }
+        }, 0);
+
+        EventValues.registerEventValue(EntityBreedEvent.class, Entity.class, new Getter<>() {
+            @Override
+            public @Nullable Entity get(EntityBreedEvent breedEvent) {
+                return breedEvent.getEntity();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(EntityBreedEvent.class, ItemType.class, new Getter<>() {
+            @Override
+            public @Nullable ItemType get(EntityBreedEvent breedEvent) {
+                ItemStack bredWith = breedEvent.getBredWith();
+                if (bredWith != null) {
+                    return new ItemType(bredWith);
+                }
+                return null;
+            }
+        }, 0);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -118,7 +118,7 @@ public class OtherEvents {
                 .description("Called when one Entity breeds with another Entity.")
                 .examples("on entity breed:", "\nif breeding mother is a sheep:",
                         "\n\nkill breeding player")
-                .since("INSERT VERSION");
+                .since("1.17.0");
 
         EventValues.registerEventValue(EntityBreedEvent.class, Player.class, new Getter<>() {
             @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
@@ -16,10 +16,10 @@ import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
 import com.destroystokyo.paper.event.player.PlayerElytraBoostEvent;
 import com.destroystokyo.paper.event.player.PlayerPickupExperienceEvent;
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent;
+import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -78,6 +78,28 @@ public class PaperEvents {
                 @Override
                 public ItemType get(PlayerElytraBoostEvent e) {
                     return new ItemType(e.getItemStack());
+                }
+            }, 0);
+        }
+
+        // Player Stop Using Item Event
+        if (Skript.classExists("io.papermc.paper.event.player.PlayerStopUsingItemEvent")) {
+            Skript.registerEvent("Player Stop Using Item", SimpleEvent.class, PlayerStopUsingItemEvent.class, "[player] stop using item")
+                    .description("Called when the server detects a player stopping using an item.",
+                            "Examples of this are letting go of the interact button when holding a bow, an edible item, or a spyglass.",
+                            "event-number is the number of ticks the item was held for.")
+                    .examples("")
+                    .since("INSERT VERSION");
+            EventValues.registerEventValue(PlayerStopUsingItemEvent.class, ItemType.class, new Getter<>() {
+                @Override
+                public ItemType get(PlayerStopUsingItemEvent event) {
+                    return new ItemType(event.getItem());
+                }
+            }, 0);
+            EventValues.registerEventValue(PlayerStopUsingItemEvent.class, Number.class, new Getter<>() {
+                @Override
+                public Number get(PlayerStopUsingItemEvent event) {
+                    return event.getTicksHeldFor();
                 }
             }, 0);
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
@@ -91,7 +91,7 @@ public class PaperEvents {
                     .examples("on player stop using item:",
                             "\tif event-item is a spyglass:",
                             "\t\tkill player")
-                    .since("INSERT VERSION");
+                    .since("1.17.0");
             EventValues.registerEventValue(PlayerStopUsingItemEvent.class, ItemType.class, new Getter<>() {
                 @Override
                 public ItemType get(PlayerStopUsingItemEvent event) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
@@ -87,8 +87,10 @@ public class PaperEvents {
             Skript.registerEvent("Player Stop Using Item", SimpleEvent.class, PlayerStopUsingItemEvent.class, "[player] stop using item")
                     .description("Called when the server detects a player stopping using an item.",
                             "Examples of this are letting go of the interact button when holding a bow, an edible item, or a spyglass.",
-                            "event-number is the number of ticks the item was held for.")
-                    .examples("")
+                            "event-number is the number of ticks the item was held for. Requires Paper (not sure which version).")
+                    .examples("on player stop using item:",
+                            "\tif event-item is a spyglass:",
+                            "\t\tkill player")
                     .since("INSERT VERSION");
             EventValues.registerEventValue(PlayerStopUsingItemEvent.class, ItemType.class, new Getter<>() {
                 @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAbsorptionAmount.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAbsorptionAmount.java
@@ -1,0 +1,71 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.Damageable;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Absorption Amount")
+@Description("Represents the absorption amount of an entity.")
+@Examples("set absorption amount of player to 5")
+@Since("INSERT VERSION")
+public class ExprAbsorptionAmount extends SimplePropertyExpression<Entity, Number> {
+
+    static {
+        register(ExprAbsorptionAmount.class, Number.class, "absorption amount", "entities");
+    }
+
+    @Override
+    public @Nullable Number convert(Entity entity) {
+        if (entity instanceof Damageable damageable) {
+            return damageable.getAbsorptionAmount();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, ADD, REMOVE -> CollectionUtils.array(Number.class);
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        double change = delta[0] != null ? ((Number) delta[0]).doubleValue() : 0;
+        for (Entity entity : getExpr().getArray(event)) {
+            if (entity instanceof Damageable damageable) {
+                double oldAmount = damageable.getAbsorptionAmount();
+                if (mode == ChangeMode.ADD) {
+                    change = oldAmount + change;
+                } else if (mode == ChangeMode.REMOVE) {
+                    change = oldAmount - change;
+                }
+                if (change < 0) change = 0;
+                damageable.setAbsorptionAmount(change);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "absorption amount";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAbsorptionAmount.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAbsorptionAmount.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 @Name("Absorption Amount")
 @Description("Represents the absorption amount of an entity.")
 @Examples("set absorption amount of player to 5")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprAbsorptionAmount extends SimplePropertyExpression<Entity, Number> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBreedEntities.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBreedEntities.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 @Description("Get the entities involved in a breed event.")
 @Examples({"on entity breed:", "\nif breeding mother is a sheep:",
         "\n\nkill breeding player"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprBreedEntities extends SimpleExpression<Entity> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBreedEntities.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBreedEntities.java
@@ -1,0 +1,96 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.log.ErrorQuality;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityBreedEvent;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Breed Event Entities")
+@Description("Get the entities involved in a breed event.")
+@Examples({"on entity breed:", "\nif breeding mother is a sheep:",
+        "\n\nkill breeding player"})
+@Since("INSERT VERSION")
+public class ExprBreedEntities extends SimpleExpression<Entity> {
+
+    static {
+        Skript.registerExpression(ExprBreedEntities.class, Entity.class, ExpressionType.SIMPLE,
+                "[the] breed[ing] parents",
+                "[the] breed[ing] (mother|1¦father|2¦baby|3¦player)");
+    }
+
+    private int pattern;
+    private int mark;
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
+        if (!ParserInstance.get().isCurrentEvent(EntityBreedEvent.class)) {
+            Skript.error("Breeding parents can only be retrieved in a breed event.", ErrorQuality.SEMANTIC_ERROR);
+            return false;
+        }
+        this.pattern = i;
+        this.mark = parseResult.mark;
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable Entity[] get(Event event) {
+        if (!(event instanceof EntityBreedEvent breedEvent)) return null;
+
+        if (pattern == 0) {
+            Entity[] parents = new Entity[2];
+            parents[0] = breedEvent.getMother();
+            parents[1] = breedEvent.getFather();
+            return parents;
+        } else if (mark == 0) {
+            return new Entity[]{breedEvent.getMother()};
+        } else if (mark == 1) {
+            return new Entity[]{breedEvent.getFather()};
+        } else if (mark == 2) {
+            return new Entity[]{breedEvent.getEntity()};
+        } else if (mark == 3) {
+            return new Entity[]{breedEvent.getBreeder()};
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return pattern == 1;
+    }
+
+    @Override
+    public @NotNull Class<? extends Entity> getReturnType() {
+        return Entity.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        if (pattern == 0) {
+            return "breed event parents";
+        } else {
+            String ent = switch (mark) {
+                case 1 -> "father";
+                case 2 -> "baby";
+                case 3 -> "breeder";
+                default -> "mother";
+            };
+            return "breed event " + ent;
+        }
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemCooldown.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemCooldown.java
@@ -1,0 +1,108 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Item Cooldown")
+@Description({"Get/set a cooldown on the specified material for a certain timespan.",
+        "Cooldowns are used by the server for items such as ender pearls and shields to prevent them from being used repeatedly.",
+        "Note that cooldowns will not by themselves stop an item from being used for attacking.",
+        "This is per player and per MATERIAL, not per actual item."})
+@Examples({"set item cooldown of player's tool for player to 1 second",
+        "set item cooldown of nether star for all players to 2 seconds",
+        "reset item cooldown of player's tool"})
+@Since("INSERT VERSION")
+public class ExprItemCooldown extends SimpleExpression<Timespan> {
+
+    static {
+        Skript.registerExpression(ExprItemCooldown.class, Timespan.class, ExpressionType.COMBINED,
+                "item cooldown (of|for) %itemtype% [(of|for) %players%]");
+    }
+
+    private Expression<ItemType> itemType;
+    private Expression<Player> players;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.itemType = (Expression<ItemType>) exprs[0];
+        this.players = (Expression<Player>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable Timespan[] get(Event event) {
+        ItemType itemType = this.itemType.getSingle(event);
+        List<Timespan> nums = new ArrayList<>();
+        if (itemType != null) {
+            Material material = itemType.getMaterial();
+            for (Player player : this.players.getArray(event)) {
+                int cooldown = player.getCooldown(material);
+                nums.add(Timespan.fromTicks_i(cooldown));
+            }
+        }
+        return nums.toArray(new Timespan[0]);
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET || mode == ChangeMode.RESET) {
+            return CollectionUtils.array(Timespan.class);
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        ItemType itemType = this.itemType.getSingle(event);
+        if (itemType == null) return;
+
+        Timespan timespan = (delta != null && delta[0] != null) ? ((Timespan) delta[0]) : Timespan.fromTicks_i(0);
+        long ticks = mode == ChangeMode.SET ? timespan.getTicks_i() : 0;
+        Material material = itemType.getMaterial();
+        if (!material.isItem()) return;
+
+        for (Player player : this.players.getArray(event)) {
+            player.setCooldown(material, (int) ticks);
+        }
+    }
+
+    @Override
+    public boolean isSingle() {
+        return this.players.isSingle();
+    }
+
+    @Override
+    public @NotNull Class<? extends Timespan> getReturnType() {
+        return Timespan.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "item cooldown of " + this.itemType.toString(e, d) + " for " + this.players.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemCooldown.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemCooldown.java
@@ -31,7 +31,7 @@ import java.util.List;
 @Examples({"set item cooldown of player's tool for player to 1 second",
         "set item cooldown of nether star for all players to 2 seconds",
         "reset item cooldown of player's tool"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprItemCooldown extends SimpleExpression<Timespan> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpellcasterSpell.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpellcasterSpell.java
@@ -1,0 +1,67 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Spellcaster;
+import org.bukkit.entity.Spellcaster.Spell;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Spellcaster Spell")
+@Description("Get/set/reset the spell of a spell casting entity (Illusioner, Evoker).")
+@Examples({"set spell of target entity to fangs",
+        "reset spell of target entity"})
+@Since("1.17.0")
+public class ExprSpellcasterSpell extends SimplePropertyExpression<Entity, Spell> {
+
+    static {
+        register(ExprSpellcasterSpell.class, Spell.class, "[spellcaster] spell", "entities");
+    }
+
+    @Override
+    public @Nullable Spell convert(Entity entity) {
+        if (entity instanceof Spellcaster spellcaster) {
+            return spellcaster.getSpell();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET || mode == ChangeMode.RESET) {
+            return CollectionUtils.array(Spell.class);
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Spell spell = delta != null ? ((Spell) delta[0]) : Spell.NONE;
+
+        for (Entity entity : getExpr().getArray(event)) {
+            if (entity instanceof Spellcaster spellcaster) {
+                spellcaster.setSpell(spell);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Spell> getReturnType() {
+        return Spell.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "spell";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTimeSpanNumbers.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTimeSpanNumbers.java
@@ -1,0 +1,56 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.Kleenean;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("TimeSpan - Numbers")
+@Description("Get the ticks/seconds/minutes/hours of a timespan.")
+@Examples("set {_ticks} to ticks of {_timespan}")
+public class ExprTimeSpanNumbers extends SimplePropertyExpression<Timespan, Number> {
+
+    static {
+        register(ExprTimeSpanNumbers.class, Number.class,
+                "(ticks|1¦seconds|2¦minutes|3¦hours)", "timespan");
+    }
+
+    private int pattern;
+
+    @SuppressWarnings({"unchecked", "NullableProblems"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.pattern = parseResult.mark;
+        setExpr((Expression<? extends Timespan>) exprs[0]);
+        return true;
+    }
+
+    @Override
+    public @Nullable Number convert(Timespan timespan) {
+        long ticks = timespan.getTicks_i();
+        return switch (pattern) {
+            case 1 -> (ticks / 20);
+            case 2 -> (ticks / 20 / 60);
+            case 3 -> (ticks / 20 / 60 / 60);
+            default -> ticks;
+        };
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        String[] numbers = new String[]{"ticks", "seconds", "minutes", "hours"};
+        return "time span " + numbers[pattern];
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprVillagerLevel.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprVillagerLevel.java
@@ -1,0 +1,110 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Villager - Level/Experience")
+@Description({"Represents the level/experience of a villager.",
+        "Level is between 1 and 5.","" +
+        "Experience is a number greater than or equal to 0."})
+@Examples({"set villager level of target entity to 5",
+        "set villager experience of last spawned villager to 10",
+        "if villager level of target entity > 2:",
+        "if villager experience of target entity > 10:"})
+@Since("INSERT VERSION")
+public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Number> {
+
+    static {
+        register(ExprVillagerLevel.class, Number.class, "villager (level|1¦experience)", "livingentities");
+    }
+
+    private int pattern;
+
+    @SuppressWarnings({"unchecked", "NullableProblems"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.pattern = matchedPattern;
+        setExpr((Expression<? extends LivingEntity>) exprs[0]);
+        return true;
+    }
+
+    @Override
+    public @Nullable Number convert(LivingEntity livingEntity) {
+        if (livingEntity instanceof Villager villager) {
+            return getValue(villager);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, RESET, ADD, REMOVE -> CollectionUtils.array(Number.class);
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int value = delta != null ? ((Number) delta[0]).intValue() : 0;
+
+        for (LivingEntity entity : getExpr().getArray(event)) {
+            if (entity instanceof Villager villager) {
+                int i = value;
+                switch (mode) {
+                    case ADD -> i += getValue(villager);
+                    case REMOVE -> i = getValue(villager) - i;
+                    case RESET -> i = 0;
+                }
+                setValue(villager, i);
+            }
+        }
+    }
+
+    private int getValue(Villager villager) {
+        if (pattern == 0) {
+            return villager.getVillagerLevel();
+        }
+        return villager.getVillagerExperience();
+    }
+
+    private void setValue(Villager villager, int value) {
+        if (pattern == 0) {
+            if (value < 1) {
+                value = 1;
+            } else if (value > 5) {
+                value = 5;
+            }
+            villager.setVillagerLevel(value);
+        } else {
+            if (value < 0) value = 0;
+            villager.setVillagerExperience(value);
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return pattern == 1 ? "experience" : "level";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprVillagerProfession.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprVillagerProfession.java
@@ -1,0 +1,69 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.Villager.Profession;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Villager - Profession")
+@Description("Represents the profession of a villager.")
+@Examples("set profession of target entity to nitwit profession")
+@Since("INSERT VERSION")
+public class ExprVillagerProfession extends SimplePropertyExpression<LivingEntity, Profession> {
+
+    static {
+        register(ExprVillagerProfession.class, Profession.class, "profession", "livingentities");
+    }
+
+    @Override
+    public @Nullable Profession convert(LivingEntity entity) {
+        if (entity instanceof Villager villager) {
+            return villager.getProfession();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, RESET -> CollectionUtils.array(Profession.class);
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Profession profession = delta != null ? ((Profession) delta[0]) : Profession.NONE;
+        Expression<? extends LivingEntity> expr = getExpr();
+        if (expr != null) {
+            for (LivingEntity entity : expr.getArray(event)) {
+                if (entity instanceof Villager villager) {
+                    villager.setProfession(profession);
+                }
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Profession> getReturnType() {
+        return Profession.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "villager profession";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprVillagerType.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprVillagerType.java
@@ -1,0 +1,66 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.Villager.Type;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Villager - Type")
+@Description("Represents the type of villager. Resetting will set a villager to a plains villager.")
+@Examples({"set {_t} to villager type of last spawned villager",
+        "set villager type of target entity to desert villager"})
+@Since("INSERT VERSION")
+public class ExprVillagerType extends SimplePropertyExpression<LivingEntity, Type> {
+
+    static {
+        register(ExprVillagerType.class, Type.class, "villager type", "livingentities");
+    }
+
+    @Override
+    public @Nullable Type convert(LivingEntity livingEntity) {
+        if (livingEntity instanceof Villager villager) {
+            return villager.getVillagerType();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, RESET -> CollectionUtils.array(Type.class);
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Type type = delta != null ? ((Type) delta[0]) : Type.PLAINS;
+        for (LivingEntity entity : getExpr().getArray(event)) {
+            if (entity instanceof Villager villager) {
+                villager.setVillagerType(type);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Type> getReturnType() {
+        return Type.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "villager type";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -21,6 +21,8 @@ import org.bukkit.Vibration;
 import org.bukkit.Vibration.Destination.BlockDestination;
 import org.bukkit.entity.Villager.Profession;
 import org.bukkit.entity.Villager.Type;
+import org.bukkit.event.entity.EntityPotionEffectEvent;
+import org.bukkit.event.entity.EntityPotionEffectEvent.Cause;
 import org.bukkit.event.player.PlayerFishEvent.State;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,6 +40,19 @@ public class Types {
                     .usage(FISH_STATE_ENUM.getAllNames())
                     .since("1.15.2")
                     .parser(FISH_STATE_ENUM.getParser()));
+        }
+
+        // Only register if no other addons have registered this class
+        // EntityPotionEffectEvent.Cause
+        if (Classes.getExactClassInfo(Cause.class) == null) {
+            EnumUtils<Cause> POTION_EFFECT_EVENT_CAUSE = new EnumUtils<>(Cause.class);
+            Classes.registerClass(new ClassInfo<>(Cause.class, "potioneffectcause")
+                    .user("potion ?effect ?causes?")
+                    .name("Potion Effect Cause")
+                    .description("Represents the different causes of an entity potion effect event.")
+                    .usage(POTION_EFFECT_EVENT_CAUSE.getAllNames())
+                    .since("INSERT VERSION")
+                    .parser(POTION_EFFECT_EVENT_CAUSE.getParser()));
         }
 
         // Only register if no other addons have registered this class

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -19,6 +19,7 @@ import org.bukkit.Particle.DustOptions;
 import org.bukkit.Particle.DustTransition;
 import org.bukkit.Vibration;
 import org.bukkit.Vibration.Destination.BlockDestination;
+import org.bukkit.entity.Spellcaster;
 import org.bukkit.event.entity.EntityPotionEffectEvent.Cause;
 import org.bukkit.event.player.PlayerFishEvent.State;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +41,21 @@ public class Types {
         } else {
             Util.logLoading("It looks like another addon registered 'fishingstate' already.");
             Util.logLoading("You may have to use their fishing states in SkBee's 'Fish Event State' expression.");
+        }
+
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Spellcaster.Spell.class) == null) {
+            EnumUtils<Spellcaster.Spell> SPELL_ENUM = new EnumUtils<>(Spellcaster.Spell.class);
+            Classes.registerClass(new ClassInfo<>(Spellcaster.Spell.class, "spell")
+                    .user("spells?")
+                    .name("Spellcaster Spell")
+                    .description("Represents the different spells of a spellcaster.")
+                    .usage(SPELL_ENUM.getAllNames())
+                    .since("1.17.0")
+                    .parser(SPELL_ENUM.getParser()));
+        } else {
+            Util.logLoading("It looks like another addon registered 'spell' already.");
+            Util.logLoading("You may have to use their spells in SkBee's 'Spell-caster Spell' expression.");
         }
 
         // Only register if no other addons have registered this class

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -51,7 +51,7 @@ public class Types {
                     .name("Potion Effect Cause")
                     .description("Represents the different causes of an entity potion effect event.")
                     .usage(POTION_EFFECT_EVENT_CAUSE.getAllNames())
-                    .since("INSERT VERSION")
+                    .since("1.17.0")
                     .parser(POTION_EFFECT_EVENT_CAUSE.getParser()));
         }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -40,34 +40,6 @@ public class Types {
                     .parser(FISH_STATE_ENUM.getParser()));
         }
 
-        // VILLAGER PROFESSION
-        // Only register if no other addons have registered this class
-        if (Classes.getExactClassInfo(Profession.class) == null) {
-            EnumUtils<Profession> VILLAGER_PROFESSION_ENUM = new EnumUtils<>(Profession.class, "", "profession");
-            Classes.registerClass(new ClassInfo<>(Profession.class, "profession")
-                    .user("professions?")
-                    .name("Villager Profession")
-                    .description("Represent the types of professions for villagers.",
-                            "Due to not parsing correctly, the professions are suffixed with 'profession'.")
-                    .usage(VILLAGER_PROFESSION_ENUM.getAllNames())
-                    .since("INSERT VERSION")
-                    .parser(VILLAGER_PROFESSION_ENUM.getParser()));
-        }
-
-        // VILLAGER TYPE
-        // Only register if no other addons have registered this class
-        if (Classes.getExactClassInfo(Type.class) == null) {
-            EnumUtils<Type> VILLAGER_TYPE_ENUM = new EnumUtils<>(Type.class, "", "villager");
-            Classes.registerClass(new ClassInfo<>(Type.class, "villagertype")
-                    .user("villager ?types?")
-                    .name("Villager Type")
-                    .description("Represents the types of villagers.",
-                            "Due to possible overlaps with biomes, types are suffixed with 'villager'.")
-                    .usage(VILLAGER_TYPE_ENUM.getAllNames())
-                    .since("INSERT VERSION")
-                    .parser(VILLAGER_TYPE_ENUM.getParser()));
-        }
-
         // Only register if no other addons have registered this class
         if (Classes.getExactClassInfo(Particle.class) == null) {
             Classes.registerClass(new ClassInfo<>(Particle.class, "particle")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -19,6 +19,8 @@ import org.bukkit.Particle.DustOptions;
 import org.bukkit.Particle.DustTransition;
 import org.bukkit.Vibration;
 import org.bukkit.Vibration.Destination.BlockDestination;
+import org.bukkit.entity.Villager.Profession;
+import org.bukkit.entity.Villager.Type;
 import org.bukkit.event.player.PlayerFishEvent.State;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +38,34 @@ public class Types {
                     .usage(FISH_STATE_ENUM.getAllNames())
                     .since("1.15.2")
                     .parser(FISH_STATE_ENUM.getParser()));
+        }
+
+        // VILLAGER PROFESSION
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Profession.class) == null) {
+            EnumUtils<Profession> VILLAGER_PROFESSION_ENUM = new EnumUtils<>(Profession.class, "", "profession");
+            Classes.registerClass(new ClassInfo<>(Profession.class, "profession")
+                    .user("professions?")
+                    .name("Villager Profession")
+                    .description("Represent the types of professions for villagers.",
+                            "Due to not parsing correctly, the professions are suffixed with 'profession'.")
+                    .usage(VILLAGER_PROFESSION_ENUM.getAllNames())
+                    .since("INSERT VERSION")
+                    .parser(VILLAGER_PROFESSION_ENUM.getParser()));
+        }
+
+        // VILLAGER TYPE
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Type.class) == null) {
+            EnumUtils<Type> VILLAGER_TYPE_ENUM = new EnumUtils<>(Type.class, "", "villager");
+            Classes.registerClass(new ClassInfo<>(Type.class, "villagertype")
+                    .user("villager ?types?")
+                    .name("Villager Type")
+                    .description("Represents the types of villagers.",
+                            "Due to possible overlaps with biomes, types are suffixed with 'villager'.")
+                    .usage(VILLAGER_TYPE_ENUM.getAllNames())
+                    .since("INSERT VERSION")
+                    .parser(VILLAGER_TYPE_ENUM.getParser()));
         }
 
         // Only register if no other addons have registered this class

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -37,6 +37,9 @@ public class Types {
                     .usage(FISH_STATE_ENUM.getAllNames())
                     .since("1.15.2")
                     .parser(FISH_STATE_ENUM.getParser()));
+        } else {
+            Util.logLoading("It looks like another addon registered 'fishingstate' already.");
+            Util.logLoading("You may have to use their fishing states in SkBee's 'Fish Event State' expression.");
         }
 
         // Only register if no other addons have registered this class
@@ -50,6 +53,9 @@ public class Types {
                     .usage(POTION_EFFECT_EVENT_CAUSE.getAllNames())
                     .since("1.17.0")
                     .parser(POTION_EFFECT_EVENT_CAUSE.getParser()));
+        } else {
+            Util.logLoading("It looks like another addon registered 'potioneffectcause' already.");
+            Util.logLoading("You may have to use their potion effect causes in SkBee's 'Entity Potion Effect' event.");
         }
 
         // Only register if no other addons have registered this class
@@ -91,8 +97,8 @@ public class Types {
                         }
                     }));
         } else {
-            Util.log("It looks like another addon registered 'particle' already. ");
-            Util.log("You may have to use their particles in SkBee's 'particle spawn' effect.");
+            Util.logLoading("It looks like another addon registered 'particle' already.");
+            Util.logLoading("You may have to use their particles in SkBee's 'particle spawn' effect.");
         }
 
         Classes.registerClass(new ClassInfo<>(DustOptions.class, "dustoption")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -19,9 +19,6 @@ import org.bukkit.Particle.DustOptions;
 import org.bukkit.Particle.DustTransition;
 import org.bukkit.Vibration;
 import org.bukkit.Vibration.Destination.BlockDestination;
-import org.bukkit.entity.Villager.Profession;
-import org.bukkit.entity.Villager.Type;
-import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent.Cause;
 import org.bukkit.event.player.PlayerFishEvent.State;
 import org.jetbrains.annotations.Nullable;
@@ -34,8 +31,8 @@ public class Types {
         // Only register if no other addons have registered this class
         if (Classes.getExactClassInfo(State.class) == null) {
             EnumUtils<State> FISH_STATE_ENUM = new EnumUtils<>(State.class);
-            Classes.registerClass(new ClassInfo<>(State.class, "fishstate")
-                    .user("fish ?states?")
+            Classes.registerClass(new ClassInfo<>(State.class, "fishingstate")
+                    .user("fish(ing)? ?states?")
                     .name("Fish Event State")
                     .usage(FISH_STATE_ENUM.getAllNames())
                     .since("1.15.2")

--- a/src/main/java/com/shanebeestudios/skbee/elements/statistic/expressions/ExprPlayerStatistic.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/statistic/expressions/ExprPlayerStatistic.java
@@ -34,7 +34,7 @@ import java.util.List;
         "add 10 to mine block stat using diamond ore for player",
         "remove 10 from chest opened stat for player",
         "reset mob kills stat for player"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprPlayerStatistic extends SimpleExpression<Number> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/statistic/expressions/ExprPlayerStatistic.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/statistic/expressions/ExprPlayerStatistic.java
@@ -1,0 +1,160 @@
+package com.shanebeestudios.skbee.elements.statistic.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.EntityUtils;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
+import org.bukkit.Statistic.Type;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Statistic - Get/Set")
+@Description("Represents the statistic of a Player. You can get, set, add, remove or reset stats.")
+@Examples({"set {_s} to kill entity stat using sheep for player",
+        "set kill entity stat using zombie for player to 10",
+        "add 10 to mine block stat using diamond ore for player",
+        "remove 10 from chest opened stat for player",
+        "reset mob kills stat for player"})
+@Since("INSERT VERSION")
+public class ExprPlayerStatistic extends SimpleExpression<Number> {
+
+    static {
+        Skript.registerExpression(ExprPlayerStatistic.class, Number.class, ExpressionType.COMBINED,
+                "%statistic% stat[istic] [using %-entitydata/itemtype%] (of|for) %offlineplayers%");
+    }
+
+    private Expression<Statistic> statistic;
+    private Expression<OfflinePlayer> player;
+    private Expression<Object> qualifier;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.statistic = (Expression<Statistic>) exprs[0];
+        this.qualifier = (Expression<Object>) exprs[1];
+        this.player = (Expression<OfflinePlayer>) exprs[2];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable Number[] get(Event event) {
+        List<Number> stats = new ArrayList<>();
+        Statistic statistic = this.statistic.getSingle(event);
+        Object qualifier = this.qualifier != null ? this.qualifier.getSingle(event) : null;
+        if (statistic == null) return null;
+
+        for (OfflinePlayer offlinePlayer : this.player.getArray(event)) {
+            stats.add(getStat(offlinePlayer, statistic, qualifier));
+        }
+        return stats.toArray(new Number[0]);
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case ADD, SET, REMOVE, RESET -> CollectionUtils.array(Number.class);
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int change = (delta != null && delta[0] instanceof Number) ? ((Number) delta[0]).intValue() : 0;
+        Object qualifier = this.qualifier != null ? this.qualifier.getSingle(event) : null;
+        Statistic statistic = this.statistic.getSingle(event);
+
+        if (statistic == null) return;
+
+        for (OfflinePlayer offlinePlayer : this.player.getArray(event)) {
+            switch (mode) {
+                case ADD -> change += getStat(offlinePlayer, statistic, qualifier);
+                case REMOVE -> change = getStat(offlinePlayer, statistic, qualifier) - change;
+                case RESET -> change = 0;
+            }
+            setStat(offlinePlayer, statistic, change, qualifier);
+        }
+    }
+
+    private void setStat(OfflinePlayer player, Statistic statistic, int change, Object qualifier) {
+        if (change < 0) {
+            change = 0;
+        }
+        Type statType = statistic.getType();
+        if (statType == Type.UNTYPED) {
+            player.setStatistic(statistic, change);
+        } else if (statType == Type.ENTITY && qualifier instanceof EntityData<?> entityData) {
+            EntityType entityType = EntityUtils.toBukkitEntityType(entityData);
+            player.setStatistic(statistic, entityType, change);
+        } else if (statType == Type.BLOCK && qualifier instanceof ItemType itemType) {
+            Material material = itemType.getMaterial();
+            if (material.isBlock()) {
+                player.setStatistic(statistic, material, change);
+            }
+        } else if (statType == Type.ITEM && qualifier instanceof ItemType itemType) {
+            Material material = itemType.getMaterial();
+            if (material.isItem()) {
+                player.setStatistic(statistic, material, change);
+            }
+        }
+    }
+
+    private int getStat(OfflinePlayer player, Statistic statistic, Object qualifier) {
+        Type statType = statistic.getType();
+        if (statType == Type.UNTYPED) {
+            return player.getStatistic(statistic);
+        } else if (statType == Type.ENTITY && qualifier instanceof EntityData<?> entityData) {
+            EntityType entityType = EntityUtils.toBukkitEntityType(entityData);
+            return player.getStatistic(statistic, entityType);
+        } else if (statType == Type.BLOCK && qualifier instanceof ItemType itemType) {
+            Material material = itemType.getMaterial();
+            if (material.isBlock()) {
+                return player.getStatistic(statistic, material);
+            }
+        } else if (statType == Type.ITEM && qualifier instanceof ItemType itemType) {
+            Material material = itemType.getMaterial();
+            if (material.isItem()) {
+                return player.getStatistic(statistic, material);
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return this.player.isSingle();
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String qualifier = this.qualifier != null ? "using " + this.qualifier.toString(e, d) : "";
+        return this.statistic.toString(e, d) + " statistic " + qualifier + " of " + this.player.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/statistic/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/statistic/type/Types.java
@@ -1,0 +1,54 @@
+package com.shanebeestudios.skbee.elements.statistic.type;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.util.StringUtils;
+import com.shanebeestudios.skbee.api.util.EnumUtils;
+import org.bukkit.Statistic;
+import org.bukkit.Statistic.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Types {
+
+    static {
+        EnumUtils<Statistic> STATISTICS_ENUM = new EnumUtils<>(Statistic.class);
+        Classes.registerClass(new ClassInfo<>(Statistic.class, "statistic")
+                .user("statistics?")
+                .name("Statistic")
+                .description("Represents the different statistics for a player.",
+                        "Some stats require extra data, these are distinguished by their data type within the square brackets.",
+                        "Underscores in stat names are not required, you can use spaces.",
+                        "NOTE: 'play_one_minute' stat's name is misleading, it's actually amount of ticks played.")
+                .usage(getNames())
+                .since("INSERT VERSION")
+                .parser(STATISTICS_ENUM.getParser()));
+    }
+
+    /**
+     * Get names of all stats
+     * <br>
+     * This includes the stat type
+     *
+     * @return List of all stats including type
+     */
+    private static String getNames() {
+        List<String> names = new ArrayList<>();
+        for (Statistic statistic : Statistic.values()) {
+            String name = statistic.getKey().getKey();
+            Type type = statistic.getType();
+
+            if (type == Type.ITEM || type == Type.BLOCK) {
+                name = name + " [ItemType]";
+            } else if (type == Type.ENTITY) {
+                name = name + " [EntityType]";
+            }
+            names.add(name);
+        }
+        Collections.sort(names);
+        return StringUtils.join(names, ", ");
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/statistic/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/statistic/type/Types.java
@@ -23,7 +23,7 @@ public class Types {
                         "Underscores in stat names are not required, you can use spaces.",
                         "NOTE: 'play_one_minute' stat's name is misleading, it's actually amount of ticks played.")
                 .usage(getNames())
-                .since("INSERT VERSION")
+                .since("1.17.0")
                 .parser(STATISTICS_ENUM.getParser()));
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffOpenMerchant.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffOpenMerchant.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 @Description("Open a merchant/villager to a player.")
 @Examples({"set {_m} to new merchant named \"Le Merchant\"",
         "open merchant {_m} to player"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffOpenMerchant extends Effect {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffOpenMerchant.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffOpenMerchant.java
@@ -1,0 +1,60 @@
+package com.shanebeestudios.skbee.elements.villager.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.Merchant;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Merchant - Open")
+@Description("Open a merchant/villager to a player.")
+@Examples({"set {_m} to new merchant named \"Le Merchant\"",
+        "open merchant {_m} to player"})
+@Since("INSERT VERSION")
+public class EffOpenMerchant extends Effect {
+
+    static {
+        Skript.registerEffect(EffOpenMerchant.class, "open merchant %merchant/entity% to %player%");
+    }
+
+    private Expression<Object> merchant;
+    private Expression<Player> player;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.merchant = (Expression<Object>) exprs[0];
+        this.player = (Expression<Player>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        Object object = this.merchant.getSingle(event);
+        Player player = this.player.getSingle(event);
+        if (player == null) return;
+
+        if (object instanceof Villager villager) {
+            player.openMerchant(villager, false);
+        } else if (object instanceof Merchant merchant) {
+            player.openMerchant(merchant, false);
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "open merchant " + this.merchant.toString(e, d) + " to " + this.player.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffVillagerEffects.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffVillagerEffects.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
         "wake up all villagers",
         "make target entity shake his head",
         "make target entity sleep at location(100, 64, 100, world \"world\")"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class EffVillagerEffects extends Effect {
 
     private static boolean CAN_ZOMBIFY = Skript.methodExists(Villager.class, "zombify");

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffVillagerEffects.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffVillagerEffects.java
@@ -1,4 +1,4 @@
-package com.shanebeestudios.skbee.elements.other.effects;
+package com.shanebeestudios.skbee.elements.villager.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/event/SimpleEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/event/SimpleEvents.java
@@ -21,7 +21,7 @@ public class SimpleEvents {
                         "`event-number` = Used to get the index of the trade the player clicked on.",
                         "`event-merchantrecipe` = The merchant recipe of the trade that the player clicked on.")
                 .examples("")
-                .since("INSERT VERSION");
+                .since("1.17.0");
 
         EventValues.registerEventValue(TradeSelectEvent.class, MerchantInventory.class, new Getter<>() {
             @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/event/SimpleEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/event/SimpleEvents.java
@@ -1,0 +1,65 @@
+package com.shanebeestudios.skbee.elements.villager.event;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.util.SimpleEvent;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.TradeSelectEvent;
+import org.bukkit.inventory.Merchant;
+import org.bukkit.inventory.MerchantInventory;
+import org.bukkit.inventory.MerchantRecipe;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class SimpleEvents {
+
+    static {
+        Skript.registerEvent("Trade Select", SimpleEvent.class, TradeSelectEvent.class, "trade select")
+                .description("This event is called whenever a player clicks a new trade on the trades sidebar.",
+                        "This event allows the user to get the index of the trade, letting them get the MerchantRecipe via the Merchant.",
+                        "`event-number` = Used to get the index of the trade the player clicked on.",
+                        "`event-merchantrecipe` = The merchant recipe of the trade that the player clicked on.")
+                .examples("")
+                .since("INSERT VERSION");
+
+        EventValues.registerEventValue(TradeSelectEvent.class, MerchantInventory.class, new Getter<>() {
+            @Override
+            public @Nullable MerchantInventory get(TradeSelectEvent event) {
+                return event.getInventory();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(TradeSelectEvent.class, Number.class, new Getter<>() {
+            @Override
+            public @Nullable Number get(TradeSelectEvent event) {
+                return event.getIndex();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(TradeSelectEvent.class, Merchant.class, new Getter<>() {
+            @Override
+            public @Nullable Merchant get(TradeSelectEvent event) {
+                return event.getMerchant();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(TradeSelectEvent.class, MerchantRecipe.class, new Getter<>() {
+            @Override
+            public @Nullable MerchantRecipe get(TradeSelectEvent event) {
+                return event.getInventory().getSelectedRecipe();
+            }
+        }, 0);
+
+        EventValues.registerEventValue(TradeSelectEvent.class, Player.class, new Getter<>() {
+            @Override
+            public @Nullable Player get(TradeSelectEvent event) {
+                HumanEntity trader = event.getMerchant().getTrader();
+                if (trader instanceof Player player) {
+                    return player;
+                }
+                return null;
+            }
+        }, 0);
+    }
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchant.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchant.java
@@ -1,0 +1,65 @@
+package com.shanebeestudios.skbee.elements.villager.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.Merchant;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Merchant - Create")
+@Description("Creates a new Merchant object with a title.")
+@Examples("set {_merch} to new merchant named \"Le-Merchant\"")
+@Since("INSERT VERSION")
+public class ExprMerchant extends SimpleExpression<Merchant> {
+
+    static {
+        Skript.registerExpression(ExprMerchant.class, Merchant.class, ExpressionType.SIMPLE,
+                "[new ]merchant named %string%");
+    }
+
+    private Expression<String> name;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.name = (Expression<String>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable Merchant[] get(Event event) {
+        String name = this.name.getSingle(event);
+        if (name != null) {
+            Merchant merchant = Bukkit.createMerchant(name);
+            return new Merchant[]{merchant};
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends Merchant> getReturnType() {
+        return Merchant.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "new merchant named " + name.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchant.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchant.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 @Name("Merchant - Create")
 @Description("Creates a new Merchant object with a title.")
 @Examples("set {_merch} to new merchant named \"Le-Merchant\"")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprMerchant extends SimpleExpression<Merchant> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipe.java
@@ -1,0 +1,117 @@
+package com.shanebeestudios.skbee.elements.villager.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Merchant Recipe - Create")
+@Description({"Create a merchant recipe.",
+        "\nmax uses = A trade has a maximum number of uses. A Villager may periodically replenish it's trades",
+        "by resetting the uses of it's merchant recipes to 0, allowing them to be used again.",
+        "\nexperience reward = A trade may or may not reward experience for being completed.",
+        "\ndemand = This value is periodically updated by the villager that owns this merchant recipe based on",
+        "how often the recipe has been used since it has been last restocked in relation to its maximum uses.",
+        "The amount by which the demand influences the amount of the first ingredient is scaled by the recipe's",
+        "price multiplier, and can never be below zero.",
+        "\nspecial price =  This value is dynamically updated whenever a player starts and stops trading with a",
+        "villager that owns this merchant recipe. It is based on the player's individual reputation with the villager,",
+        "and the player's currently active status effects (ex: hero of the village).",
+        "The influence of the player's reputation on the special price is scaled by the recipe's price multiplier."})
+@Examples("set {_m} to merchant recipe with result diamond sword with max uses 10")
+@Since("INSERT VERSION")
+public class ExprMerchantRecipe extends SimpleExpression<MerchantRecipe> {
+
+    static {
+        Skript.registerExpression(ExprMerchantRecipe.class, MerchantRecipe.class, ExpressionType.SIMPLE,
+                "[new] merchant recipe with result %itemtype% with max uses %number% [with uses %-number%] " +
+                        "[(|1¦with experience reward)] " +
+                        "[with villager experience %-number%] [ with price multiplier %-number%] [ with demand %-number%] " +
+                        "[with special price %-number%]");
+    }
+
+    private Expression<ItemType> result;
+    private Expression<Number> maxUses;
+    private Expression<Number> uses;
+    private boolean reward;
+    private Expression<Number> villagerExp;
+    private Expression<Number> priceMulti;
+    private Expression<Number> demand;
+    private Expression<Number> specialPrice;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.result = (Expression<ItemType>) exprs[0];
+        this.maxUses = (Expression<Number>) exprs[1];
+        this.uses = (Expression<Number>) exprs[2];
+        this.reward = parseResult.mark == 1;
+        this.villagerExp = (Expression<Number>) exprs[3];
+        this.priceMulti = (Expression<Number>) exprs[4];
+        this.demand = (Expression<Number>) exprs[5];
+        this.specialPrice = (Expression<Number>) exprs[6];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable MerchantRecipe[] get(Event event) {
+        ItemType itemType = this.result.getSingle(event);
+        Number maxUses = this.maxUses.getSingle(event);
+        Number uses = this.uses != null ? this.uses.getSingle(event) : null;
+        Number villagerExp = this.villagerExp != null ? this.villagerExp.getSingle(event) : null;
+        Number priceMulti = this.priceMulti != null ? this.priceMulti.getSingle(event) : null;
+        Number demand = this.demand != null ? this.demand.getSingle(event) : null;
+        Number specialPrice = this.specialPrice != null ? this.specialPrice.getSingle(event) : null;
+        if (itemType == null || maxUses == null) return null;
+
+        ItemStack random = itemType.getRandom();
+        int maxUsesI = maxUses.intValue();
+        int usesI = uses == null ? 0 : uses.intValue();
+        int villXP = villagerExp == null ? 0 : villagerExp.intValue();
+        float priceMultiF = priceMulti == null ? 0 : priceMulti.floatValue();
+        int demandI = demand == null ? 0 : demand.intValue();
+        int specialPriceI = specialPrice == null ? 0 : specialPrice.intValue();
+
+        MerchantRecipe merchantRecipe = new MerchantRecipe(random, usesI, maxUsesI, reward,
+                villXP, priceMultiF, demandI, specialPriceI);
+        return new MerchantRecipe[]{merchantRecipe};
+
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends MerchantRecipe> getReturnType() {
+        return MerchantRecipe.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String result = this.result.toString(e, d);
+        String max = this.maxUses.toString(e, d);
+        String uses = this.uses != null ? " with uses " + this.uses.toString(e, d) : "";
+        String reward = this.reward ? " with experience reward" : "";
+        String xp = this.villagerExp != null ? " with villager experience " + this.villagerExp.toString(e, d) : "";
+        String price = this.priceMulti != null ? " with price multiplier " + this.priceMulti.toString(e, d) : "";
+        String demand = this.demand != null ? " with demand " + this.demand.toString(e, d) : "";
+        String special = this.specialPrice != null ? " with special price " + this.specialPrice.toString(e, d) : "";
+        return "merchant recipe with result " + result + " with max uses " + max + uses + reward + xp + price + demand + special;
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipe.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
         "and the player's currently active status effects (ex: hero of the village).",
         "The influence of the player's reputation on the special price is scaled by the recipe's price multiplier."})
 @Examples("set {_m} to merchant recipe with result diamond sword with max uses 10")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprMerchantRecipe extends SimpleExpression<MerchantRecipe> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipeIngredients.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipeIngredients.java
@@ -1,0 +1,105 @@
+package com.shanebeestudios.skbee.elements.villager.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("NullableProblems")
+@Name("Merchant Recipe - Ingredients")
+@Description({"Represents the ingredients/result of a merchant recipe.",
+        "Ingredients can be set, but the result can not be changed.",
+        "If you wish to change the result, you will have to create a new merchant recipe."})
+@Examples({"set {_ing::*} to ingredients of merchant recipe {_recipe}",
+        "set ingredients of merchant recipe {_recipe} to diamond and stone",
+        "set {_result} to result item of merchant recipe {_recipe}"})
+@Since("INSERT VERSION")
+public class ExprMerchantRecipeIngredients extends SimpleExpression<ItemType> {
+
+    static {
+        Skript.registerExpression(ExprMerchantRecipeIngredients.class, ItemType.class, ExpressionType.SIMPLE,
+                "(ingredients|1¦result [item]) of merchant recipe %merchantrecipe%");
+    }
+
+    private int pattern;
+    private Expression<MerchantRecipe> recipe;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.pattern = parseResult.mark;
+        this.recipe = (Expression<MerchantRecipe>) exprs[0];
+        return true;
+    }
+
+    @Override
+    protected @Nullable ItemType[] get(Event event) {
+        MerchantRecipe recipe = this.recipe.getSingle(event);
+        if (recipe == null) return null;
+
+        if (pattern == 0) {
+            List<ItemType> items = new ArrayList<>();
+            recipe.getIngredients().forEach(itemStack -> items.add(new ItemType(itemStack)));
+            return items.toArray(new ItemType[0]);
+        } else {
+            ItemStack result = recipe.getResult();
+            ItemType itemType = new ItemType(result);
+            return new ItemType[]{itemType};
+        }
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET && pattern == 0) {
+            return CollectionUtils.array(ItemType[].class);
+        }
+        return null;
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        MerchantRecipe recipe = this.recipe.getSingle(event);
+        if (recipe == null || mode != ChangeMode.SET) return;
+
+        List<ItemStack> stacks = new ArrayList<>();
+        for (ItemType item : (ItemType[]) delta) {
+            if (stacks.size() <= 1) { // Recipe only accepts 2 ingredients
+                stacks.add(item.getRandom());
+            }
+        }
+        recipe.setIngredients(stacks);
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends ItemType> getReturnType() {
+        return ItemType.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        return "ingredients of merchant recipe " + this.recipe.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipeIngredients.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipeIngredients.java
@@ -30,7 +30,7 @@ import java.util.List;
 @Examples({"set {_ing::*} to ingredients of merchant recipe {_recipe}",
         "set ingredients of merchant recipe {_recipe} to diamond and stone",
         "set {_result} to result item of merchant recipe {_recipe}"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprMerchantRecipeIngredients extends SimpleExpression<ItemType> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -1,0 +1,134 @@
+package com.shanebeestudios.skbee.elements.villager.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.Merchant;
+import org.bukkit.inventory.MerchantRecipe;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Name("Merchant - Recipes")
+@Description({"Represents the recipes of a merchant. All recipes returns a list of all the recipes this merchant offers.",
+        "You can also set/delete them or add to them. You can also get/set/delete a specific recipe."})
+@Examples({"add {_recipe} to merchant recipes of {_merchant}",
+        "set merchant recipe 1 of {_merchant} to {_recipe}"})
+@Since("INSERT VERSION")
+public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
+
+    static {
+        Skript.registerExpression(ExprMerchantRecipes.class, MerchantRecipe.class, ExpressionType.COMBINED,
+                "[all] merchant recipes of %merchant/entity%",
+                "merchant recipe %number% of %merchant/entity%");
+    }
+
+    private Expression<Object> merchant;
+    private Expression<Number> recipe;
+    private boolean all;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.merchant = (Expression<Object>) exprs[i];
+        this.recipe = i == 1 ? (Expression<Number>) exprs[0] : null;
+        this.all = i == 0;
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable MerchantRecipe[] get(Event event) {
+        if (this.merchant.getSingle(event) instanceof Merchant merchant) {
+            if (all) {
+                return merchant.getRecipes().toArray(new MerchantRecipe[0]);
+            } else {
+                int recipe = 0;
+                if (this.recipe != null) {
+                    Number number = this.recipe.getSingle(event);
+                    if (number != null) recipe = number.intValue();
+                }
+                int count = merchant.getRecipeCount();
+                if (count == 0) return null;
+
+                recipe -= 1;
+                if (recipe < 0) recipe = 0;
+                if (recipe > (count - 1)) return null;
+
+                return new MerchantRecipe[]{merchant.getRecipe(recipe)};
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET || mode == ChangeMode.DELETE || (mode == ChangeMode.ADD && all)) {
+            return CollectionUtils.array(MerchantRecipe[].class);
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        if (this.merchant.getSingle(event) instanceof Merchant merchant) {
+            if (all) {
+                MerchantRecipe[] recipes = delta != null ? ((MerchantRecipe[]) delta) : null;
+                if (mode == ChangeMode.SET) {
+                    List<MerchantRecipe> recipesList = new ArrayList<>(Arrays.asList(recipes));
+                    merchant.setRecipes(recipesList);
+                } else if (mode == ChangeMode.DELETE) {
+                    merchant.setRecipes(new ArrayList<>());
+                } else if (mode == ChangeMode.ADD) {
+                    List<MerchantRecipe> merchantRecipes = new ArrayList<>(merchant.getRecipes());
+                    merchantRecipes.addAll(Arrays.asList(recipes));
+                    merchant.setRecipes(merchantRecipes);
+                }
+            } else if (delta[0] instanceof MerchantRecipe merchantRecipe) {
+                int recipe = this.recipe.getSingle(event).intValue() - 1;
+                if (recipe < 0) recipe = 0;
+                if (recipe >= merchant.getRecipeCount()) {
+                    List<MerchantRecipe> recipes = new ArrayList<>(merchant.getRecipes());
+                    recipes.add(merchantRecipe);
+                    merchant.setRecipes(recipes);
+                } else {
+                    merchant.setRecipe(recipe, merchantRecipe);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean isSingle() {
+        return !all;
+    }
+
+    @Override
+    public @NotNull Class<? extends MerchantRecipe> getReturnType() {
+        return MerchantRecipe.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        if (all) {
+            return "all merchant recipes of " + merchant.toString(e, d);
+        }
+        return "merchant recipe " + recipe.toString(e, d) + " of " + merchant.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -27,7 +27,7 @@ import java.util.List;
         "You can also set/delete them or add to them. You can also get/set/delete a specific recipe."})
 @Examples({"add {_recipe} to merchant recipes of {_merchant}",
         "set merchant recipe 1 of {_merchant} to {_recipe}"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerLevel.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerLevel.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
         "set villager experience of last spawned villager to 10",
         "if villager level of target entity > 2:",
         "if villager experience of target entity > 10:"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Number> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerLevel.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerLevel.java
@@ -1,4 +1,4 @@
-package com.shanebeestudios.skbee.elements.other.expressions;
+package com.shanebeestudios.skbee.elements.villager.expressions;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerProfession.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerProfession.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 @Name("Villager - Profession")
 @Description("Represents the profession of a villager.")
 @Examples("set profession of target entity to nitwit profession")
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprVillagerProfession extends SimplePropertyExpression<LivingEntity, Profession> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerProfession.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerProfession.java
@@ -1,4 +1,4 @@
-package com.shanebeestudios.skbee.elements.other.expressions;
+package com.shanebeestudios.skbee.elements.villager.expressions;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerType.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerType.java
@@ -1,4 +1,4 @@
-package com.shanebeestudios.skbee.elements.other.expressions;
+package com.shanebeestudios.skbee.elements.villager.expressions;
 
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerType.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerType.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 @Description("Represents the type of villager. Resetting will set a villager to a plains villager.")
 @Examples({"set {_t} to villager type of last spawned villager",
         "set villager type of target entity to desert villager"})
-@Since("INSERT VERSION")
+@Since("1.17.0")
 public class ExprVillagerType extends SimplePropertyExpression<LivingEntity, Type> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
@@ -1,0 +1,40 @@
+package com.shanebeestudios.skbee.elements.villager.type;
+
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.registrations.Classes;
+import com.shanebeestudios.skbee.api.util.EnumUtils;
+import org.bukkit.entity.Villager;
+
+public class Types {
+
+    static {
+        // VILLAGER PROFESSION
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Villager.Profession.class) == null) {
+            EnumUtils<Villager.Profession> VILLAGER_PROFESSION_ENUM = new EnumUtils<>(Villager.Profession.class, "", "profession");
+            Classes.registerClass(new ClassInfo<>(Villager.Profession.class, "profession")
+                    .user("professions?")
+                    .name("Villager Profession")
+                    .description("Represent the types of professions for villagers.",
+                            "Due to not parsing correctly, the professions are suffixed with 'profession'.")
+                    .usage(VILLAGER_PROFESSION_ENUM.getAllNames())
+                    .since("INSERT VERSION")
+                    .parser(VILLAGER_PROFESSION_ENUM.getParser()));
+        }
+
+        // VILLAGER TYPE
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Villager.Type.class) == null) {
+            EnumUtils<Villager.Type> VILLAGER_TYPE_ENUM = new EnumUtils<>(Villager.Type.class, "", "villager");
+            Classes.registerClass(new ClassInfo<>(Villager.Type.class, "villagertype")
+                    .user("villager ?types?")
+                    .name("Villager Type")
+                    .description("Represents the types of villagers.",
+                            "Due to possible overlaps with biomes, types are suffixed with 'villager'.")
+                    .usage(VILLAGER_TYPE_ENUM.getAllNames())
+                    .since("INSERT VERSION")
+                    .parser(VILLAGER_TYPE_ENUM.getParser()));
+        }
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
@@ -1,9 +1,22 @@
 package com.shanebeestudios.skbee.elements.villager.type;
 
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import com.shanebeestudios.skbee.api.util.EnumUtils;
+import org.bukkit.entity.AbstractVillager;
 import org.bukkit.entity.Villager;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Merchant;
+import org.bukkit.inventory.MerchantInventory;
+import org.bukkit.inventory.MerchantRecipe;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Types {
 
@@ -34,6 +47,91 @@ public class Types {
                     .usage(VILLAGER_TYPE_ENUM.getAllNames())
                     .since("INSERT VERSION")
                     .parser(VILLAGER_TYPE_ENUM.getParser()));
+        }
+
+        // MERCHANT
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(Merchant.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Merchant.class, "merchant")
+                    .user("merchants?")
+                    .name("Merchant")
+                    .description("Represents a merchant.",
+                            "A merchant is a special type of inventory which can facilitate custom trades between items.")
+                    .since("INSERT VERSION")
+                    .parser(new Parser<>() {
+
+                        @SuppressWarnings("NullableProblems")
+                        @Override
+                        public boolean canParse(ParseContext context) {
+                            return false;
+                        }
+
+                        @Override
+                        public @NotNull String toString(Merchant merchant, int i) {
+                            if (merchant instanceof AbstractVillager villager) {
+                                return EntityData.toString(villager, i);
+                            }
+                            return "Merchant{trader=" + Classes.toString(merchant.getTrader()) + "}";
+                        }
+
+                        @Override
+                        public @NotNull String toVariableNameString(Merchant merchant) {
+                            return "merchant";
+                        }
+                    }));
+        }
+
+        // MERCHANT INVENTORY
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(MerchantInventory.class) == null) {
+            Classes.registerClass(new ClassInfo<>(MerchantInventory.class, "merchantinventory")
+                    .user("merchant ?inventor(y|ies)")
+                    .name("Merchant Inventory")
+                    .description("Represents a trading inventory between a player and a merchant.",
+                            "The holder of this Inventory is the owning Villager, or null if the player is trading with a custom merchant.")
+                    .since("INSERT VERSION"));
+        }
+
+        // MERCHANT RECIPE
+        // Only register if no other addons have registered this class
+        if (Classes.getExactClassInfo(MerchantRecipe.class) == null) {
+            Classes.registerClass(new ClassInfo<>(MerchantRecipe.class, "merchantrecipe")
+                    .user("merchant ?recipes?")
+                    .name("Merchant Recipe")
+                    .description("Represents a merchant's trade. Trades can take one or two ingredients, and provide one result.")
+                    .since("INSERT VERSION")
+                    .parser(new Parser<>() {
+
+                        @Override
+                        public boolean canParse(ParseContext context) {
+                            return false;
+                        }
+
+                        @Override
+                        public @NotNull String toString(MerchantRecipe merchantRecipe, int i) {
+                            String result = ItemType.toString(merchantRecipe.getResult());
+                            List<String> ingredients = new ArrayList<>();
+                            for (ItemStack ingredient : merchantRecipe.getIngredients()) {
+                                ingredients.add(ItemType.toString(ingredient));
+                            }
+                            int maxUses = merchantRecipe.getMaxUses();
+                            int uses = merchantRecipe.getUses();
+                            boolean reward = merchantRecipe.hasExperienceReward();
+                            int villagerXP = merchantRecipe.getVillagerExperience();
+                            float priceMultiplier = merchantRecipe.getPriceMultiplier();
+                            int demand = merchantRecipe.getDemand();
+                            int specialPrice = merchantRecipe.getSpecialPrice();
+                            return String.format(
+                                    "MerchantRecipe{result=%s, maxUses=%s, ingredients=%s, uses=%s, " +
+                                            "reward=%s, villagerXP=%s, priceMultiplier=%s, demand=%s, specialPrice=%s}",
+                                    result, maxUses, ingredients, uses, reward, villagerXP, priceMultiplier, demand, specialPrice);
+                        }
+
+                        @Override
+                        public @NotNull String toVariableNameString(MerchantRecipe merchantRecipe) {
+                            return "merchant recipe";
+                        }
+                    }));
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
@@ -7,6 +7,7 @@ import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import com.shanebeestudios.skbee.api.util.EnumUtils;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.entity.AbstractVillager;
 import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemStack;
@@ -33,6 +34,9 @@ public class Types {
                     .usage(VILLAGER_PROFESSION_ENUM.getAllNames())
                     .since("1.17.0")
                     .parser(VILLAGER_PROFESSION_ENUM.getParser()));
+        } else {
+            Util.logLoading("It looks like another addon registered 'profession' already.");
+            Util.logLoading("You may have to use their profession in SkBee's 'Villager Profession' expression.");
         }
 
         // VILLAGER TYPE
@@ -47,6 +51,9 @@ public class Types {
                     .usage(VILLAGER_TYPE_ENUM.getAllNames())
                     .since("1.17.0")
                     .parser(VILLAGER_TYPE_ENUM.getParser()));
+        } else {
+            Util.logLoading("It looks like another addon registered 'villagertype' already.");
+            Util.logLoading("You may have to use their villagertype in SkBee's 'Villager Type' expression.");
         }
 
         // MERCHANT

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/type/Types.java
@@ -31,7 +31,7 @@ public class Types {
                     .description("Represent the types of professions for villagers.",
                             "Due to not parsing correctly, the professions are suffixed with 'profession'.")
                     .usage(VILLAGER_PROFESSION_ENUM.getAllNames())
-                    .since("INSERT VERSION")
+                    .since("1.17.0")
                     .parser(VILLAGER_PROFESSION_ENUM.getParser()));
         }
 
@@ -45,7 +45,7 @@ public class Types {
                     .description("Represents the types of villagers.",
                             "Due to possible overlaps with biomes, types are suffixed with 'villager'.")
                     .usage(VILLAGER_TYPE_ENUM.getAllNames())
-                    .since("INSERT VERSION")
+                    .since("1.17.0")
                     .parser(VILLAGER_TYPE_ENUM.getParser()));
         }
 
@@ -57,7 +57,7 @@ public class Types {
                     .name("Merchant")
                     .description("Represents a merchant.",
                             "A merchant is a special type of inventory which can facilitate custom trades between items.")
-                    .since("INSERT VERSION")
+                    .since("1.17.0")
                     .parser(new Parser<>() {
 
                         @SuppressWarnings("NullableProblems")
@@ -89,7 +89,7 @@ public class Types {
                     .name("Merchant Inventory")
                     .description("Represents a trading inventory between a player and a merchant.",
                             "The holder of this Inventory is the owning Villager, or null if the player is trading with a custom merchant.")
-                    .since("INSERT VERSION"));
+                    .since("1.17.0"));
         }
 
         // MERCHANT RECIPE
@@ -99,7 +99,7 @@ public class Types {
                     .user("merchant ?recipes?")
                     .name("Merchant Recipe")
                     .description("Represents a merchant's trade. Trades can take one or two ingredients, and provide one result.")
-                    .since("INSERT VERSION")
+                    .since("1.17.0")
                     .parser(new Parser<>() {
 
                         @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/conditions/CondWorldBorderInside.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/conditions/CondWorldBorderInside.java
@@ -1,0 +1,54 @@
+package com.shanebeestudios.skbee.elements.worldborder.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.Location;
+import org.bukkit.WorldBorder;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("WorldBorder - Location Within")
+@Description("Check if a location is within a world border.")
+@Examples("if location of player is within world border of world of player:")
+@Since("1.17.0")
+public class CondWorldBorderInside extends Condition {
+
+    static {
+        PropertyCondition.register(CondWorldBorderInside.class, "within [border] %worldborder%", "locations");
+    }
+
+    private Expression<Location> locations;
+    private Expression<WorldBorder> worldBorder;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.locations = (Expression<Location>) exprs[0];
+        this.worldBorder = (Expression<WorldBorder>) exprs[1];
+        setNegated(i == 1);
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean check(Event event) {
+        return locations.check(event,
+                location -> worldBorder.check(event,
+                        worldBorder -> worldBorder.isInside(location), isNegated()));
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String not = isNegated() ? " is/are not" : " is/are";
+        return this.locations.toString(e, d) + not + " within " + this.worldBorder.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/effects/EffWorldBorderExpand.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/effects/EffWorldBorderExpand.java
@@ -1,0 +1,95 @@
+package com.shanebeestudios.skbee.elements.worldborder.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.Kleenean;
+import org.bukkit.WorldBorder;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("WorldBorder - Expand/Shrink")
+@Description({"Expand or shrink a world border.",
+        "\nBY = adds/subtracts from current size of border.",
+        "\nTO = sets to the specified size.",
+        "\ntimespan = how long it will take the border to get to the new size."})
+@Examples({"expand world border of player by 100 in 5 seconds",
+        "shrink world border of world border of world \"world\" to 100 in 10 seconds"})
+@Since("1.17.0")
+public class EffWorldBorderExpand extends Effect {
+
+    static {
+        Skript.registerEffect(EffWorldBorderExpand.class,
+                "(expand|1¦shrink) %worldborders% by %number% [in %-timespan%]",
+                "(expand|1¦shrink) %worldborders% to %number% [in %-timespan%]");
+    }
+
+    private boolean expand;
+    private int pattern;
+    private Expression<WorldBorder> worldBorders;
+    private Expression<Number> size;
+    private Expression<Timespan> timeSpan;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        this.expand = parseResult.mark == 0;
+        this.pattern = i;
+        this.worldBorders = (Expression<WorldBorder>) exprs[0];
+        this.size = (Expression<Number>) exprs[1];
+        this.timeSpan = (Expression<Timespan>) exprs[2];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        Number sizeNum = this.size.getSingle(event);
+        if (sizeNum == null) return;
+
+        long speed = 0;
+        if (this.timeSpan != null) {
+            Timespan timeSpan = this.timeSpan.getSingle(event);
+            if (timeSpan != null) speed = timeSpan.getTicks_i() / 20;
+        }
+
+        int size = sizeNum.intValue();
+        for (WorldBorder border : this.worldBorders.getArray(event)) {
+            if (pattern == 0) {
+                expand(border, size, speed);
+            } else {
+                if (size < 0) size = 0;
+                border.setSize(size, speed);
+            }
+        }
+    }
+
+    private void expand(WorldBorder worldBorder, double size, long seconds) {
+        double oldSize = worldBorder.getSize();
+        if (expand) {
+            worldBorder.setSize(oldSize + size, seconds);
+        } else {
+            double newSize = oldSize - size;
+            if (newSize < 0) newSize = 0;
+            worldBorder.setSize(newSize, seconds);
+        }
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String expand = this.expand ? "expand" : "shrink";
+        String to = pattern == 1 ? "to" : "by";
+        String size = this.size.toString(e, d);
+        String time = this.timeSpan != null ? "in " + this.timeSpan.toString(e, d) : "";
+        return String.format("%s %s %s %s %s",
+                expand, this.worldBorders.toString(e, d), to, size, time);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorder.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorder.java
@@ -1,0 +1,142 @@
+package com.shanebeestudios.skbee.elements.worldborder.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.log.ErrorQuality;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.WorldBorder;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("WorldBorder")
+@Description({"Represents the world border of a player/world, or create a virtual world border.",
+        "World border of a world can not be changed.",
+        "World border of a player can be set to a virtual world border.",
+        "Resetting border of player will set back to the world border of the world the player is in.",
+        "If you would like to reset default values of a border, you will have to do it in a var (see examples).",
+        "Multiple players can share a virtual world border.",
+        "NOTE: Virtual world borders do not seem to be persistent (ie: restarts, quitting, death, world change)."})
+@Examples({"set world border of player to virtual world border",
+        "set center of world border of player to location of player",
+        "set size of world border of player to 100",
+        "reset world border of player #will remove the player's virtual border",
+        "set {_w} to world border of player",
+        "reset {_w} #will reset default values of the border"})
+@Since("1.17.0")
+public class ExprWorldBorder extends SimpleExpression<WorldBorder> {
+
+    private static final boolean SUPPORTS_VIRTUAL_BORDER = Skript.methodExists(Player.class, "getWorldBorder");
+
+    static {
+        Skript.registerExpression(ExprWorldBorder.class, WorldBorder.class, ExpressionType.SIMPLE,
+                "world border of %players/worlds%",
+                "[new] virtual world border");
+    }
+
+    private int pattern;
+    private Expression<Object> object;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
+        if (i == 1 && !SUPPORTS_VIRTUAL_BORDER) {
+            Skript.error("Virtual world borders are not supported on your version.", ErrorQuality.SEMANTIC_ERROR);
+            return false;
+        }
+        this.pattern = i;
+        this.object = i == 0 ? (Expression<Object>) exprs[0] : null;
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable WorldBorder[] get(Event event) {
+        List<WorldBorder> borders = new ArrayList<>();
+
+        if (pattern == 1 && SUPPORTS_VIRTUAL_BORDER) {
+            return new WorldBorder[]{Bukkit.createWorldBorder()};
+        }
+        for (Object object : this.object.getArray(event)) {
+            if (object instanceof Player player && SUPPORTS_VIRTUAL_BORDER) {
+                borders.add(player.getWorldBorder());
+            } else if (object instanceof World world) {
+                borders.add(world.getWorldBorder());
+            }
+        }
+        return borders.toArray(new WorldBorder[0]);
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (pattern == 0 && !SUPPORTS_VIRTUAL_BORDER) {
+            Skript.error("Virtual world borders are not supported on your version therefor a border cannot be changed", ErrorQuality.SEMANTIC_ERROR);
+            return null;
+        }
+        if (pattern == 0 && (mode == ChangeMode.SET || mode == ChangeMode.RESET)) {
+            return CollectionUtils.array(WorldBorder.class);
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        WorldBorder border = delta != null ? ((WorldBorder) delta[0]) : null;
+        for (Object object : this.object.getArray(event)) {
+            if (object instanceof Player player) {
+                if (mode == ChangeMode.SET) {
+                    if (border != null && border.getWorld() != null && border.getWorld() != player.getWorld()) {
+                        // This means the border belongs to a world the player is not in
+                        // Virtual borders will not have an attached world
+                        continue;
+                    }
+                    player.setWorldBorder(border);
+                } else {
+                    // Assigns the border of the world the player is in
+                    player.setWorldBorder(null);
+                }
+            } else if (object instanceof World world && mode == ChangeMode.RESET) {
+                world.getWorldBorder().reset();
+            }
+        }
+    }
+
+    @Override
+    public boolean isSingle() {
+        if (pattern == 0) {
+            return this.object.isSingle();
+        }
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends WorldBorder> getReturnType() {
+        return WorldBorder.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        if (pattern == 0) {
+            return "world border of " + this.object.toString(e, d);
+        }
+        return "virtual world border";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderCenter.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderCenter.java
@@ -1,0 +1,59 @@
+package com.shanebeestudios.skbee.elements.worldborder.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Location;
+import org.bukkit.WorldBorder;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("WorldBorder - Center")
+@Description("Get/set the center location of a world border.")
+@Examples("set center of world border of player to location(1,1,1)")
+@Since("1.17.0")
+public class ExprWorldBorderCenter extends SimplePropertyExpression<WorldBorder, Location> {
+
+    static {
+        register(ExprWorldBorderCenter.class, Location.class, "[border] center", "worldborders");
+    }
+
+    @Override
+    public @Nullable Location convert(WorldBorder worldBorder) {
+        return worldBorder.getCenter();
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET) return CollectionUtils.array(Location.class);
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Location location = (Location) delta[0];
+        if (location == null) return;
+
+        for (WorldBorder border : getExpr().getArray(event)) {
+            border.setCenter(location);
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Location> getReturnType() {
+        return Location.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "world border center";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderNumbers.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderNumbers.java
@@ -1,0 +1,90 @@
+package com.shanebeestudios.skbee.elements.worldborder.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.WorldBorder;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("WorldBorder - Stats")
+@Description({"Get/set different stats of a world border.",
+        "\ndamage amount = amount of damage a player takes when outside the border plus the border buffer.",
+        "\ndamage buffer = amount of blocks a player may safely be outside the border before taking damage.",
+        "\nsize = border to a square region with the specified side length in blocks.",
+        "\nwarning distance = distance that causes the screen to be tinted red when the player is within the specified number of blocks from the border."})
+@Examples({"set damage amount of world border of world of player to 10",
+        "set size of world border of player to 100"})
+@Since("1.17.0")
+public class ExprWorldBorderNumbers extends SimplePropertyExpression<WorldBorder, Number> {
+
+    static {
+        register(ExprWorldBorderNumbers.class, Number.class,
+                "[border] (damage amount|1¦damage buffer|2¦size|3¦warning distance)",
+                "worldborders");
+    }
+
+    private int pattern;
+
+    @SuppressWarnings({"unchecked", "NullableProblems"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.pattern = parseResult.mark;
+        setExpr((Expression<? extends WorldBorder>) exprs[0]);
+        return true;
+    }
+
+    @Override
+    public @Nullable Number convert(WorldBorder worldBorder) {
+        return switch (pattern) {
+            case 1 -> worldBorder.getDamageBuffer();
+            case 2 -> worldBorder.getSize();
+            case 3 -> worldBorder.getWarningDistance();
+            default -> worldBorder.getDamageAmount();
+        };
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET) return CollectionUtils.array(Number.class);
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Number number = (Number) delta[0];
+        if (number == null) return;
+
+        for (WorldBorder border : getExpr().getArray(event)) {
+            switch (pattern) {
+                case 1 -> border.setDamageBuffer(number.doubleValue());
+                case 2 -> border.setSize(number.doubleValue());
+                case 3 -> border.setWarningDistance(number.intValue());
+                default -> border.setDamageAmount(number.doubleValue());
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    private static final String[] PATTERNS = new String[]{"damage amount", "damage buffer", "size", "warning distance"};
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return PATTERNS[pattern];
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderWarningTime.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderWarningTime.java
@@ -1,0 +1,61 @@
+package com.shanebeestudios.skbee.elements.worldborder.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.WorldBorder;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+@Name("WorldBorder - Warning Time")
+@Description("Get/set the warning time of a world border.")
+@Examples("set warning time of world border of world \"world\" to 5 seconds")
+@Since("1.17.0")
+public class ExprWorldBorderWarningTime extends SimplePropertyExpression<WorldBorder, Timespan> {
+
+    static {
+        register(ExprWorldBorderWarningTime.class, Timespan.class,
+                "[border] warning time", "worldborders");
+    }
+
+    @Override
+    public @Nullable Timespan convert(WorldBorder worldBorder) {
+        return Timespan.fromTicks_i(worldBorder.getWarningTime());
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET) return CollectionUtils.array(Timespan.class);
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Timespan timespan = (Timespan) delta[0];
+        if (timespan == null) return;
+
+        int seconds = (int)(timespan.getTicks_i() / 20);
+        for (WorldBorder border : getExpr().getArray(event)) {
+            border.setWarningTime(seconds);
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Timespan> getReturnType() {
+        return Timespan.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "warning time";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/type/Types.java
@@ -45,8 +45,8 @@ public class Types {
                     .parser(new Parser<>() {
                         @SuppressWarnings("NullableProblems")
                         @Override
-                        public @Nullable WorldBorder parse(String s, ParseContext context) {
-                            return null;
+                        public boolean canParse(ParseContext context) {
+                            return false;
                         }
 
                         @SuppressWarnings("NullableProblems")

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/type/Types.java
@@ -6,6 +6,7 @@ import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.World;
 import org.bukkit.WorldBorder;
 import org.eclipse.jdt.annotation.Nullable;
@@ -73,6 +74,9 @@ public class Types {
                         }
                     })
                     .changer(BORDER_CHANGER));
+        } else {
+            Util.logLoading("It looks like another addon registered 'worldborder' already.");
+            Util.logLoading("You may have to use their worldborder in SkBee's 'WorldBorder elements.");
         }
     }
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/type/Types.java
@@ -1,0 +1,78 @@
+package com.shanebeestudios.skbee.elements.worldborder.type;
+
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.classes.Parser;
+import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.World;
+import org.bukkit.WorldBorder;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class Types {
+
+    private static final Changer<WorldBorder> BORDER_CHANGER = new Changer<>() {
+        @SuppressWarnings("NullableProblems")
+        @Override
+        public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+            if (mode == ChangeMode.RESET) return CollectionUtils.array(WorldBorder.class);
+            return null;
+        }
+
+        @SuppressWarnings("NullableProblems")
+        @Override
+        public void change(WorldBorder[] worldBorders, @Nullable Object[] objects, ChangeMode mode) {
+            if (mode == ChangeMode.RESET) {
+                for (WorldBorder worldBorder : worldBorders) {
+                    worldBorder.reset();
+                }
+            }
+        }
+    };
+
+    static {
+        if (Classes.getExactClassInfo(WorldBorder.class) == null) {
+            Classes.registerClass(new ClassInfo<>(WorldBorder.class, "worldborder")
+                    .user("world ?borders?")
+                    .name("World Border")
+                    .description("Represents the world border of a world/player.",
+                            "World borders can be reset.",
+                            "(This will need to be done from a var since the expression handles it differently)")
+                    .examples("set {_w} to world border of player",
+                            "reset {_w}")
+                    .since("1.17.0")
+                    .parser(new Parser<>() {
+                        @SuppressWarnings("NullableProblems")
+                        @Override
+                        public @Nullable WorldBorder parse(String s, ParseContext context) {
+                            return null;
+                        }
+
+                        @SuppressWarnings("NullableProblems")
+                        @Override
+                        public String toString(WorldBorder worldBorder, int i) {
+                            World world = worldBorder.getWorld();
+                            if (world != null) {
+                                String worldName = Classes.toString(world);
+                                return "world border of world '" + worldName + "'";
+                            }
+                            String borderString = worldBorder.toString();
+                            if (borderString.contains("@")) {
+                                borderString = " @" + borderString.split("@")[1];
+                            } else {
+                                borderString = "";
+                            }
+                            return "virtual world border" + borderString;
+                        }
+
+                        @SuppressWarnings("NullableProblems")
+                        @Override
+                        public String toVariableNameString(WorldBorder worldBorder) {
+                            return "worldborder: " + toString(worldBorder, 0);
+                        }
+                    })
+                    .changer(BORDER_CHANGER));
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -48,6 +48,9 @@ elements:
   # Enable boss bar elements
   boss-bar: true
 
+  # Enable statistic elements
+  statistic: true
+
 recipe:
   # This is the namespace all recipes will be saved under
   # You can choose whatever you wish

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -54,6 +54,9 @@ elements:
   # Enable villager/merchant elements
   villager: true
 
+  # Enable advancement elements
+  advancement: true
+
 recipe:
   # This is the namespace all recipes will be saved under
   # You can choose whatever you wish

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -51,6 +51,9 @@ elements:
   # Enable statistic elements
   statistic: true
 
+  # Enable villager/merchant elements
+  villager: true
+
 recipe:
   # This is the namespace all recipes will be saved under
   # You can choose whatever you wish

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -57,6 +57,9 @@ elements:
   # Enable advancement elements
   advancement: true
 
+  # Enable world border elements
+  world-border: true
+
 recipe:
   # This is the namespace all recipes will be saved under
   # You can choose whatever you wish

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -34,3 +34,4 @@ types:
 	statistic: statistic¦s
 	profession: profession¦s
 	villagertype: villager type¦s
+	potioneffectcause: potion effect cause¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -35,3 +35,6 @@ types:
 	profession: profession¦s
 	villagertype: villager type¦s
 	potioneffectcause: potion effect cause¦s
+	merchant: merchant¦s
+	merchantrecipe: merchant recipe¦s
+	merchantinventory: merchant inventor(y|ies)

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -26,7 +26,7 @@ types:
 	attributeoperation: attribute operation¦s
 	attributepair: attribute pair¦s
 	attributemodifier: attribute modifier¦s
-	fishstate: fish state¦s
+	fishingstate: fish[ing] state¦s
 	bossbar: boss bars¦s
 	bossbarcolor: boss bar color¦s
 	bossbarstyle: boss bar style¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -41,3 +41,4 @@ types:
 	advancement: advancement¦s
 	advancementpro: advancement progress¦es
 	worldborder: world border¦s
+	spell: spell¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -38,3 +38,5 @@ types:
 	merchant: merchant¦s
 	merchantrecipe: merchant recipe¦s
 	merchantinventory: merchant inventor(y|ies)
+	advancement: advancement¦s
+	advancementpro: advancement progress¦es

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -31,3 +31,4 @@ types:
 	bossbarcolor: boss bar color¦s
 	bossbarstyle: boss bar style¦s
 	bossbarflag: boss bar flags¦s
+	statistic: statistic¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -40,3 +40,4 @@ types:
 	merchantinventory: merchant inventor(y|ies)
 	advancement: advancement¦s
 	advancementpro: advancement progress¦es
+	worldborder: world border¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -32,3 +32,5 @@ types:
 	bossbarstyle: boss bar style¦s
 	bossbarflag: boss bar flags¦s
 	statistic: statistic¦s
+	profession: profession¦s
+	villagertype: villager type¦s

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,3 +11,7 @@ softdepend:
   - skript-variable-dump
 loadbefore:
   - SkQuery
+commands:
+  skbee:
+    description: Main SkBee command
+    permission: skbee.command


### PR DESCRIPTION
This PR is a focus on a future version of SkBee with some new features.

Features so far added:
- Statistics #179 
- Villager elements (level, experience, profession, type) #180
- Merchant elements (merchants, merchant recipes, trade select event) #180 
- Update particle effect to include `force` #183 
- New `/skbee info` command (used for debugging purposes)
- New update checker (will print in console if an update is available)
- Expression for getting ticks/seconds/minutes/hours from a timespan #195 
- Potion change event
- Show demo screen effect #195 
- Effect to load/unload a chunk (with optional ticket) #195 
- Breed event, event values, expression for breed event entities (parents, baby, breeder) #195 
- Advancement objects, event, expressions #195 
- WorldBorder elements (including virtual world borders for players) #195 
- Expression to get/set spell of a spell caster #142 