### PR TITLE
Fix line seperator in hover event expression

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprHoverEvent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprHoverEvent.java
@@ -66,7 +66,7 @@ public class ExprHoverEvent extends SimpleExpression<HoverEvent> {
             String[] string = ((String[]) this.object.getArray(event));
             Component texts = Component.empty();
             for (int i = 0; i < string.length; i++) {
-                Component component = Component.text(string[i] + (i < (string.length - 1) ? System.lineSeparator() : ""));
+                Component component = Component.text(string[i] + (i < (string.length - 1) ? "\n" : ""));
                 texts = texts.append(component);
             }
             return new HoverEvent[]{HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, texts)};


### PR DESCRIPTION
Minecraft likes just LF, but System#lineSeperator can return CRLF on some platforms like Windows. This causes an erroneous "CR" character to be displayed in the hover text.