### PR TITLE
ExprIngredientsOfRecipe - fix shaped recipes that are 3 slots wide but not 3 slots tall

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprIngredientsOfRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprIngredientsOfRecipe.java
@@ -63,13 +63,14 @@ public class ExprIngredientsOfRecipe extends SimpleExpression<ItemType> {
             if (recipe instanceof Keyed keyed && keyed.getKey().toString().equalsIgnoreCase(this.recipe.getSingle(e))) {
                 if (recipe instanceof ShapedRecipe shapedRecipe) {
                     String[] shape = shapedRecipe.getShape();
-                    for (int i = 0; i < Math.pow(shape.length, 2); i++) {
+                    int length = Math.max(shape.length, shape[0].length());
+                    for (int i = 0; i < Math.pow(length, 2); i++) {
                         items.add(new ItemType(Material.AIR));
                     }
                     for (int i = 0; i < shape.length; i++) {
                         for (int x = 0; x < shape[i].length(); x++) {
                             ItemStack ingredient = shapedRecipe.getIngredientMap().get(shape[i].toCharArray()[x]);
-                            if (ingredient != null) items.set(i * shape.length + x, new ItemType(ingredient));
+                            if (ingredient != null) items.set(i * length + x, new ItemType(ingredient));
                         }
                     }
                 } else if (recipe instanceof ShapelessRecipe shapelessRecipe) {


### PR DESCRIPTION
Fixes the issue described in #298.

Seems like the problem was that shaped recipes that are 3 slots wide but less than 3 slots tall didn't get a big enough ArrayList to store their items.

Some example items are `minecraft:oak_boat` and `minecraft:oak_slab`.

```
[18:47:16 INFO]: executing 'send ingredients of recipe "minecraft:oak_boat"'
[18:47:16 INFO]: oak wood planks
[18:47:16 INFO]: air
[18:47:16 INFO]: oak wood planks
[18:47:16 INFO]: oak wood planks
[18:47:16 INFO]: oak wood planks
[18:47:16 INFO]: oak wood planks
[18:47:16 INFO]: air
[18:47:16 INFO]: air
[18:47:16 INFO]: air
[18:47:18 INFO]: executing 'send ingredients of recipe "minecraft:oak_slab"'
[18:47:18 INFO]: oak wood planks
[18:47:18 INFO]: oak wood planks
[18:47:18 INFO]: oak wood planks
[18:47:18 INFO]: air
[18:47:18 INFO]: air
[18:47:18 INFO]: air
[18:47:18 INFO]: air
[18:47:18 INFO]: air
[18:47:18 INFO]: air
```
