### PR TITLE
ExprMergeComponents | Add delimiter

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/text/BeeComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/text/BeeComponent.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("PatternValidation")
@@ -130,10 +131,22 @@ public class BeeComponent {
     }
 
     public static BeeComponent fromComponents(@Nullable BeeComponent... components) {
+        return fromComponents(components, null);
+    }
+
+    public static BeeComponent fromComponents(@Nullable BeeComponent[] components, @Nullable String delimiter) {
         Component component = Component.empty();
-        for (BeeComponent beeComponent : components) {
-            if (beeComponent == null) continue;
-            component = component.append(beeComponent.component);
+        if (components != null && components.length > 0) {
+            Component delimiterComp = delimiter != null ? Component.text(delimiter) : null;
+            component = component.append(components[0].component);
+            int end = components.length;
+            for (int i = 1; i < end; ++i) {
+                if (components[i] == null) continue;
+                if (delimiterComp != null) {
+                    component = component.append(delimiterComp);
+                }
+                component = component.append(components[i].component);
+            }
         }
         return new BeeComponent(component);
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffSendComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffSendComponent.java
@@ -34,7 +34,7 @@ public class EffSendComponent extends Effect {
 
     static {
         Skript.registerEffect(EffSendComponent.class,
-                "send [(text|1¦action[[ ]bar])] component[s] %objects% [to %commandsenders%] [from %-player%]",
+                "send [(text|1¦action[[ ]bar])] component[s] %objects% [to %-commandsenders%] [from %-player%]",
                 "broadcast [text] component[s] %objects% [from %-player%]");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffSendComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffSendComponent.java
@@ -34,7 +34,7 @@ public class EffSendComponent extends Effect {
 
     static {
         Skript.registerEffect(EffSendComponent.class,
-                "send [(text|1¦action[[ ]bar])] component[s] %objects% [to %-commandsenders%] [from %-player%]",
+                "send [(text|1¦action[[ ]bar])] component[s] %objects% [to %commandsenders%] [from %-player%]",
                 "broadcast [text] component[s] %objects% [from %-player%]");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprMergeComponents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprMergeComponents.java
@@ -44,8 +44,9 @@ public class ExprMergeComponents extends SimpleExpression<BeeComponent> {
         if (this.components == null)
             return null;
         BeeComponent[] components = this.components.getArray(event);
-        String delimiter = this.delimiter.getSingle(event);
-        return new BeeComponent[]{BeeComponent.fromComponents(components, delimiter)};
+        if (this.delimiter != null)
+            return new BeeComponent[]{BeeComponent.fromComponents(components, this.delimiter.getSingle(event))};
+        return new BeeComponent[]{BeeComponent.fromComponents(components)};
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprMergeComponents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprMergeComponents.java
@@ -17,29 +17,35 @@ import org.jetbrains.annotations.NotNull;
 
 @Name("Text Component - Merge Components")
 @Description("Merge multiple components into one.")
-@Examples("set {_t} to merge components {_t::*}")
-@Since("2.4.0")
+@Examples({"set {_t} to merge components {_t::*}",
+        "set {_t} to merge components {_t::*} joined with newline"})
+@Since("2.4.0, INSERT VERSION (delimiter)")
 public class ExprMergeComponents extends SimpleExpression<BeeComponent> {
 
     static {
         Skript.registerExpression(ExprMergeComponents.class, BeeComponent.class, ExpressionType.SIMPLE,
-                "merge components %textcomponents%");
+                "merge components %textcomponents% [[join[ed]] with %-string%]");
     }
 
     private Expression<BeeComponent> components;
+    private Expression<String> delimiter;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         this.components = (Expression<BeeComponent>) exprs[0];
+        this.delimiter = (Expression<String>) exprs[1];
         return true;
     }
 
     @SuppressWarnings("NullableProblems")
     @Override
     protected @Nullable BeeComponent[] get(Event event) {
+        if (this.components == null)
+            return null;
         BeeComponent[] components = this.components.getArray(event);
-        return new BeeComponent[]{BeeComponent.fromComponents(components)};
+        String delimiter = this.delimiter.getSingle(event);
+        return new BeeComponent[]{BeeComponent.fromComponents(components, delimiter)};
     }
 
     @Override


### PR DESCRIPTION
Congrates, probably the smallest pr I have planned <3 

This pr aims to add an optional delimiter to the merge components expression while also adding a '-' to the send component effect for command sender

Send component didn't return any known errors but one of my failed builds sent an error at that point which made me aware of this issue. 