### PR TITLE
ExprTagOfNBT - add option to add/remove to/from tags

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
@@ -15,34 +15,54 @@ import java.util.Map;
 public enum NBTCustomType {
 
     NBTTagEnd("tag end", NBTType.NBTTagEnd),
-    NBTTagByte("byte", NBTType.NBTTagByte),
-    NBTTagShort("short", NBTType.NBTTagShort),
-    NBTTagInt("int", NBTType.NBTTagInt),
-    NBTTagLong("long", NBTType.NBTTagLong),
-    NBTTagFloat("float", NBTType.NBTTagFloat),
-    NBTTagDouble("double", NBTType.NBTTagDouble),
-    NBTTagByteArray("byte array", NBTType.NBTTagByteArray),
-    NBTTagUUID("uuid", NBTType.NBTTagIntArray),
-    NBTTagIntArray("int array", NBTType.NBTTagIntArray),
-    NBTTagString("string", NBTType.NBTTagString),
-    NBTTagCompound("compound", NBTType.NBTTagCompound),
-    NBTTagDoubleList("double list", NBTType.NBTTagList),
-    NBTTagFloatList("float list", NBTType.NBTTagList),
-    NBTTagLongList("long list", NBTType.NBTTagList),
-    NBTTagIntList("int list", NBTType.NBTTagList),
-    NBTTagCompoundList("compound list", NBTType.NBTTagList),
-    NBTTagStringList("string list", NBTType.NBTTagList);
+    NBTTagByte("byte", NBTType.NBTTagByte, Number.class),
+    NBTTagShort("short", NBTType.NBTTagShort, Number.class),
+    NBTTagInt("int", NBTType.NBTTagInt, Number.class),
+    NBTTagLong("long", NBTType.NBTTagLong, Number.class),
+    NBTTagFloat("float", NBTType.NBTTagFloat, Number.class),
+    NBTTagDouble("double", NBTType.NBTTagDouble, Number.class),
+    NBTTagString("string", NBTType.NBTTagString, String.class),
+    NBTTagUUID("uuid", NBTType.NBTTagIntArray, String.class),
+    NBTTagCompound("compound", NBTType.NBTTagCompound, NBTCompound.class),
+    NBTTagByteArray("byte array", NBTType.NBTTagByteArray, Number[].class, true),
+    NBTTagIntArray("int array", NBTType.NBTTagIntArray, Number[].class, true),
+    NBTTagDoubleList("double list", NBTType.NBTTagList, Number[].class, true),
+    NBTTagFloatList("float list", NBTType.NBTTagList, Number[].class, true),
+    NBTTagLongList("long list", NBTType.NBTTagList, Number[].class, true),
+    NBTTagIntList("int list", NBTType.NBTTagList, Number[].class, true),
+    NBTTagCompoundList("compound list", NBTType.NBTTagList, NBTCompound[].class, true),
+    NBTTagStringList("string list", NBTType.NBTTagList, String[].class,true);
 
     final String name;
     final NBTType nbtType;
+    final Class<?> typeClass;
+    final boolean isList;
 
     NBTCustomType(String name, NBTType nbtType) {
+        this(name, nbtType, Void.class);
+    }
+
+    NBTCustomType(String name, NBTType nbtType, Class<?> typeClass) {
+        this(name, nbtType, typeClass, false);
+    }
+
+    NBTCustomType(String name, NBTType nbtType, Class<?> typeClass, boolean isList) {
         this.name = name + " tag";
         this.nbtType = nbtType;
+        this.typeClass = typeClass;
+        this.isList = isList;
     }
 
     public String getName() {
-        return name;
+        return this.name;
+    }
+
+    public Class<?> getTypeClass() {
+        return this.typeClass;
+    }
+
+    public boolean isList() {
+        return this.isList;
     }
 
     private static final Map<String, NBTCustomType> BY_NAME = new HashMap<>();

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/effects/EffSpawnEntityNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/effects/EffSpawnEntityNBT.java
@@ -25,7 +25,8 @@ import javax.annotation.Nullable;
 @Description("Spawn an entity at a location with NBT.")
 @Examples({"set {_n} to nbt compound from \"{NoAI:1b}\"",
         "spawn sheep at player with nbt {_n}",
-        "spawn 1 of zombie at player with nbt nbt compound from \"{NoGravity:1b}\""})
+        "spawn 1 of zombie at player with nbt nbt compound from \"{NoGravity:1b}\"",
+        "spawn an armor stand at player with nbt from \"{Small:1b,NoBasePlate:1b,Marker:1b}\""})
 @Since("1.0.0")
 public class EffSpawnEntityNBT extends Effect {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprItemWithNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprItemWithNBT.java
@@ -22,7 +22,9 @@ import javax.annotation.Nullable;
 @Description("Get an item with nbt.")
 @Examples({"give player diamond sword with nbt compound from \"{Unbreakable:1}\"",
         "set {_n} to nbt compound from \"{Points:10}\"",
-        "set {_i} to netherite axe with nbt {_n}"})
+        "set {_i} to netherite axe with nbt {_n}",
+        "give player diamond sword with nbt from \"{points:1}\"",
+        "give player diamond pickaxe with nbt from \"{Damage:100}\""})
 @Since("1.0.0")
 public class ExprItemWithNBT extends PropertyExpression<ItemType, ItemType> {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
@@ -43,7 +43,13 @@ import java.util.ArrayList;
         "set int tag \"custom;score\" of nbt compound of player to 10",
         "set {_i} to int tag \"Score\" of nbt compound of player",
         "set {_t::*} to compound list tag \"abilities\" of nbt compound of player",
-        "delete tag \"Enchantments\" of nbt item compound of player's tool"})
+        "delete tag \"Enchantments\" of nbt item compound of player's tool",
+        "add 5 to int tag \"points\" of {_n}",
+        "remove 5 from int tag \"points\" of {_n}",
+        "add \"bob\" and \"joe\" to string list tag \"names\" of {_n}",
+        "remove \"bob\" from string list tag \"names\" of {_n}",
+        "add 1,2,3 to byte array tag \"bytes\" of {_n}",
+        "remove 1 and 2 from byte array tag \"bytes\" of {_n}"})
 @Since("1.0.0")
 public class ExprTagOfNBT extends SimpleExpression<Object> {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
@@ -8,6 +8,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
@@ -27,7 +28,10 @@ import java.util.ArrayList;
         "\nNOTE: `uuid tag` will set an int array tag (This is how MC stores uuids). On return it'll convert back to a uuid.",
         "\nNOTE: Entities/blocks can not natively hold custom NBT tags. SkBee allows you to put custom nbt",
         "data in the \"custom\" tag of a block/entity's NBT compound. Due to Minecraft not supporting this, I had to use some hacky methods to make this happen.",
-        "That said, this system is a tad convoluted, see the SkBee WIKI for more details."})
+        "That said, this system is a tad convoluted, see the SkBee WIKI for more details.",
+        "\nADD: You can add numbers to number type tags, you can also add numbers/strings/compounds to lists.",
+        "\nREMOVE: You can remove numbers from number type tags, you can also remove numbers/strings from lists.",
+        "(You can NOT remove compounds from lists)"})
 @Examples({"set {_tag} to tag \"Invulnerable\" of nbt compound of target entity",
         "send \"Tag: %tag \"CustomName\" of nbt compound of target entity%\" to player",
         "set {_tag::*} to compound list tag \"Enchantments\" of nbt compound of player's tool",
@@ -54,14 +58,22 @@ public class ExprTagOfNBT extends SimpleExpression<Object> {
     private Expression<String> tag;
     private Expression<NBTCompound> nbt;
     @Nullable
-    private Expression<NBTCustomType> nbtType;
+    private Literal<NBTCustomType> nbtType;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parser) {
         this.tag = (Expression<String>) exprs[matchedPattern == 2 ? 1 : 0];
         this.nbt = (Expression<NBTCompound>) exprs[matchedPattern < 2 ? 1 : 2];
-        this.nbtType = matchedPattern > 1 ? (Expression<NBTCustomType>) exprs[matchedPattern == 2 ? 0 : 1] : null;
+        if (matchedPattern > 1) {
+            Expression<?> expr = exprs[matchedPattern == 2 ? 0 : 1];
+            if (expr instanceof Literal<?>) {
+                this.nbtType = (Literal<NBTCustomType>) expr;
+            } else {
+                Skript.error("NBT TYPE must be a literal, variables cannot be used here!");
+                return false;
+            }
+        }
         return true;
     }
 
@@ -75,7 +87,7 @@ public class ExprTagOfNBT extends SimpleExpression<Object> {
         assert tag != null;
 
         Object object = type != null ? NBTApi.getTag(tag, nbt, type) : NBTApi.getTag(tag, nbt);
-        if (object instanceof ArrayList arrayList) {
+        if (object instanceof ArrayList<?> arrayList) {
             return arrayList.toArray();
         }
         return new Object[]{object};
@@ -84,39 +96,73 @@ public class ExprTagOfNBT extends SimpleExpression<Object> {
     @SuppressWarnings("NullableProblems")
     @Override
     public Class<?>[] acceptChange(@NotNull ChangeMode mode) {
-        if (mode == ChangeMode.SET || mode == ChangeMode.DELETE) {
+        if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) {
+            if (this.nbtType == null) {
+                Skript.error("add/remove is only supported when using '%nbttype% tag'");
+                return null;
+            } else {
+                NBTCustomType nbtType = this.nbtType.getSingle();
+                if (nbtType == NBTCustomType.NBTTagCompoundList && mode == ChangeMode.REMOVE) {
+                    Skript.error("NBT compounds cannot be removed from an NBT compound list!");
+                    return null;
+                }
+                if (nbtType.isList() || nbtType.getTypeClass() == Number.class) {
+                    return CollectionUtils.array(nbtType.getTypeClass());
+                }
+            }
+        } else if (mode == ChangeMode.SET) {
+            if (this.nbtType != null) {
+                NBTCustomType nbtType = this.nbtType.getSingle();
+                if (nbtType != NBTCustomType.NBTTagUUID) {
+                    return CollectionUtils.array(nbtType.getTypeClass());
+                }
+            }
             return CollectionUtils.array(Object[].class);
+        } else if (mode == ChangeMode.DELETE) {
+            return CollectionUtils.array();
         }
         return null;
     }
 
     @Override
-    public void change(@NotNull Event e, @Nullable Object[] delta, @NotNull ChangeMode mode) {
-        NBTCompound compound = this.nbt.getSingle(e);
-        String tag = this.tag.getSingle(e);
+    public void change(@NotNull Event event, @Nullable Object[] delta, @NotNull ChangeMode mode) {
+        NBTCompound compound = this.nbt.getSingle(event);
+        String tag = this.tag.getSingle(event);
         if (compound == null || tag == null) return;
 
-        if (mode == ChangeMode.SET) {
-            if (delta == null) return;
+        if (mode == ChangeMode.DELETE) {
+            NBTApi.deleteTag(tag, compound);
+            return;
+        }
+        if (delta == null) return;
 
+        if (mode == ChangeMode.SET) {
             if (this.nbtType != null) {
-                NBTCustomType type = this.nbtType.getSingle(e);
+                NBTCustomType type = this.nbtType.getSingle();
                 NBTApi.setTag(tag, compound, delta, type);
             } else {
                 NBTApi.setTag(tag, compound, delta);
             }
-        } else if (mode == ChangeMode.DELETE) {
-            NBTApi.deleteTag(tag, compound);
+        } else if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) {
+            if (this.nbtType == null) return;
+            NBTCustomType type = this.nbtType.getSingle();
+            if (mode == ChangeMode.ADD) {
+                NBTApi.addToTag(tag, compound, delta, type);
+            } else {
+                NBTApi.removeFromTag(tag, compound, delta, type);
+            }
         }
     }
 
     @Override
     public boolean isSingle() {
+        if (this.nbtType != null) return !this.nbtType.getSingle().isList();
         return true;
     }
 
     @Override
     public @NotNull Class<?> getReturnType() {
+        if (this.nbtType != null) return this.nbtType.getSingle().getTypeClass();
         return Object.class;
     }
 


### PR DESCRIPTION
This PR aims to add the ability to add/remove to/from nbt tags.
Making `%nbttype%` now a literal, error messages will be better and easier to understand.

This should not create an breaking changes.