### PR TITLE
⭐ Config and Namespace changes

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/listener/NBTListener.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/listener/NBTListener.java
@@ -27,11 +27,11 @@ public class NBTListener implements Listener {
     private final boolean BLOCK_EXPLODE;
 
     public NBTListener(Config config) {
-        this.BREAK_BLOCK = config.ELEMENTS_NBT_EVENTS_BREAK_BLOCK;
-        this.PISTON_EXTEND = config.ELEMENTS_NBT_EVENTS_PISTON_EXTEND;
-        this.ENTITY_CHANGE = config.ELEMENTS_NBT_EVENTS_ENTITY_CHANGE_BLOCK;
-        this.ENTITY_EXPLODE = config.ELEMENTS_NBT_EVENTS_ENTITY_EXPLODE;
-        this.BLOCK_EXPLODE = config.ELEMENTS_NBT_EVENTS_BLOCK_EXPLODE;
+        this.BREAK_BLOCK = config.NBT_EVENTS_BREAK_BLOCK;
+        this.PISTON_EXTEND = config.NBT_EVENTS_PISTON_EXTEND;
+        this.ENTITY_CHANGE = config.NBT_EVENTS_ENTITY_CHANGE_BLOCK;
+        this.ENTITY_EXPLODE = config.NBT_EVENTS_ENTITY_EXPLODE;
+        this.BLOCK_EXPLODE = config.NBT_EVENTS_BLOCK_EXPLODE;
     }
 
     // Note regarding event priority:

--- a/src/main/java/com/shanebeestudios/skbee/api/recipe/RecipeUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/recipe/RecipeUtil.java
@@ -1,7 +1,6 @@
 package com.shanebeestudios.skbee.api.recipe;
 
 import ch.njol.skript.util.Timespan;
-import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
@@ -19,22 +18,23 @@ import java.util.NoSuchElementException;
 
 public class RecipeUtil {
 
-    private static final String NAMESPACE = SkBee.getPlugin().getPluginConfig().RECIPE_NAMESPACE;
-
     /**
      * Get a NamespacedKey from string
      * <p>If no namespace is provided, it will default to namespace in SkBee config (default = "skbee")</p>
      *
+     * @deprecated Planning to remove all string based ids for recipes in the future, please use Util#getNamespacedkey
+     * more information on this in the future when it's put into action
      * @param key Key for new NamespacedKey, ex: "plugin:key" or "minecraft:something"
      * @return New NamespacedKey
      */
+    @Deprecated()
     public static NamespacedKey getKey(String key) {
         try {
             NamespacedKey namespacedKey;
             if (key.contains(":")) {
                 namespacedKey = NamespacedKey.fromString(key.toLowerCase(Locale.ROOT));
             } else {
-                namespacedKey = new NamespacedKey(NAMESPACE, key.toLowerCase());
+                namespacedKey = Util.getNamespacedKey(key, false);
             }
             if (namespacedKey == null) {
                 error("Invalid namespaced key. Must be [a-z0-9/._-:]: " + key);

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -81,7 +81,7 @@ public class Util {
      * Gets a Minecraft NamespacedKey from string
      * <p>If no colon (':') is not include it will prepend it to the start</p>
      *
-     * @param key Key for new Minecraft NamespacedKey
+     * @param key   Key for new Minecraft NamespacedKey
      * @param error Whether to send a skript/console error if one occurs
      * @return new Minecraft NamespacedKey
      */
@@ -95,7 +95,7 @@ public class Util {
      * Get a NamespacedKey from string
      * <p>If no namespace is provided, it will default to namespace in SkBee config (default = "skbee")</p>
      *
-     * @param key Key for new NamespacedKey, ex: "plugin:key" or "minecraft:something"
+     * @param key   Key for new NamespacedKey, ex: "plugin:key" or "minecraft:something"
      * @param error Whether to send a skript/console error if one occurs
      * @return new NamespacedKey
      */
@@ -109,11 +109,9 @@ public class Util {
         NamespacedKey namespacedKey = null;
         if (key.contains(":")) {
             namespacedKey = NamespacedKey.fromString(key);
-        }
-        else if (SETTINGS_NAMESPACE != null) {
+        } else if (SETTINGS_NAMESPACE != null) {
             namespacedKey = new NamespacedKey(SETTINGS_NAMESPACE, key);
-        }
-        else { // Just a safety check, settings_namespace can't be null but in case this is defaulted to.
+        } else { // Just a safety check, settings_namespace can't be null but in case this is defaulted to.
             try {
                 namespacedKey = new NamespacedKey(SkBee.getPlugin(), key);
             } catch (Exception exception) {

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -8,10 +8,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -25,6 +25,7 @@ public class Util {
     private static final String PREFIX_ERROR = "&7[&bSk&3Bee &cERROR&7] ";
     private static final Pattern HEX_PATTERN = Pattern.compile("<#([A-Fa-f\\d]){6}>");
     private static final boolean SKRIPT_IS_THERE = Bukkit.getPluginManager().getPlugin("Skript") != null;
+    private static final String SETTINGS_NAMESPACE = SkBee.getPlugin().getPluginConfig().SETTINGS_NAMESPACE;
 
     @SuppressWarnings("deprecation") // Paper deprecation
     public static String getColString(String string) {
@@ -76,37 +77,54 @@ public class Util {
         return DEBUGS;
     }
 
+    /**
+     * Gets a Minecraft NamespacedKey from string
+     * <p>If no colon (':') is not include it will prepend it to the start</p>
+     *
+     * @param key Key for new Minecraft NamespacedKey
+     * @param error Whether to send a skript/console error if one occurs
+     * @return new Minecraft NamespacedKey
+     */
+    @Nullable
     public static NamespacedKey getMCNamespacedKey(@NotNull String key, boolean error) {
-        String string = key;
-        if (!string.contains(":")) {
-            string = "minecraft:" + string;
-        }
-        return getNamespacedKey(string, error);
+        if (!key.contains(":")) key = "minecraft:" + key;
+        return getNamespacedKey(key, error);
     }
+
+    /**
+     * Get a NamespacedKey from string
+     * <p>If no namespace is provided, it will default to namespace in SkBee config (default = "skbee")</p>
+     *
+     * @param key Key for new NamespacedKey, ex: "plugin:key" or "minecraft:something"
+     * @param error Whether to send a skript/console error if one occurs
+     * @return new NamespacedKey
+     */
+    @Nullable
     public static NamespacedKey getNamespacedKey(@NotNull String key, boolean error) {
+        key = key.toLowerCase();
         if (key.contains(" ")) {
             key = key.replace(" ", "_");
         }
-        key = key.toLowerCase(Locale.ROOT);
+
+        NamespacedKey namespacedKey = null;
         if (key.contains(":")) {
-            NamespacedKey namespacedKey = NamespacedKey.fromString(key);
-            if (namespacedKey == null) {
-                if (error) {
-                    skriptError("Invalid key. Must be [a-z0-9/._-:]: %s", key);
-                }
-                return null;
-            }
-            return namespacedKey;
-        } else {
+            namespacedKey = NamespacedKey.fromString(key);
+        }
+        else if (SETTINGS_NAMESPACE != null) {
+            namespacedKey = new NamespacedKey(SETTINGS_NAMESPACE, key);
+        }
+        else { // Just a safety check, settings_namespace can't be null but in case this is defaulted to.
             try {
-                return new NamespacedKey(SkBee.getPlugin(), key);
-            } catch (IllegalArgumentException ex) {
+                namespacedKey = new NamespacedKey(SkBee.getPlugin(), key);
+            } catch (Exception exception) {
                 if (error) {
-                    skriptError(ex.getMessage());
+                    skriptError(exception.getMessage());
                 }
-                return null;
             }
         }
+        if (namespacedKey == null && error)
+            skriptError("An invalid key was provided, that didn't follow [a-z0-9/._-:]. key: %s", key);
+        return namespacedKey;
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -17,12 +17,13 @@ public class Config {
     // Config stuff
     public boolean SETTINGS_DEBUG;
     public boolean SETTINGS_UPDATE_CHECKER;
+    public String SETTINGS_NAMESPACE;
     public boolean ELEMENTS_NBT;
-    public boolean ELEMENTS_NBT_EVENTS_BREAK_BLOCK;
-    public boolean ELEMENTS_NBT_EVENTS_PISTON_EXTEND;
-    public boolean ELEMENTS_NBT_EVENTS_ENTITY_CHANGE_BLOCK;
-    public boolean ELEMENTS_NBT_EVENTS_ENTITY_EXPLODE;
-    public boolean ELEMENTS_NBT_EVENTS_BLOCK_EXPLODE;
+    public boolean NBT_EVENTS_BREAK_BLOCK;
+    public boolean NBT_EVENTS_PISTON_EXTEND;
+    public boolean NBT_EVENTS_ENTITY_CHANGE_BLOCK;
+    public boolean NBT_EVENTS_ENTITY_EXPLODE;
+    public boolean NBT_EVENTS_BLOCK_EXPLODE;
     public boolean ELEMENTS_BOARD;
     public boolean ELEMENTS_OBJECTIVE;
     public boolean ELEMENTS_TEAM;
@@ -45,7 +46,6 @@ public class Config {
     public boolean ELEMENTS_FISHING;
     public boolean ELEMENTS_DISPLAY;
     public boolean AUTO_LOAD_WORLDS;
-    public String RECIPE_NAMESPACE;
 
     public Config(SkBee plugin) {
         this.plugin = plugin;
@@ -101,18 +101,22 @@ public class Config {
     }
 
     private boolean getNBTEvent(String nbtEvent) {
-        return this.config.getBoolean("elements.nbt-events." + nbtEvent);
+        return this.config.getBoolean("nbt-events." + nbtEvent);
     }
 
     private void loadConfigs() {
         this.SETTINGS_DEBUG = getSetting("debug");
         this.SETTINGS_UPDATE_CHECKER = getSetting("update-checker");
+        String namespace = this.config.getString("settings.namespace");
+        this.SETTINGS_NAMESPACE = namespace != null ? namespace.toLowerCase() : "skbee";
+
         this.ELEMENTS_NBT = getElement("nbt");
-        this.ELEMENTS_NBT_EVENTS_BREAK_BLOCK = getNBTEvent("block-break");
-        this.ELEMENTS_NBT_EVENTS_PISTON_EXTEND = getNBTEvent("piston-extend");
-        this.ELEMENTS_NBT_EVENTS_ENTITY_CHANGE_BLOCK = getNBTEvent("entity-change-block");
-        this.ELEMENTS_NBT_EVENTS_ENTITY_EXPLODE = getNBTEvent("entity-explode");
-        this.ELEMENTS_NBT_EVENTS_BLOCK_EXPLODE = getNBTEvent("block-explode");
+        this.NBT_EVENTS_BREAK_BLOCK = getNBTEvent("block-break");
+        this.NBT_EVENTS_PISTON_EXTEND = getNBTEvent("piston-extend");
+        this.NBT_EVENTS_ENTITY_CHANGE_BLOCK = getNBTEvent("entity-change-block");
+        this.NBT_EVENTS_ENTITY_EXPLODE = getNBTEvent("entity-explode");
+        this.NBT_EVENTS_BLOCK_EXPLODE = getNBTEvent("block-explode");
+
         this.ELEMENTS_BOARD = getElement("scoreboard");
         this.ELEMENTS_OBJECTIVE = getElement("scoreboard-objective");
         this.ELEMENTS_TEAM = getElement("team");
@@ -135,11 +139,6 @@ public class Config {
         this.ELEMENTS_FISHING = getElement("fishing");
         this.ELEMENTS_DISPLAY = getElement("display-entity");
         this.AUTO_LOAD_WORLDS = getElement("auto-load-custom-worlds");
-        String namespace = this.config.getString("recipe.namespace");
-        if (namespace == null) {
-            namespace = "skbee";
-        }
-        this.RECIPE_NAMESPACE = namespace.toLowerCase();
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.StringUtils;
+import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.GameEvent;
 import org.bukkit.NamespacedKey;
@@ -16,6 +17,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class Types {
+
+    private static final boolean CONFIG_DEBUG_ENABLED = SkBee.getPlugin().getPluginConfig().SETTINGS_DEBUG;
 
     static {
         Classes.registerClass(new ClassInfo<>(GameEvent.class, "gameevent")
@@ -33,7 +36,7 @@ public class Types {
                     @Override
                     public GameEvent parse(String string, ParseContext context) {
                         try {
-                            NamespacedKey namespacedKey = Util.getMCNamespacedKey(string, false);
+                            NamespacedKey namespacedKey = Util.getMCNamespacedKey(string, CONFIG_DEBUG_ENABLED);
                             if (namespacedKey == null) return null;
                             return GameEvent.getByKey(namespacedKey);
                         } catch (IllegalArgumentException ignore) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
@@ -56,11 +56,11 @@ public class ExprNamespacedKey extends SimpleExpression<NamespacedKey> {
         List<NamespacedKey> namespacedKeys = new ArrayList<>();
         if (useMinecraftNamespace) {
             for (String string : this.strings.getArray(event)) {
-                namespacedKeys.add(Util.getNamespacedKey(string, true));
+                namespacedKeys.add(Util.getMCNamespacedKey(string, true));
             }
         } else {
             for (String string : this.strings.getArray(event)) {
-                namespacedKeys.add(Util.getMCNamespacedKey(string, true));
+                namespacedKeys.add(Util.getNamespacedKey(string, true));
             }
         }
         return namespacedKeys.toArray(new NamespacedKey[0]);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
@@ -53,7 +53,7 @@ public class ExprNamespacedKey extends SimpleExpression<NamespacedKey> {
     protected @Nullable NamespacedKey[] get(Event event) {
         List<NamespacedKey> namespacedKeys = new ArrayList<>();
         for (String string : this.strings.getArray(event)) {
-            namespacedKeys.add(Util.getMCNamespacedKey(string, true));
+            namespacedKeys.add(Util.getNamespacedKey(string, true));
         }
         return namespacedKeys.toArray(new NamespacedKey[0]);
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
@@ -25,7 +25,7 @@ import java.util.List;
         "NamespacedKeys are a string based key which consists of two components - a namespace and a key.",
         "\nNamespaces may only contain lowercase alphanumeric characters, periods, underscores, and hyphens.",
         "Minecraft generally uses the \"minecraft\" namespace for built in objects.",
-        "\nIf a namespace is not provided, the Minecraft namespace will be used by default -> \"minecraft:your_key\"",
+        "\nIf a namespace is not provided, the SkBee config namespace will be used by default -> \"skbee:your_key\"",
         "\nKeys may only contain lowercase alphanumeric characters, periods, underscores, hyphens, and forward slashes.",
         "\nKeep an eye on your console when using namespaced keys as errors will spit out when they're invalid."})
 @Examples({"set {_n} to namespaced key from \"minecraft:log\"",
@@ -36,15 +36,17 @@ public class ExprNamespacedKey extends SimpleExpression<NamespacedKey> {
 
     static {
         Skript.registerExpression(ExprNamespacedKey.class, NamespacedKey.class, ExpressionType.COMBINED,
-                "namespaced[ ]key from %strings%");
+                "[mc:(minecraft|mc)] namespaced[ ]key from %strings%");
     }
 
     private Expression<String> strings;
+    private boolean useMinecraftNamespace;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         this.strings = (Expression<String>) exprs[0];
+        this.useMinecraftNamespace = parseResult.hasTag("mc");
         return true;
     }
 
@@ -52,8 +54,14 @@ public class ExprNamespacedKey extends SimpleExpression<NamespacedKey> {
     @Override
     protected @Nullable NamespacedKey[] get(Event event) {
         List<NamespacedKey> namespacedKeys = new ArrayList<>();
-        for (String string : this.strings.getArray(event)) {
-            namespacedKeys.add(Util.getNamespacedKey(string, true));
+        if (useMinecraftNamespace) {
+            for (String string : this.strings.getArray(event)) {
+                namespacedKeys.add(Util.getNamespacedKey(string, true));
+            }
+        } else {
+            for (String string : this.strings.getArray(event)) {
+                namespacedKeys.add(Util.getMCNamespacedKey(string, true));
+            }
         }
         return namespacedKeys.toArray(new NamespacedKey[0]);
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
@@ -36,7 +36,7 @@ public class ExprNamespacedKey extends SimpleExpression<NamespacedKey> {
 
     static {
         Skript.registerExpression(ExprNamespacedKey.class, NamespacedKey.class, ExpressionType.COMBINED,
-                "[mc:(minecraft|mc)] namespaced[ ]key from %strings%");
+                "[mc:(minecraft|mc)] (namespaced|resource)[ ](key|id[entifier]|location) from %strings%");
     }
 
     private Expression<String> strings;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNamespacedKey.java
@@ -77,8 +77,8 @@ public class ExprNamespacedKey extends SimpleExpression<NamespacedKey> {
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
-        return "namespaced key from '" + this.strings.toString(e,d) + "'";
+    public @NotNull String toString(@Nullable Event event, boolean debug) {
+        return "namespaced key from '" + this.strings.toString(event, debug) + "'";
     }
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,24 +8,31 @@ settings:
   # Disable this if you do not want to check for updates, or it takes too long/has issues checking
   update-checker: true
 
+  # This is the namespace skbee uses for recipe ids and namespace expression.
+  # You're free to use whatever you want as long as it follows the rules listed below
+  # all lowercase, alphabetical, numbers, a single colon, underscores, hyphens and periods. NO SPACES!!!
+  # Example, when using the minecraft recipe command `/minecraft:recipe give playerName skbee:my_custom_recipe`
+  # Example, when using the namespaced key expression `namespaced key from "some_cool_namespace"` (`skbee:some_cool_namespace`)
+  namespace: "skbee"
+
+# Enable different event listeners for NBT
+nbt-events:
+  # Whether breaking a block should remove NBT
+  block-break: true
+  # Whether pistons pushing blocks should remove NBT
+  piston-extend: true
+  # Whether an entity changing a block should remove NBT
+  # Examples would be rabbit breaking carrots or enderman picking up blocks
+  entity-change-block: true
+  # Whether a block exploding should remove NBT
+  block-explode: true
+  # Whether an entity exploding should remove NBT from broken blocks
+  entity-explode: true
+
 # Disable elements you do not plan to use.
 elements:
   # Enable NBT elements
   nbt: true
-
-  # Enable different event listeners for NBT
-  nbt-events:
-    # Whether breaking a block should remove NBT
-    block-break: true
-    # Whether pistons pushing blocks should remove NBT
-    piston-extend: true
-    # Whether an entity changing a block should remove NBT
-    # Examples would be rabbit breaking carrots or enderman picking up blocks
-    entity-change-block: true
-    # Whether a block exploding should remove NBT
-    block-explode: true
-    # Whether an entity exploding should remove NBT from broken blocks
-    entity-explode: true
 
   # Enable Scoreboard elements
   scoreboard: true
@@ -96,9 +103,3 @@ elements:
   # Enable display entity elements
   # This is specifically for Minecraft 1.19.4+
   display-entity: true
-
-recipe:
-  # This is the namespace all recipes will be saved under
-  # You can choose whatever you wish
-  # Example, when using the minecraft recipe command `/minecraft:recipe give playerName skbee:my_custom_recipe`
-  namespace: "skbee"


### PR DESCRIPTION
## Changes Made
- `NBT EVENTS` has been moved out of `elements.nbt-events.`
- `NBT EVENTS` now has it's own config section and is no longer polluting `elements` 
- `RECIPE` has been removed and `recipe.namespace` was moved to `settings.namespace`
- `RecipeUtils#getKey` has been marked as deprecated, and will be removed in a future release
- `ExprNamespacedKey` has been changed from `Util#getMCNamespacedKey` to just `#getNamespacedKey`, it no longer defaults to `minecraft:`
- Added optional minecraft parse tag for using minecraft namespace in ExprNamespacedKey
- `Types.GameEvent` classinfo has been changed to error depending on config debug state


## Reason Behind Changes

<details>
  <summary><bold>CLICK THIS TO SHOW REASONS</bold></summary>

SNBT events didn't make sense to stay within `elements`, they're closely tied with NBT so as Recipe once was they were moved to it's own area for easier reading. 

Recipe as mentioned on discord I'm wanting to put more focus on namespacedkeys over strings, this is similar to how string nbt and compounds are in my opinion where we kept doing additional work in code over just taking the defined given expression. More about this in the section below

ExprNamespacedKey didn't make any sense in defaulting to a minecraft tag, as these should encourage users to define namespace as needed. Additionally we're now defaulting to the config default to keep everything inline

</details>

## [FUTURE PLAN] Remove string ids in recipes
<details>
  <summary><bold>CLICK THIS TO SHOW PARAGRAPH</bold></summary>

In recipes anymore the only things remaining that we really have to watch over are recipe ids, my goal is to deprecate and remove the whole usage of `with id "blah"` in the future, to make this type of system more streamlined. As I mentioned before by keeping `string` and adding `namespacedkey` we're forced to handle two separate methods as one and this gets out of hand as time goes and namespacedkey becomes more and more used. A basic syntax for recipe is currently
```applescript
# Newer Syntax
register new shaped recipe for %itemstack% using %recipechoices% with id %string/namespacedkey% and with group %string%
# Previous Syntax
register new shaped recipe for %itemtype% using %itemtypes/mateiralchoices% with id %string% with group %string%
```
before we had to managed 2 skript types for ingredients, converting result and updating recipe id to namespace.
Now using the newer the only part we update is the recipe id, only kept due to breaking change, I'm wanting to remove this usleess part and keep everything simplified.

I have no intention of making this change until #365 is merged and everyone is accustomed to changes, however to encourage this change I'll be changing brewing syntax to follow this rule and see player feedback whether it's a poor decision or one I can safely make without worry

</details>

## Proposed Changelog Reference

## CHANGED
- Recipe namespace no longer exists and has been moved under settings and renamed to namespace, default is still skbee. 
- Changed how ExprNamespacedKey works, it will no longer default to the minecraft namespace but rather your skbee config namespace. *(Editable in config)* additionally you can now type `mc namespaced key of %strings%` for minecraft. 
- NBT Events have been moved out of the elements section of config and into their own respective section similar to how recipe was.

