### PR TITLE
ExprSuspiciousBlock - Fix a 1.20 issue

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSuspiciousBlock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSuspiciousBlock.java
@@ -11,7 +11,7 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.SuspiciousSand;
+import org.bukkit.block.BrushableBlock;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
 public class ExprSuspiciousBlock extends SimplePropertyExpression<Block, ItemType> {
 
     static {
-        if (Skript.classExists("org.bukkit.block.SuspiciousSand")) {
+        if (Skript.classExists("org.bukkit.block.BrushableBlock")) {
             register(ExprSuspiciousBlock.class, ItemType.class, "suspicious item", "blocks");
         }
     }
@@ -34,9 +34,9 @@ public class ExprSuspiciousBlock extends SimplePropertyExpression<Block, ItemTyp
     @Override
     public @Nullable ItemType convert(Block block) {
         BlockState state = block.getState();
-        if (state instanceof SuspiciousSand suspiciousSand) {
-            ItemStack item = suspiciousSand.getItem();
-            if (item != null) return new ItemType(item);
+        if (state instanceof BrushableBlock brushableBlock) {
+            ItemStack item = brushableBlock.getItem();
+            if (item != null && !item.getType().isAir()) return new ItemType(item);
         }
         return null;
     }
@@ -57,9 +57,9 @@ public class ExprSuspiciousBlock extends SimplePropertyExpression<Block, ItemTyp
 
         for (Block block : getExpr().getArray(event)) {
             BlockState state = block.getState();
-            if (state instanceof SuspiciousSand suspiciousSand) {
-                suspiciousSand.setItem(itemStack);
-                suspiciousSand.update();
+            if (state instanceof BrushableBlock brushableBlock) {
+                brushableBlock.setItem(itemStack);
+                brushableBlock.update();
             }
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSuspiciousBlock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSuspiciousBlock.java
@@ -2,7 +2,7 @@ package com.shanebeestudios.skbee.elements.other.expressions;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -12,55 +12,65 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.BrushableBlock;
+import org.bukkit.block.SuspiciousSand;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 
 @Name("Suspicious Block - Item")
-@Description({"Represents the item hiding in a Suspicious Block."})
+@Description({"Represents the item hiding in a Suspicious Block. Requires Minecraft 1.19.4+"})
 @Examples({"set suspicious item of target block to a diamond",
         "delete suspicious item of block at location(199,10,-199, \"very_goodNames\")"})
-@Since("2.8.1, INSERT VERSION (suspicious gravel")
+@Since("2.8.1, INSERT VERSION (suspicious gravel)")
 public class ExprSuspiciousBlock extends SimplePropertyExpression<Block, ItemType> {
 
+    private static final boolean HAS_SUSPICIOUS_SAND = Skript.classExists("org.bukkit.block.SuspiciousSand");
+    private static final boolean HAS_BRUSHABLE_BLOCK = Skript.classExists("org.bukkit.block.BrushableBlock");
+
     static {
-        if (Skript.classExists("org.bukkit.block.BrushableBlock")) {
+        if (HAS_BRUSHABLE_BLOCK || HAS_SUSPICIOUS_SAND) {
             register(ExprSuspiciousBlock.class, ItemType.class, "suspicious item", "blocks");
         }
     }
 
-    @SuppressWarnings("UnstableApiUsage")
+    @SuppressWarnings({"deprecation"})
     @Override
     public @Nullable ItemType convert(Block block) {
         BlockState state = block.getState();
-        if (state instanceof BrushableBlock brushableBlock) {
-            ItemStack item = brushableBlock.getItem();
-            if (item != null && !item.getType().isAir()) return new ItemType(item);
+        ItemStack itemStack = null;
+        if (HAS_BRUSHABLE_BLOCK && state instanceof BrushableBlock brushableBlock) {
+            itemStack = brushableBlock.getItem();
+        } else if (HAS_SUSPICIOUS_SAND && state instanceof SuspiciousSand suspiciousSand) {
+            itemStack = suspiciousSand.getItem();
         }
+        if (itemStack != null && !itemStack.getType().isAir()) return new ItemType(itemStack);
         return null;
     }
 
     @SuppressWarnings("NullableProblems")
     @Override
-    public @Nullable Class<?>[] acceptChange(Changer.ChangeMode mode) {
-        if (mode == Changer.ChangeMode.SET || mode == Changer.ChangeMode.DELETE)
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET || mode == ChangeMode.DELETE)
             return CollectionUtils.array(ItemType.class);
         return null;
     }
 
-    @SuppressWarnings({"UnstableApiUsage", "NullableProblems", "ConstantValue"})
+    @SuppressWarnings({"NullableProblems", "ConstantValue", "deprecation"})
     @Override
-    public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
         ItemStack itemStack = null;
         if (delta != null && delta[0] instanceof ItemType itemType) itemStack = itemType.getRandom();
 
         for (Block block : getExpr().getArray(event)) {
             BlockState state = block.getState();
-            if (state instanceof BrushableBlock brushableBlock) {
+            if (HAS_BRUSHABLE_BLOCK && state instanceof BrushableBlock brushableBlock) {
                 brushableBlock.setItem(itemStack);
                 brushableBlock.update();
+            } else if (HAS_SUSPICIOUS_SAND && state instanceof SuspiciousSand suspiciousSand) {
+                suspiciousSand.setItem(itemStack);
+                suspiciousSand.update();
             }
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSuspiciousBlock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSuspiciousBlock.java
@@ -14,14 +14,15 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.BrushableBlock;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
-import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 
+
 @Name("Suspicious Block - Item")
-@Description({"Represents the item hiding in a Suspicious Block.",
-        "As of Minecraft 1.19.4 the only block is Suspicious Sand."})
-@Examples("set suspicious item of target block to a diamond")
-@Since("2.8.1")
+@Description({"Represents the item hiding in a Suspicious Block."})
+@Examples({"set suspicious item of target block to a diamond",
+        "delete suspicious item of block at location(199,10,-199, \"very_goodNames\")"})
+@Since("2.8.1, INSERT VERSION (suspicious gravel")
 public class ExprSuspiciousBlock extends SimplePropertyExpression<Block, ItemType> {
 
     static {


### PR DESCRIPTION
This expression no longer worked when using 1.20 anymore it seemed, a user on discord pointed out to me that it was returning none even with items. After a quick look around turns out there was a new Brushable class for these blocks added which now includes gravel and sand. 

Changes made
- Made expression only work if the Brushable class exists
- Add isAir check to item and return null if it's air (I don't know if it original returned air but it does now)
- Updated interals to use Brushable class which adds support for suspicious gravel 

If you have any idea on how to update the documentation annotations that'll be great as now it's only 1.20 not 1.19.4