### PR TITLE
Add spawner support

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondSpawnerIsActivated.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondSpawnerIsActivated.java
@@ -1,0 +1,36 @@
+package com.shanebeestudios.skbee.elements.other.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+
+@Name("Spawner - Is Activated")
+@Description("Returns true if a player is currently within the required player range of the spawner.")
+@Examples({"at 7:00:",
+        "\tloop {spawners::*}:",
+        "\t\tloop-value is activated",
+        "\t\tbroadcast loop-value"})
+@Since("INSERT VERSION")
+public class CondSpawnerIsActivated extends PropertyCondition<Block> {
+
+    static {
+        register(CondSpawnerIsActivated.class, "activated", "blocks");
+    }
+
+    @Override
+    public boolean check(Block block) {
+        if (block.getState() instanceof CreatureSpawner spawner)
+            return spawner.isActivated();
+        return false;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "activated";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffSpawnerResetTimer.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffSpawnerResetTimer.java
@@ -1,0 +1,57 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Spawner - Reset Timer")
+@Description({"Resets the spawner timer for a spawner.",
+        "Requires a PaperMC server"})
+@Examples({"on spawner spawn:",
+        "\treset spawner timer"})
+@Since("INSERT VERSION")
+public class EffSpawnerResetTimer extends Effect {
+
+    static {
+        Skript.registerEffect(EffSpawnerResetTimer.class, "reset spawner timer [of %blocks%]");
+    }
+
+    private static final boolean SUPPORTS_RESET_TIMER = Skript.methodExists(CreatureSpawner.class, "resetTimer");
+    private Expression<Block> blocks;
+
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!SUPPORTS_RESET_TIMER) {
+            Skript.error("The reset timer effect requires a PaperMC server.");
+            return false;
+        }
+        this.blocks = (Expression<Block>) exprs[0];
+        return true;
+    }
+
+    @Override
+    protected void execute(Event event) {
+        for (Block block : blocks.getArray(event)) {
+            if (block.getState() instanceof CreatureSpawner spawner) {
+                spawner.resetTimer();
+                spawner.update();
+            }
+        }
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return "reset timer of " + blocks.toString(event, debug);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffSpawnerResetTimer.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffSpawnerResetTimer.java
@@ -15,8 +15,7 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Spawner - Reset Timer")
-@Description({"Resets the spawner timer for a spawner.",
-        "Requires a PaperMC server"})
+@Description("Resets the spawner timer for a spawner. Requires a PaperMC server.")
 @Examples({"on spawner spawn:",
         "\treset spawner timer"})
 @Since("INSERT VERSION")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtSpawnerSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtSpawnerSpawn.java
@@ -1,0 +1,62 @@
+package com.shanebeestudios.skbee.elements.other.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.SpawnerSpawnEvent;
+import org.jetbrains.annotations.Nullable;
+
+public class EvtSpawnerSpawn extends SkriptEvent {
+
+    static {
+        Skript.registerEvent("Spawner - Spawn", EvtSpawnerSpawn.class, SpawnerSpawnEvent.class,
+                        "spawner spawn[ing] [of %entitydatas%]6")
+                .description("Called whenever an entity is spawned via a spawner.")
+                .examples("on spawner spawn of zombie:",
+                        "\treset spawner timer of event-block")
+                .since("INSERT VERSION");
+
+        EventValues.registerEventValue(SpawnerSpawnEvent.class, Block.class, new Getter<>() {
+            @Override
+            public Block get(SpawnerSpawnEvent event) {
+                return event.getSpawner().getBlock();
+            }
+        }, EventValues.TIME_NOW);
+
+    }
+
+    private EntityData<?>[] spawnedEntities;
+
+    @Override
+    public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult) {
+        this.spawnedEntities = literals[0] == null ? null : ((Literal<EntityData<?>>) literals[0]).getAll();
+        return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        if (spawnedEntities == null) return true;
+        if (event instanceof SpawnerSpawnEvent spawnerEvent) {
+            Entity spawnedEntity = spawnerEvent.getEntity();
+            for (EntityData<?> entity : spawnedEntities) {
+                if (entity.isInstance(spawnedEntity))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean b) {
+        return "spawner spawn" + (this.spawnedEntities != null ? " of " + Classes.toString(this.spawnedEntities) : "");
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtSpawnerSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtSpawnerSpawn.java
@@ -18,7 +18,7 @@ public class EvtSpawnerSpawn extends SkriptEvent {
 
     static {
         Skript.registerEvent("Spawner - Spawn", EvtSpawnerSpawn.class, SpawnerSpawnEvent.class,
-                        "spawner spawn[ing] [of %entitydatas%]6")
+                        "spawner spawn[ing] [of %entitydatas%]")
                 .description("Called whenever an entity is spawned via a spawner.")
                 .examples("on spawner spawn of zombie:",
                         "\treset spawner timer of event-block")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -2,7 +2,6 @@ package com.shanebeestudios.skbee.elements.other.events;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.lang.Unit;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Getter;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerMaxNearbyEntities.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerMaxNearbyEntities.java
@@ -1,0 +1,87 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Spawner - Max Nearby Entities")
+@Description({"Set the new maximum amount of similar entities that are allowed to be within spawning range of a spawner.",
+        "If more than the maximum number of entities are within range, the spawner will not spawn and try again.",
+        "Default value is 16."})
+@Examples({"add 10 to maximum nearby entities of {_spawner}",
+        "remove 10 from maximum nearby entities of {_spawner}",
+        "reset maximum nearby entities of {_spawner}",
+        "set maximum nearby entities of {_spawner} to 10"})
+@Since("INSERT VERSION")
+public class ExprSpawnerMaxNearbyEntities extends SimplePropertyExpression<Block, Integer> {
+
+    static {
+        register(ExprSpawnerMaxNearbyEntities.class, Integer.class, "max nearby [spawner] entities", "blocks");
+    }
+
+    private static final int DEFAULT_MAX_NEARBY_ENTITIES = 16;
+
+    @Override
+    public @Nullable Integer convert(Block block) {
+        if (block.getState() instanceof CreatureSpawner spawner)
+            return spawner.getMaxNearbyEntities();
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, ADD, REMOVE -> CollectionUtils.array(Integer.class);
+            case RESET -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int changeValue = delta == null ? DEFAULT_MAX_NEARBY_ENTITIES : (Integer) delta[0];
+        switch (mode) {
+            case RESET:
+            case SET:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        spawner.setMaxNearbyEntities(Math.max(changeValue, 0));
+                        spawner.update();
+                    }
+                }
+                break;
+            case REMOVE:
+                changeValue = -changeValue;
+            case ADD:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        int value = spawner.getMaxNearbyEntities() + changeValue;
+                        spawner.setMaxNearbyEntities(Math.max(value, 0));
+                        spawner.update();
+                    }
+                }
+                break;
+            default:
+                assert false;
+        }
+    }
+
+    @Override
+    public Class<? extends Integer> getReturnType() {
+        return Integer.class;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "max nearby spawner entities";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerRequiredPlayerRange.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerRequiredPlayerRange.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 @Name("Spawner - Required Player Range")
 @Description({"Get the maximum distance(squared) a player can be in order for a spawner to be active.",
         "If this value is less than 0, the spawner is always active (given that there are players online).",
-        "Otherwise if the value is 0 the spawner is never active", // Documentation is incorrect, saying <= 0 is always active
+        "Otherwise if the value is 0 the spawner is never active.", // Documentation is incorrect, saying <= 0 is always active
         "Default value is 16."})
 @Examples({"on place of mob spawner:",
         "\tset required player range of event-block to 0"})

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerRequiredPlayerRange.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerRequiredPlayerRange.java
@@ -1,0 +1,85 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Spawner - Required Player Range")
+@Description({"Get the maximum distance(squared) a player can be in order for a spawner to be active.",
+        "If this value is less than 0, the spawner is always active (given that there are players online).",
+        "Otherwise if the value is 0 the spawner is never active", // Documentation is incorrect, saying <= 0 is always active
+        "Default value is 16."})
+@Examples({"on place of mob spawner:",
+        "\tset required player range of event-block to 0"})
+@Since("INSERT VERSION")
+public class ExprSpawnerRequiredPlayerRange extends SimplePropertyExpression<Block, Integer> {
+
+    static {
+        register(ExprSpawnerRequiredPlayerRange.class, Integer.class, "required (player|activation) range", "blocks");
+    }
+
+    private static final int DEFAULT_ACTIVATION_RANGE = 16;
+
+    @Override
+    public @Nullable Integer convert(Block block) {
+        if (block.getState() instanceof CreatureSpawner spawner)
+            return spawner.getRequiredPlayerRange();
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case ADD, REMOVE, SET -> CollectionUtils.array(Integer.class);
+            case RESET -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int changeValue = delta == null ? DEFAULT_ACTIVATION_RANGE : (Integer) delta[0];
+        switch (mode) {
+            case RESET, SET:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        spawner.setRequiredPlayerRange(changeValue);
+                        spawner.update();
+                    }
+                }
+                break;
+            case REMOVE:
+                changeValue = -changeValue;
+            case ADD:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        int value = spawner.getRequiredPlayerRange() + changeValue;
+                        spawner.setRequiredPlayerRange(value);
+                        spawner.update();
+                    }
+                }
+                break;
+            default:
+                assert false;
+        }
+    }
+
+    @Override
+    public Class<? extends Integer> getReturnType() {
+        return Integer.class;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "spawner required activation range";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnCount.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnCount.java
@@ -1,0 +1,85 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Spawner - Spawn Count")
+@Description({"Get how many mobs attempt to spawn.",
+        "Default is 4"})
+@Examples({"on place of mob spawner:",
+        "\tset spawner spawn count of event-block to 10",
+        "\tadd 10 to spawn count of event-block",
+        "\treset spawn count of event-block"})
+@Since("INSERT VERSION")
+public class ExprSpawnerSpawnCount extends SimplePropertyExpression<Block, Integer> {
+
+    static {
+        register(ExprSpawnerSpawnCount.class, Integer.class, "[spawner] spawn count", "blocks");
+    }
+
+    private static final int DEFAULT_SPAWN_COUNT = 4;
+
+    @Override
+    public @Nullable Integer convert(Block block) {
+        if (block.getState() instanceof CreatureSpawner spawner)
+            return spawner.getSpawnCount();
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case ADD, SET, REMOVE -> CollectionUtils.array(Integer.class);
+            case RESET -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int changeValue = delta == null ? DEFAULT_SPAWN_COUNT : (Integer) delta[0];
+        switch (mode) {
+            case RESET, SET:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        spawner.setSpawnCount(Math.max(changeValue, 0));
+                        spawner.update();
+                    }
+                }
+                break;
+            case REMOVE:
+                changeValue = -changeValue;
+            case ADD:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        int value = spawner.getSpawnCount() + changeValue;
+                        spawner.setSpawnCount(Math.max(value, 0));
+                        spawner.update();
+                    }
+                }
+                break;
+            default:
+                assert false;
+        }
+    }
+
+    @Override
+    public Class<? extends Integer> getReturnType() {
+        return Integer.class;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "spawner spawn count";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnCount.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnCount.java
@@ -13,8 +13,7 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Spawner - Spawn Count")
-@Description({"Get how many mobs attempt to spawn.",
-        "Default is 4"})
+@Description("Get how many mobs attempt to spawn. Default is 4.")
 @Examples({"on place of mob spawner:",
         "\tset spawner spawn count of event-block to 10",
         "\tadd 10 to spawn count of event-block",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnDelay.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnDelay.java
@@ -1,0 +1,127 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+
+@Name("Spawner - Spawn Delay")
+@Description({"The delay between a spawner spawning a new entity",
+        "Maximum default is 800 ticks (40 seconds)",
+        "Minimum default is 200 ticks (10 seconds)"})
+@Examples({"on place of mob spawner:",
+        "\tset spawner spawn delay of event-block to 3 seconds",
+        "\tadd 100 to max spawn delay of event-block",
+        "\tremove 1 second from min spawn delay of event-block",
+        "\treset spawn delay of event-block"})
+@Since("INSERT VERSION")
+public class ExprSpawnerSpawnDelay extends SimplePropertyExpression<Block, Timespan> {
+
+    static {
+        register(ExprSpawnerSpawnDelay.class, Timespan.class, "[(-1:min|1:max)[imum]] [spawner] spawn delay", "blocks");
+    }
+
+    private static final int DEFAULT_MAX_TICKS = 800, DEFAULT_MIN_TICKS = 200;
+    private Kleenean action;
+
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        action = Kleenean.get(parseResult.mark);
+        return super.init(exprs, matchedPattern, isDelayed, parseResult);
+    }
+
+    @Override
+    @Nullable
+    public Timespan convert(Block block) {
+        BlockState blockState = block.getState();
+        if (blockState instanceof CreatureSpawner spawner) {
+            int delay = switch (action) {
+                case FALSE -> spawner.getMinSpawnDelay();
+                case TRUE -> spawner.getMaxSpawnDelay();
+                default -> spawner.getDelay();
+            };
+            return Timespan.fromTicks_i(delay);
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, ADD, REMOVE -> CollectionUtils.array(Timespan.class, Integer.class);
+            case RESET -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int changeValue = 0;
+        if (delta != null) {
+            changeValue += delta[0] instanceof Timespan timespan ? timespan.getTicks_i() : ((Integer) delta[0]);
+        } else {
+            changeValue = switch (action) {
+                case TRUE -> DEFAULT_MAX_TICKS;
+                case FALSE -> DEFAULT_MIN_TICKS;
+                default -> 0;
+            };
+        }
+        for (Block block : getExpr().getArray(event)) {
+            if (block.getState() instanceof CreatureSpawner spawner) {
+                int value = switch (action) {
+                    case TRUE -> spawner.getMaxSpawnDelay();
+                    case FALSE -> spawner.getMinSpawnDelay();
+                    default -> spawner.getDelay();
+                };
+                switch (mode) {
+                    case REMOVE -> value -= changeValue;
+                    case ADD -> value += changeValue;
+                    case SET, RESET -> value = changeValue;
+                }
+                value = Math.max(value, 0);
+                switch (action) {
+                    case TRUE -> {
+                        if (value < spawner.getMinSpawnDelay())
+                            spawner.setMinSpawnDelay(value);
+                        spawner.setMaxSpawnDelay(value);
+                    }
+                    case FALSE -> {
+                        if (value > spawner.getMaxSpawnDelay())
+                            spawner.setMaxSpawnDelay(value);
+                        spawner.setMinSpawnDelay(value);
+                    }
+                    default -> spawner.setDelay(value);
+                }
+                spawner.update();
+            }
+        }
+    }
+
+    @Override
+    public Class<? extends Timespan> getReturnType() {
+        return Timespan.class;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return switch (action) {
+            case TRUE -> "maximum ";
+            case FALSE -> "minimum ";
+            default -> "";
+        } + "spawn delay";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnDelay.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnDelay.java
@@ -19,9 +19,9 @@ import org.jetbrains.annotations.Nullable;
 
 
 @Name("Spawner - Spawn Delay")
-@Description({"The delay between a spawner spawning a new entity",
-        "Maximum default is 800 ticks (40 seconds)",
-        "Minimum default is 200 ticks (10 seconds)"})
+@Description({"The delay between a spawner spawning a new entity.",
+        "Maximum default is 800 ticks (40 seconds).",
+        "Minimum default is 200 ticks (10 seconds)."})
 @Examples({"on place of mob spawner:",
         "\tset spawner spawn delay of event-block to 3 seconds",
         "\tadd 100 to max spawn delay of event-block",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnRange.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprSpawnerSpawnRange.java
@@ -1,0 +1,85 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Spawner - Spawn Range")
+@Description({"Get the radius around which a spawner will attempt to spawn mobs in.",
+        "This area is square, includes the block the spawner is in, and is centered on the spawner's x,z coordinates - not the spawner itself.",
+        "It is 2 blocks high, centered on the spawner's y-coordinate (its bottom); thus allowing mobs to spawn as high as its top surface and as low as 1 block below its bottom surface.",
+        "Default value is 4."})
+@Examples({"on place of mob spawner:",
+        "\tset spawn range of event-block to random integer between 0 and 10"})
+@Since("INSERT VERSION")
+public class ExprSpawnerSpawnRange extends SimplePropertyExpression<Block, Integer> {
+
+    static {
+        register(ExprSpawnerSpawnRange.class, Integer.class, "[spawner] spawn range", "blocks");
+    }
+
+    private static final int DEFAULT_SPAWN_RANGE = 4;
+
+    @Override
+    public @Nullable Integer convert(Block block) {
+        if (block.getState() instanceof CreatureSpawner spawner)
+            return spawner.getSpawnRange();
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case ADD, REMOVE, SET -> CollectionUtils.array(Integer.class);
+            case RESET -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        int changeValue = delta == null ? DEFAULT_SPAWN_RANGE : (Integer) delta[0];
+        switch (mode) {
+            case RESET, SET:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        spawner.setSpawnRange(Math.max(changeValue, 0));
+                        spawner.update();
+                    }
+                }
+                break;
+            case REMOVE:
+                changeValue = -changeValue;
+            case ADD:
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof CreatureSpawner spawner) {
+                        int value = spawner.getSpawnRange() + changeValue;
+                        spawner.setSpawnRange(Math.max(value, 0));
+                        spawner.update();
+                    }
+                }
+                break;
+            default:
+                assert false;
+        }
+    }
+
+    @Override
+    public Class<? extends Integer> getReturnType() {
+        return Integer.class;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "spawner spawn range";
+    }
+
+}


### PR DESCRIPTION
This PR adds a bunch of spawner related syntax
A list of everything added is below
- Added CondSpawnerIsActivated
- Added EffSpawnerResetTimer (PaperMC)
- Added EvtSpawnerSpawn
- Added ExprSpawnerRequiredPlayerRange
- Added ExprSpawnerSpawnCount
- Added ExprSpawnerSpawnDelay
- Added ExprSpawnerSpawnRange
- Added ExprSpawnerMaxNearbyEntities

officially I spent far too many days working on this and now I must go to sleep as I work in about 10 hours
majority of the descriptions are copied from the javadocs.

I added a comment on `ExprSpawnerRequiredPlayerRange` as it states `<= 0` for infinite range which is false it's only `< 0`
if the range is set to 0 it's disabled even disables the spawn delay 