### PR TITLE
Add Lockable block state

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
@@ -10,7 +10,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Container;
 
 @Name("Is Locked")
-@Description("Check if a container or beacon is in a locked state")
+@Description("Check if a container or beacon is in a locked state.")
 @Examples({"on right click on shulker box or beacon",
         "\tclicked block is locked",
         "\tplayer has permission \"see.locked\"",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
@@ -1,0 +1,40 @@
+package com.shanebeestudios.skbee.elements.other.conditions;
+
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import org.bukkit.block.Beacon;
+import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+
+@Name("Is Locked")
+@Description("Check if a container or beacon is in a locked state")
+@Examples({"on right click on shulker box or beacon",
+        "\tclicked block is locked",
+        "\tplayer has permission \"see.locked\"",
+        "send action bar \"%lock of clicked block%\" to player"})
+@Since("INSERT VERSION")
+public class CondIsLocked extends PropertyCondition<Block> {
+
+    static {
+        register(CondIsLocked.class, "locked", "blocks");
+    }
+
+    @Override
+    public boolean check(Block block) {
+        if (block.getState() instanceof Container container) {
+            return container.isLocked();
+        } else if (block.getState() instanceof Beacon beacon) {
+            return beacon.isLocked();
+        }
+        return false;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "locked";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
@@ -11,10 +11,10 @@ import org.bukkit.block.Container;
 
 @Name("Is Locked")
 @Description("Check if a container or beacon is in a locked state.")
-@Examples({"on right click on shulker box or beacon",
+@Examples({"on right click on shulker box or beacon:",
         "\tclicked block is locked",
         "\tplayer has permission \"see.locked\"",
-        "send action bar \"%lock of clicked block%\" to player"})
+        "\tsend action bar \"%lock of clicked block%\" to player"})
 @Since("INSERT VERSION")
 public class CondIsLocked extends PropertyCondition<Block> {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondIsLocked.java
@@ -14,7 +14,7 @@ import org.bukkit.block.Container;
 @Examples({"on right click on shulker box or beacon:",
         "\tclicked block is locked",
         "\tplayer has permission \"see.locked\"",
-        "\tsend action bar \"%lock of clicked block%\" to player"})
+        "\tsend action bar \"%container key of clicked block%\" to player"})
 @Since("INSERT VERSION")
 public class CondIsLocked extends PropertyCondition<Block> {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableKey.java
@@ -13,7 +13,7 @@ import org.bukkit.block.Container;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
-@Name("Lock of Block")
+@Name("Key of Block")
 @Description("Get or set the lock of a container or beacon.")
 @Examples({"on right click on shulker box or beacon:",
         "\tclicked block is locked",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableKey.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableKey.java
@@ -18,12 +18,12 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"on right click on shulker box or beacon:",
         "\tclicked block is locked",
         "\tplayer has permission \"see.locked\"",
-        "\tsend action bar \"%lock of clicked block%\" to player"})
+        "\tsend action bar \"%container key of clicked block%\" to player"})
 @Since("INSERT VERSION")
-public class ExprLockableLock extends SimplePropertyExpression<Block, String> {
+public class ExprLockableKey extends SimplePropertyExpression<Block, String> {
 
     static {
-        register(ExprLockableLock.class, String.class, "lock", "blocks");
+        register(ExprLockableKey.class, String.class, "(container|lockable) key", "blocks");
     }
 
     @Override
@@ -74,7 +74,7 @@ public class ExprLockableLock extends SimplePropertyExpression<Block, String> {
 
     @Override
     protected String getPropertyName() {
-        return "lockable key";
+        return "container key";
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableLock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableLock.java
@@ -14,7 +14,7 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Lock of Block")
-@Description("Get or set the lock of a container or beacon")
+@Description("Get or set the lock of a container or beacon.")
 @Examples({"on right click on shulker box or beacon",
         "\tclicked block is locked",
         "\tplayer has permission \"see.locked\"",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableLock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableLock.java
@@ -1,0 +1,80 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.block.Beacon;
+import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Lock of Block")
+@Description("Get or set the lock of a container or beacon")
+@Examples({"on right click on shulker box or beacon",
+        "\tclicked block is locked",
+        "\tplayer has permission \"see.locked\"",
+        "send action bar \"%lock of clicked block%\" to player"})
+@Since("INSERT VERSION")
+public class ExprLockableLock extends SimplePropertyExpression<Block, String> {
+
+    static {
+        register(ExprLockableLock.class, String.class, "lock", "blocks");
+    }
+
+    @Override
+    public @Nullable String convert(Block block) {
+        if (block.getState() instanceof Container container) {
+            return container.isLocked() ? container.getLock() : null;
+        } else if (block.getState() instanceof Beacon beacon) {
+            return beacon.isLocked() ? beacon.getLock() : null;
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET -> CollectionUtils.array(String.class);
+            case RESET -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        String lock = delta == null ? null : (String) delta[0];
+        if (lock != null && lock.isBlank()) lock = null;
+        switch (mode) {
+            case RESET, SET -> {
+                for (Block block : getExpr().getArray(event)) {
+                    if (block.getState() instanceof Container container) {
+                        container.setLock(lock);
+                        container.update();
+                    } else if (block.getState() instanceof Beacon beacon) {
+                        beacon.setLock(lock);
+                        beacon.update();
+                    }
+                }
+            }
+            default -> {
+                assert false;
+            }
+        }
+    }
+
+    @Override
+    public Class<? extends String> getReturnType() {
+        return String.class;
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "lockable key";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableLock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLockableLock.java
@@ -15,10 +15,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Lock of Block")
 @Description("Get or set the lock of a container or beacon.")
-@Examples({"on right click on shulker box or beacon",
+@Examples({"on right click on shulker box or beacon:",
         "\tclicked block is locked",
         "\tplayer has permission \"see.locked\"",
-        "send action bar \"%lock of clicked block%\" to player"})
+        "\tsend action bar \"%lock of clicked block%\" to player"})
 @Since("INSERT VERSION")
 public class ExprLockableLock extends SimplePropertyExpression<Block, String> {
 


### PR DESCRIPTION
Adds support for the lockable block state includes everything container and beacons

the lockable state is a interface instead of a stand alone class to extend stupidly so must check for container and beacon classes
as such