### PR TITLE
Add paper's pre spawn events

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffAbortSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffAbortSpawn.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Abort Creature Spawn")
 @Description({"Abort a creature spawn event, preventing it from retrying more attempts after canceling.",
-        "aborting should only be done if you're blanket blocking this entity type from spawning"})
+        "aborting should only be done if you're blanket blocking this entity type from spawning."})
 @Examples({"on pre creature spawn of an animal",
         "\tcancel event",
         "\tabort creature spawn"})

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffAbortSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffAbortSpawn.java
@@ -1,0 +1,58 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Abort Creature Spawn")
+@Description({"Abort a creature spawn event, preventing it from retrying more attempts after canceling.",
+        "aborting should only be done if you're blanket blocking this entity type from spawning"})
+@Examples({"on pre creature spawn of an animal",
+        "\tcancel event",
+        "\tabort creature spawn"})
+@Since("INSERT VERSION")
+public class EffAbortSpawn extends Effect {
+
+    private static final boolean HAS_PRE_SPAWN_EVENT = Skript.classExists("com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent");
+
+    static {
+        Skript.registerEffect(EffAbortSpawn.class,
+                "[:un]abort creature spawn");
+    }
+
+    private boolean abort;
+
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPatteren, Kleenean isDelayed, ParseResult parseResult) {
+        if (!HAS_PRE_SPAWN_EVENT) {
+            Skript.error("In order to use the 'abort spawn' effect, you must be running a PaperMC server.");
+            return false;
+        }
+        if (!getParser().isCurrentEvent(PreCreatureSpawnEvent.class)) {
+            Skript.error("The 'abort spawn' effect can only be used an a pre creature spawn event!");
+            return false;
+        }
+        abort = !parseResult.hasTag("un");
+        return true;
+    }
+
+    @Override
+    protected void execute(Event event) {
+        if (event instanceof PreCreatureSpawnEvent preCreatureSpawnEvent)
+            preCreatureSpawnEvent.setShouldAbortSpawn(abort);
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean b) {
+        return (abort ? "" : "un") + "abort creature spawn";
+    }
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffAbortSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffAbortSpawn.java
@@ -15,8 +15,8 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Abort Creature Spawn")
 @Description({"Abort a creature spawn event, preventing it from retrying more attempts after canceling.",
-        "aborting should only be done if you're blanket blocking this entity type from spawning."})
-@Examples({"on pre creature spawn of an animal",
+        "Aborting should only be done if you're blanket blocking this entity type from spawning."})
+@Examples({"on pre creature spawn of an animal:",
         "\tcancel event",
         "\tabort creature spawn"})
 @Since("INSERT VERSION")
@@ -25,8 +25,7 @@ public class EffAbortSpawn extends Effect {
     private static final boolean HAS_PRE_SPAWN_EVENT = Skript.classExists("com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent");
 
     static {
-        Skript.registerEffect(EffAbortSpawn.class,
-                "[:un]abort creature spawn");
+        Skript.registerEffect(EffAbortSpawn.class, "[:un]abort creature spawn");
     }
 
     private boolean abort;
@@ -55,4 +54,5 @@ public class EffAbortSpawn extends Effect {
     public String toString(@Nullable Event event, boolean b) {
         return (abort ? "" : "un") + "abort creature spawn";
     }
+
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPreSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPreSpawn.java
@@ -26,18 +26,15 @@ public class EvtPreSpawn extends SkriptEvent {
     private static final boolean HAS_PRE_PHANTOM_SPAWN_EVENT = Skript.classExists("com.destroystokyo.paper.event.entity.PhantomPreSpawnEvent");
 
     static {
-
         // Paper - PreCreatureSpawnEvent
         if (HAS_PRE_CREATURE_SPAWN_EVENT) {
-
             Skript.registerEvent("Pre Creature Spawn", EvtPreSpawn.class, PreCreatureSpawnEvent.class,
                             "pre [creature] spawn[ing] [of %entitydatas%]")
                     .description("Called before an entity is spawned into the world.",
                             "Note: The spawning entity does not exist when this event is called only the entitytype exists.",
-                            "",
-                            "event-spawnreason - the reason the entity is spawned",
-                            "event-location - the location the spawned entity will appear",
-                            "event-entitytype - the type of entity being spawned")
+                            "\nevent-spawnreason = the reason the entity is spawned.",
+                            "\nevent-location = the location the spawned entity will appear.",
+                            "\nevent-entitytype = the type of entity being spawned.")
                     .examples("on pre spawn of a pig:",
                             "\tbroadcast \"a %event-entitytype% is spawning in\"")
                     .since("INSERT VERSION");
@@ -48,6 +45,7 @@ public class EvtPreSpawn extends SkriptEvent {
                     return event.getSpawnLocation();
                 }
             }, EventValues.TIME_NOW);
+
             EventValues.registerEventValue(PreCreatureSpawnEvent.class, EntityData.class, new Getter<>() {
                 @Override
                 public EntityData<?> get(PreCreatureSpawnEvent event) {
@@ -65,14 +63,12 @@ public class EvtPreSpawn extends SkriptEvent {
 
         // Paper - PreSpawnerSpawnEvent
         if (HAS_PRE_SPAWNER_SPAWN_EVENT) {
-
             Skript.registerEvent("Pre Spawner Spawn", EvtPreSpawn.class, PreSpawnerSpawnEvent.class,
                             "pre spawner spawn[ing] [of %entitydatas%]")
                     .description("Called before an entity is spawned via a spawner.",
                             "Note: The spawned entity does not exist when this event is called only the entitytype exists.",
-                            "",
-                            "View the pre creature spawn event for more event values.",
-                            "event-block - the block location of the spawner spawning the entity")
+                            "\nView the pre creature spawn event for more event values.",
+                            "\nevent-block = the block location of the spawner spawning the entity.")
                     .examples("on pre spawner spawn of a zombie:",
                             "\tbroadcast \"%event-entitytype% is spawning in\"")
                     .since("INSERT VERSION");
@@ -91,9 +87,8 @@ public class EvtPreSpawn extends SkriptEvent {
                     "pre phantom spawn[ing]")
                     .description("Called before a phantom is spawned for an entity.",
                             "Note: The phantom entity does not exist when this event is called only the entitytype exists.",
-                            "",
-                            "View the pre creature spawn event for more event values.",
-                            "event-entity - the entity the spawned phantom is spawning for")
+                            "\nView the pre creature spawn event for more event values.",
+                            "\nevent-entity = the entity the spawned phantom is spawning for.")
                     .examples("on pre phantom spawn:",
                             "\tbroadcast \"Watch out %event-entity% a phantom is coming!\"")
                     .since("INSERT VERSION");

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPreSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPreSpawn.java
@@ -32,6 +32,7 @@ public class EvtPreSpawn extends SkriptEvent {
                             "pre [creature] spawn[ing] [of %entitydatas%]")
                     .description("Called before an entity is spawned into the world.",
                             "Note: The spawning entity does not exist when this event is called only the entitytype exists.",
+                            "This event is called very frequently, and can cause server lag, use it sparingly.",
                             "\nevent-spawnreason = the reason the entity is spawned.",
                             "\nevent-location = the location the spawned entity will appear.",
                             "\nevent-entitytype = the type of entity being spawned.")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPreSpawn.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/EvtPreSpawn.java
@@ -1,0 +1,138 @@
+package com.shanebeestudios.skbee.elements.other.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.bukkitutil.EntityUtils;
+import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import com.destroystokyo.paper.event.entity.PhantomPreSpawnEvent;
+import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
+import com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.jetbrains.annotations.Nullable;
+
+public class EvtPreSpawn extends SkriptEvent {
+
+    private static final boolean HAS_PRE_CREATURE_SPAWN_EVENT = Skript.classExists("com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent");
+    private static final boolean HAS_PRE_SPAWNER_SPAWN_EVENT = Skript.classExists("com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent");
+    private static final boolean HAS_PRE_PHANTOM_SPAWN_EVENT = Skript.classExists("com.destroystokyo.paper.event.entity.PhantomPreSpawnEvent");
+
+    static {
+
+        // Paper - PreCreatureSpawnEvent
+        if (HAS_PRE_CREATURE_SPAWN_EVENT) {
+
+            Skript.registerEvent("Pre Creature Spawn", EvtPreSpawn.class, PreCreatureSpawnEvent.class,
+                            "pre [creature] spawn[ing] [of %entitydatas%]")
+                    .description("Called before an entity is spawned into the world.",
+                            "Note: The spawning entity does not exist when this event is called only the entitytype exists.",
+                            "",
+                            "event-spawnreason - the reason the entity is spawned",
+                            "event-location - the location the spawned entity will appear",
+                            "event-entitytype - the type of entity being spawned")
+                    .examples("on pre spawn of a pig:",
+                            "\tbroadcast \"a %event-entitytype% is spawning in\"")
+                    .since("INSERT VERSION");
+
+            EventValues.registerEventValue(PreCreatureSpawnEvent.class, Location.class, new Getter<>() {
+                @Override
+                public Location get(PreCreatureSpawnEvent event) {
+                    return event.getSpawnLocation();
+                }
+            }, EventValues.TIME_NOW);
+            EventValues.registerEventValue(PreCreatureSpawnEvent.class, EntityData.class, new Getter<>() {
+                @Override
+                public EntityData<?> get(PreCreatureSpawnEvent event) {
+                    return EntityUtils.toSkriptEntityData(event.getType());
+                }
+            }, EventValues.TIME_NOW);
+
+            EventValues.registerEventValue(PreCreatureSpawnEvent.class, SpawnReason.class, new Getter<>() {
+                @Override
+                public SpawnReason get(PreCreatureSpawnEvent event) {
+                    return event.getReason();
+                }
+            }, EventValues.TIME_NOW);
+        }
+
+        // Paper - PreSpawnerSpawnEvent
+        if (HAS_PRE_SPAWNER_SPAWN_EVENT) {
+
+            Skript.registerEvent("Pre Spawner Spawn", EvtPreSpawn.class, PreSpawnerSpawnEvent.class,
+                            "pre spawner spawn[ing] [of %entitydatas%]")
+                    .description("Called before an entity is spawned via a spawner.",
+                            "Note: The spawned entity does not exist when this event is called only the entitytype exists.",
+                            "",
+                            "View the pre creature spawn event for more event values.",
+                            "event-block - the block location of the spawner spawning the entity")
+                    .examples("on pre spawner spawn of a zombie:",
+                            "\tbroadcast \"%event-entitytype% is spawning in\"")
+                    .since("INSERT VERSION");
+
+            EventValues.registerEventValue(PreSpawnerSpawnEvent.class, Block.class, new Getter<>() {
+                @Override
+                public Block get(PreSpawnerSpawnEvent event) {
+                    return event.getSpawnerLocation().getBlock();
+                }
+            }, EventValues.TIME_NOW);
+        }
+
+        // Paper - PhantomPreSpawnEvent
+        if (HAS_PRE_PHANTOM_SPAWN_EVENT) {
+            Skript.registerEvent("Pre Phantom Spawn", EvtPreSpawn.class, PhantomPreSpawnEvent.class,
+                    "pre phantom spawn[ing]")
+                    .description("Called before a phantom is spawned for an entity.",
+                            "Note: The phantom entity does not exist when this event is called only the entitytype exists.",
+                            "",
+                            "View the pre creature spawn event for more event values.",
+                            "event-entity - the entity the spawned phantom is spawning for")
+                    .examples("on pre phantom spawn:",
+                            "\tbroadcast \"Watch out %event-entity% a phantom is coming!\"")
+                    .since("INSERT VERSION");
+
+            EventValues.registerEventValue(PhantomPreSpawnEvent.class, Entity.class, new Getter<>() {
+                @Override
+                @Nullable
+                public Entity get(PhantomPreSpawnEvent event) {
+                    return event.getSpawningEntity();
+                }
+            }, EventValues.TIME_NOW);
+        }
+
+    }
+
+    private EntityData[] spawnedEntities = null;
+
+    @Override
+    public boolean init(Literal<?>[] literals, int matchedPattern, ParseResult parseResult) {
+        this.spawnedEntities = literals[0] == null ? null : ((Literal<EntityData<?>>) literals[0]).getAll();
+        return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        if (this.spawnedEntities == null) return true;
+        if (event instanceof PreCreatureSpawnEvent preCreatureSpawnEvent) {
+            EntityData<?> spawnedEntity = EntityUtils.toSkriptEntityData(preCreatureSpawnEvent.getType());
+            for (EntityData<?> entityData : this.spawnedEntities) {
+                if (entityData.isSupertypeOf(spawnedEntity))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return "pre spawn" + (spawnedEntities != null ? " of " + Classes.toString(spawnedEntities, false) : "");
+    }
+
+}


### PR DESCRIPTION
Stupid system forcing a creation

This PRs adds paper's three events for pre spawning 
- PreCreatureSpawnEvent (called before bukkit's creature spawn event)
- PreSpawnerSpawnEvent (called before bukkit's spawner spawn event)
- PhantomPreSpawnEvent (unsure much use for it but as it existed added it)

In addition added an effect for aborting the spawn events, if used the entity will not attempt to respawn again.

Didn't want to add this with the spawner support PR so waited until that was merged