### PR TITLE
EffCraftingRecipe - Fixed change which broke recipes

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCraftingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCraftingRecipe.java
@@ -91,7 +91,7 @@ public class EffCraftingRecipe extends Effect {
             return;
         }
 
-        if (ingredients.length != 4 && ingredients.length != 9) {
+        if (ingredients.length == 0) {
             RecipeUtil.error("Error registering crafting recipe - requires 4 or 9 ingredients");
             RecipeUtil.error("Current Item: §6" + this.toString(event, true));
             return;


### PR DESCRIPTION
In the issue #435 if you provided a `null` value as the ingredients you'd be sent a null pointer the fix at the time was just check if size of the list was 4 or 9 which ended up breaking 1,2,3,5,6,7 and 8 sized recipes despite the fact they are supported.

The new change is to just check if the size of the array is 0 and if so we error, during my testing this does seem to have fixed the issue and it'll no longer be caused