### PR TITLE
SecClickEventCallback - Some minor cleanup changes

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
@@ -121,10 +121,10 @@ public class SecClickEventCallback extends Section {
 
     @Override
     @NotNull
-    public String toString(@Nullable Event event, boolean d) {
-        String uses = this.uses != null ? (" with " + this.uses.toString(event, d) + " uses") : "";
-        String time = this.lifeTime != null ? (" with lifetime of " + this.lifeTime.toString(event, d)) : "";
-        return "create click event callback for " + this.component.toString(event, d) + uses + time;
+    public String toString(@Nullable Event e, boolean d) {
+        String uses = this.uses != null ? (" with " + this.uses.toString(e, d) + " uses") : "";
+        String time = this.lifeTime != null ? (" with lifetime of " + this.lifeTime.toString(e, d)) : "";
+        return "create click event callback for " + this.component.toString(e, d) + uses + time;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
@@ -6,8 +6,8 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
-import ch.njol.skript.lang.EffectSection;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
@@ -31,24 +31,30 @@ import java.util.List;
 @Description({"Create a click event, that when clicked will run the code in this section.",
         "\nNOTE: Internally this just makes the player run a special command",
         "so you will see console messages where a player runs the command \"/paper callback\" in your console.",
-        "\nNOTE: Paper didn't make this command avaiable by default",
+        "\nNOTE: Paper didn't make this command available by default",
         "so you'll have to give your players the permission `bukkit.command.paper.callback`.",
         "\n`uses` = The amount of times the player can click this. Defaults to 1. Use `-1` for unlimited uses.",
         "\n`lifetime` = How long the player has til they can't click it. Defaults to 12 hours."})
-@Examples({"set {_t} to mini message from \"JOIN US AT SPAWN FOR A SPECIAL EVENT\"",
-        "create callback for {_t}:",
+@Examples({"set {_t} to mini message from \"JOIN US AT SPAWN FOR A SPECIAL EVENT (10 SECONDS REMAINING!)\"",
+        "create callback for {_t} with a duration of 10 seconds:",
         "\tteleport player to spawn of world \"world\"",
         "send component {_t} to all players",
         "",
         "set {_t} to text component from \"&cDONT CLICK ME\"",
-        "create callback for {_t}:",
+        "create callback for {_t} with (size of players) uses:",
         "\tkill player",
         "\tbroadcast \"&b%player% &eclicked it &cAND DIED&7!!!\"",
-        "send component {_t} to all players"})
+        "send component {_t} to all players",
+        "",
+        "set {_t} to text component from \"Hey you! Click this for a free item.\"",
+        "set {_t2} to text component from \"&e&lONE TIME USE!\"",
+        "create a callback for {_t}:",
+        "\tgive player random item out of available item types",
+        "send components (merge components {_t} and {_t2} with \" \") to players"})
 @Since("INSERT VERSION")
-public class SecClickEventCallback extends EffectSection {
+public class SecClickEventCallback extends Section {
 
-    static class ComponentCallbackEvent extends PlayerEvent {
+    private static class ComponentCallbackEvent extends PlayerEvent {
 
         public ComponentCallbackEvent(Player player) {
             super(player);
@@ -64,66 +70,61 @@ public class SecClickEventCallback extends EffectSection {
     static {
         Skript.registerSection(SecClickEventCallback.class,
                 "create [a] [new] [click event] callback for %textcomponent% " +
-                        "[with %-number% use[s]] [[and] with lifetime of %-timespan%]");
+                        "[with %-number% use[s]] [[and] with [a] (lifetime|duration) of %-timespan%]");
     }
 
     private Expression<ComponentWrapper> component;
     private Expression<Number> uses;
-    private Expression<Timespan> timeLimit;
+    private Expression<Timespan> lifeTime;
     private Trigger trigger;
 
-    @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult,
-                        @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+                        SectionNode sectionNode, List<TriggerItem> triggerItems) {
         this.component = (Expression<ComponentWrapper>) exprs[0];
         this.uses = (Expression<Number>) exprs[1];
-        this.timeLimit = (Expression<Timespan>) exprs[2];
-        if (sectionNode != null) {
-            this.trigger = loadCode(sectionNode, "callback", ComponentCallbackEvent.class);
-        } else {
-            Skript.error("`click event callback` can only be used as a section.");
-            return false;
-        }
+        this.lifeTime = (Expression<Timespan>) exprs[2];
+        this.trigger = loadCode(sectionNode, "callback", ComponentCallbackEvent.class);
         return true;
     }
 
-    @SuppressWarnings("NullableProblems")
-    @Override
-    protected @Nullable TriggerItem walk(Event event) {
-        ComponentWrapper component = this.component.getSingle(event);
-        if (this.trigger != null && component != null) {
-            Object localVars = Variables.copyLocalVariables(event);
 
+    @Override
+    @Nullable
+    protected TriggerItem walk(Event event) {
+        ComponentWrapper component = this.component.getSingle(event);
+        if (component != null) {
             int uses = 1;
             if (this.uses != null) {
                 Number usesNum = this.uses.getSingle(event);
                 if (usesNum != null) uses = usesNum.intValue();
             }
 
-            Duration timeLimit = ClickCallback.DEFAULT_LIFETIME;
-            if (this.timeLimit != null) {
-                Timespan timespan = this.timeLimit.getSingle(event);
-                if (timespan != null) timeLimit = Duration.ofMillis(timespan.getTicks_i() * 50);
+            Duration lifeTime = ClickCallback.DEFAULT_LIFETIME;
+            if (this.lifeTime != null) {
+                Timespan lifeTimeSpan = this.lifeTime.getSingle(event);
+                if (lifeTimeSpan != null) lifeTime = Duration.ofMillis(lifeTimeSpan.getMilliSeconds());
             }
 
+            Object localVariables = Variables.copyLocalVariables(event);
             component.setClickEvent(ClickEvent.callback(audience -> {
                 Player player = audience instanceof Player p ? p : null;
                 ComponentCallbackEvent callbackEvent = new ComponentCallbackEvent(player);
-                Variables.setLocalVariables(callbackEvent, localVars);
+                Variables.setLocalVariables(callbackEvent, localVariables);
                 TriggerItem.walk(this.trigger, callbackEvent);
                 Variables.setLocalVariables(event, Variables.copyLocalVariables(callbackEvent));
                 Variables.removeLocals(callbackEvent);
-            }, ClickCallback.Options.builder().uses(uses).lifetime(timeLimit).build()));
+            }, ClickCallback.Options.builder().uses(uses).lifetime(lifeTime).build()));
         }
         return super.walk(event, false);
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
-        String uses = this.uses != null ? (" with " + this.uses.toString(e, d) + " uses") : "";
-        String time = this.timeLimit != null ? (" with lifetime of " + this.timeLimit.toString(e, d)) : "";
-        return "create click event callback for " + this.component.toString(e, d) + uses + time;
+    @NotNull
+    public String toString(@Nullable Event event, boolean d) {
+        String uses = this.uses != null ? (" with " + this.uses.toString(event, d) + " uses") : "";
+        String time = this.lifeTime != null ? (" with lifetime of " + this.lifeTime.toString(event, d)) : "";
+        return "create click event callback for " + this.component.toString(event, d) + uses + time;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
@@ -88,7 +88,6 @@ public class SecClickEventCallback extends Section {
         return true;
     }
 
-
     @Override
     protected @Nullable TriggerItem walk(Event event) {
         ComponentWrapper component = this.component.getSingle(event);

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/sections/SecClickEventCallback.java
@@ -90,8 +90,7 @@ public class SecClickEventCallback extends Section {
 
 
     @Override
-    @Nullable
-    protected TriggerItem walk(Event event) {
+    protected @Nullable TriggerItem walk(Event event) {
         ComponentWrapper component = this.component.getSingle(event);
         if (component != null) {
             int uses = 1;
@@ -120,8 +119,7 @@ public class SecClickEventCallback extends Section {
     }
 
     @Override
-    @NotNull
-    public String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(@Nullable Event e, boolean d) {
         String uses = this.uses != null ? (" with " + this.uses.toString(e, d) + " uses") : "";
         String time = this.lifeTime != null ? (" with lifetime of " + this.lifeTime.toString(e, d)) : "";
         return "create click event callback for " + this.component.toString(e, d) + uses + time;


### PR DESCRIPTION
## Changes Made *short and simple*
- Swapped section from `EffectSection` to `Section` and cleaned it up a bit
- Updated some examples to showcase the usage of `lifetime` and `uses`
- Added `duration` into the `lifetime` portion allowing more possible combinations

## Bit more detailed ones
The swap from `EffectSection` to `Section` was by tud pointing out on discord it didn't make much sense to use it if we can't allow one line usage anyways, the only reason I found why you'd do this is adding a custom error message, however I don't believe this a good practice to follow and believe it's best to stop before it's started.

Some cleanup to the class was made with the removal of nullable properties allowing a little bit easier readability. renamed the `timeLimit` field to `lifeTime` making it a bit more intuitive, and lastly made the event private as no where else will need this event.

`lifetime` was given the counterpart of `duration` which was accompanied by am optional `[a]`
new format looks like `[[and] with [a] (lifetime|duration) of %timespan%]`

Additionally updated examples and added another one to make an example for all 3 usages of the section making it eaiser for people to understand