### PR TITLE
Fix Trim Material/Pattern comparisons

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Comparators.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Comparators.java
@@ -1,0 +1,24 @@
+package com.shanebeestudios.skbee.elements.other.type;
+
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.skriptlang.skript.lang.comparator.Comparator;
+import org.skriptlang.skript.lang.comparator.Relation;
+
+// Reviewer note: re-added this class since I was not sure if we wanted to add it to 'Types'
+public class Comparators {
+
+    static {
+        // Reviewer note: Skript has updated their comparators in 2.7, allowing us to use a lambda over a new class
+        // I couldn't find any other comparators in SkBee, so I haven't updated them if they exist
+        if (Types.HAS_ARMOR_TRIM) {
+            register(TrimPattern.class, TrimPattern.class, (pattern1,pattern2) -> Relation.get(pattern1.equals(pattern2)));
+            register(TrimMaterial.class, TrimMaterial.class, (material1, material2) -> Relation.get(material1.equals(material2)));
+        }
+    }
+
+    private static <T1, T2> void register(Class<T1> class1, Class<T2> class2, Comparator<T1, T2> comparator) {
+        org.skriptlang.skript.lang.comparator.Comparators.registerComparator(class1, class2, comparator);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Comparators.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Comparators.java
@@ -5,12 +5,9 @@ import org.bukkit.inventory.meta.trim.TrimPattern;
 import org.skriptlang.skript.lang.comparator.Comparator;
 import org.skriptlang.skript.lang.comparator.Relation;
 
-// Reviewer note: re-added this class since I was not sure if we wanted to add it to 'Types'
 public class Comparators {
 
     static {
-        // Reviewer note: Skript has updated their comparators in 2.7, allowing us to use a lambda over a new class
-        // I couldn't find any other comparators in SkBee, so I haven't updated them if they exist
         if (Types.HAS_ARMOR_TRIM) {
             register(TrimPattern.class, TrimPattern.class, (pattern1,pattern2) -> Relation.get(pattern1.equals(pattern2)));
             register(TrimMaterial.class, TrimMaterial.class, (material1, material2) -> Relation.get(material1.equals(material2)));


### PR DESCRIPTION
Someone brought up in skript-help-2 channel that `trim (material|pattern) of %armortrim%` can't be compared with their respective enum values.

This PR adds back the `Comparator.java` class we removed once updating `dev/3.0.0` branch. I've also updated this to Skript 2.7 comparators which supports a cleaner method with lambdas. Most importantly adds comparators for each of them.

This cannot be cherry picked for a 2.18.3 build as it's using 2.7 comparator rework

---

I've learned I hate skript's comparison system rn, as this should be handled but isn't. This is only fixed for doing `if trim material of armor trim of {_item} is copper material`, as only this caused as cannot compare issue. Any other like variable comparison worked fine.