### PR TITLE
Bug - Fishing Min/Max 

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/fishing/expressions/ExprFishHookWaitTime.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/fishing/expressions/ExprFishHookWaitTime.java
@@ -74,14 +74,13 @@ public class ExprFishHookWaitTime extends SimplePropertyExpression<Entity, Times
                     case RESET -> value = this.max ? 600 : 100;
                     case REMOVE -> value -= changeValue;
                 }
+                if (value < 0) return;
                 if (this.max) {
-                    if (value >= 0 && value >= fishHook.getMinWaitTime()) {
-                        fishHook.setMaxWaitTime(value);
-                    }
+                    if (value < fishHook.getMinWaitTime()) fishHook.setMinWaitTime(value);
+                    fishHook.setMaxWaitTime(value);
                 } else {
-                    if (value >= 0 && value <= fishHook.getMaxWaitTime()) {
-                        fishHook.setMinWaitTime(value);
-                    }
+                    if (value > fishHook.getMaxWaitTime()) fishHook.setMaxWaitTime(value);
+                    fishHook.setMinWaitTime(value);
                 }
             }
         }


### PR DESCRIPTION
This pr aims to fix an issue with how we handled fishing min/max wait time. When attempting to set maximum/minimum wait time in certain orders with a higher/lower value than default would cause one or the other to not update to new values. Refer to screenshots for showcase.

Solution was to remove clamping between min/max values and set min/max if value is lower/greater than

![image](https://github.com/ShaneBeee/SkBee/assets/81952476/b38a2ffe-a876-46d5-86ee-0785a9ac45c5)
Top half I set min then set max
Bottom half I set max then I set min

- Related Issue: #605