### PR TITLE
ExprMerchantRecipes - cleanup and fix

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -22,8 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Name("Merchant - Recipes")
-@Description({"Represents the recipes of a merchant. All recipes returns a list of all the recipes this merchant offers.",
-        "You can also set/delete them or add to them. You can also get/set/delete a specific recipe."})
+@Description({"Represents the recipes of a merchant. All recipes returns a list of all the recipes this merchant offers.", "You can also set/delete them or add to them. You can also get/set/delete a specific recipe.", "<b>note: when setting/deleting a specific merchant recipe the merchant MUST have a recipe in that slot</b>"})
 @Examples({"add {_recipe} to merchant recipes of {_merchant}",
         "set merchant recipe 1 of {_merchant} to {_recipe}"})
 @Since("1.17.0")
@@ -96,6 +95,7 @@ public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
             }
             for (Object obj : this.merchants.getArray(event)) {
                 if (!(obj instanceof Merchant merchant)) continue;
+                // create a copy of the recipes to update/modify existing recipes
                 List<MerchantRecipe> recipeCopy = new ArrayList<>(recipes);
                 switch (mode) {
                     case ADD:

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -92,12 +92,14 @@ public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
     }
 
     @Override
-    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+    public void change(Event event, Object@Nullable [] delta, ChangeMode mode) {
         if (this.recipe == null) {
             List<MerchantRecipe> recipes = new ArrayList<>();
             if (delta != null) {
                 for (Object object : delta) {
-                    if (object instanceof MerchantRecipe merchantRecipe) recipes.add(merchantRecipe);
+                    if (!(object instanceof MerchantRecipe merchantRecipe)) continue;
+                    if (merchantRecipe.getIngredients().isEmpty()) continue;
+                    recipes.add(merchantRecipe);
                 }
             }
             for (Object obj : this.merchants.getArray(event)) {
@@ -120,13 +122,16 @@ public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
         if (num == null) return;
         int recipeSlot = num.intValue() - 1; // 1 = 0 | 0 = -1
         if (recipeSlot < 0) return;
+        MerchantRecipe merchantRecipe = delta != null ? (MerchantRecipe) delta[0] : null;
+        if (merchantRecipe != null && merchantRecipe.getIngredients().isEmpty()) return;
         for (Object obj : this.merchants.getArray(event)) {
             if (!(obj instanceof Merchant merchant)) continue;
             int recipeCount = merchant.getRecipeCount();
             if (recipeCount == 0 || recipeCount - 1 < recipeSlot) continue;
             switch (mode) {
                 case SET:
-                    merchant.setRecipe(recipeSlot, (MerchantRecipe) delta[0]);
+                    assert merchantRecipe != null;
+                    merchant.setRecipe(recipeSlot, merchantRecipe);
                     break;
                 case DELETE:
                     List<MerchantRecipe> updatedRecipes = new ArrayList<>(merchant.getRecipes());

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -114,7 +114,7 @@ public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
             }
             return;
         }
-        if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) return;
+        if (mode == ChangeMode.ADD) return;
 
         Number num = this.recipe.getSingle(event);
         if (num == null) return;

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -22,14 +22,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Name("Merchant - Recipes")
-@Description({"Represents the recipes of a merchant. All recipes returns a list of all the recipes this merchant offers.", "You can also set/delete them or add to them. You can also get/set/delete a specific recipe.", "<b>note: when setting/deleting a specific merchant recipe the merchant MUST have a recipe in that slot</b>"})
+@Description({"Represents the recipes of a merchant. All recipes returns a list of all the recipes this merchant offers.",
+        "You can also set/delete them or add to them. You can also get/set/delete a specific recipe.",
+        "<b>note: when setting/deleting a specific merchant recipe the merchant MUST have a recipe in that slot</b>"})
 @Examples({"add {_recipe} to merchant recipes of {_merchant}",
         "set merchant recipe 1 of {_merchant} to {_recipe}"})
 @Since("1.17.0")
 public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
 
     static {
-        Skript.registerExpression(ExprMerchantRecipes.class, MerchantRecipe.class, ExpressionType.COMBINED, "[all] merchant recipes of %merchants/entities%", "merchant recipe %number% of %merchants/entities%");
+        Skript.registerExpression(ExprMerchantRecipes.class, MerchantRecipe.class, ExpressionType.COMBINED,
+                "[all] merchant recipes of %merchants/entities%",
+                "merchant recipe %number% of %merchants/entities%");
     }
 
     private Expression<?> merchants;
@@ -59,7 +63,10 @@ public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
                 recipes.add(merchant.getRecipe(recipe));
             }
         } else {
-            this.merchants.stream(event).filter(merchant -> merchant instanceof Merchant).map(merchant -> ((Merchant) merchant)).forEach(merchant -> recipes.addAll(merchant.getRecipes()));
+            for (Object obj : this.merchants.getArray(event)) {
+                if (!(obj instanceof Merchant merchant)) continue;
+                recipes.addAll(merchant.getRecipes());
+            }
         }
         return recipes.toArray(MerchantRecipe[]::new);
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipes.java
@@ -130,8 +130,10 @@ public class ExprMerchantRecipes extends SimpleExpression<MerchantRecipe> {
                     break;
                 case DELETE:
                     List<MerchantRecipe> updatedRecipes = new ArrayList<>(merchant.getRecipes());
-                    updatedRecipes.remove(merchant.getRecipe(recipeSlot));
-                    merchant.setRecipes(updatedRecipes);
+                    if (updatedRecipes.size() >= recipeSlot) {
+                        updatedRecipes.remove(recipeSlot);
+                        merchant.setRecipes(updatedRecipes);
+                    }
                     break;
             }
         }


### PR DESCRIPTION
Omg, where do I even start with this class. For starters this pr aims to fix the issue mentioned in #616. Somewhere within the 3 places `delta` was used there was cases where delta wasn't set, this seems most likely to stem from `delete` changer not existing but #616 proves it existed under the set changer as well.

## Bug Fix
Honestly I'm not 100% sure what the issue was but with how that class was actually set up it wouldn't shock me if a bitcoin miner existed inside it. however after messing around and cleaning it up it seems like the issue was solved and more proper checks were created. The systems internally were heavily a mess and melded together as such they've been split this allowed introduction of the `delete` change into `merchant recipe x of y` expression.


## Enhancements
This pr adds 2 *minor* enhancements first one being plural support, don't get me even started on how effing annoying this was to add but it's now added. Lastly similar to the nbt tag acceptchange method a new error message is now sent when using `add` outside of `merchant recipes of x` to further explain why it won't work. And you know what why not a third, docs now explicitly state you shouldn't be trying to set recipe of a non existent slot in the merchant that's what the add changer is for.

## Developer Note
In the future I believe it'll be best to implement a custom comparator for merchant recipes that can be used for more coherent comparisons. Since the merchant class doesn't override equals it follows the default usage which makes this fail rather than pass. I believe the comparator should compare result and ingredients while ignoring max uses, current uses, and other special values. If you believe enforcing those special values is the right direction, we can see in the future.
```
on load:
    set {_recipe1} to merchant recipe with result stone with max uses 10
    set {_recipe2} to merchant recipe with result stone with max uses 10
    set ingredients of merchant recipe {_recipe1} to bedrock and diamond
    set ingredients of merchant recipe {_recipe2} to bedrock and diamond
    if {_recipe1} is {_recipe2}:
        broadcast "They're the same damn thing"
    else:
        broadcast "It's one or the other guy man thing"
```
![image](https://github.com/ShaneBeee/SkBee/assets/81952476/d4f32c6f-cffa-4dbf-95ba-32891cca226d)
