### PR TITLE
dev/patch - Future Patch Release

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,20 +40,20 @@ jobs:
                     # A file, directory or wildcard pattern that describes what to upload
                     path: build/libs/SkBee*.jar
 
-#    test:
-#        runs-on: ubuntu-latest
-#        needs: [ build ]
-#        steps:
-#            -   name: Checkout repo
-#                uses: actions/checkout@v2
-#            -   name: Download artifacts
-#                uses: actions/download-artifact@v4
-#                with:
-#                    path: extra-plugins/
-#                    merge-multiple: true
-#            -   name: Run tests
-#                uses: SkriptLang/skript-test-action@v1.0
-#                with:
-#                    test_script_directory: src/test/scripts
-#                    skript_repo_ref: dev/patch
-#                    extra_plugins_directory: extra-plugins/
+    test:
+        runs-on: ubuntu-latest
+        needs: [ build ]
+        steps:
+            -   name: Checkout repo
+                uses: actions/checkout@v2
+            -   name: Download artifacts
+                uses: actions/download-artifact@v4
+                with:
+                    path: extra-plugins/
+                    merge-multiple: true
+            -   name: Run tests
+                uses: SkriptLang/skript-test-action@v1.1
+                with:
+                    test_script_directory: src/test/scripts
+                    skript_repo_ref: dev/patch
+                    extra_plugins_directory: extra-plugins/

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'maven-publish'
 }
 
+compileJava {
+    options.encoding = 'UTF-8'
+}
+
 // SkBee version
 version = '3.5.0'
 def latestJava = 21

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,6 @@ repositories {
 
     // CodeMC (NBT-API)
     maven { url 'https://repo.codemc.io/repository/maven-public/' }
-
-    // Adventure - Paper isn't including this?!?!
-    maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
 }
 
 dependencies {

--- a/src/main/java/com/shanebeestudios/skbee/api/listener/BoundBorderListener.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/listener/BoundBorderListener.java
@@ -1,10 +1,11 @@
 package com.shanebeestudios.skbee.api.listener;
 
+import ch.njol.skript.Skript;
 import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.bound.Bound;
 import com.shanebeestudios.skbee.api.event.bound.BoundEnterEvent;
 import com.shanebeestudios.skbee.api.event.bound.BoundExitEvent;
 import com.shanebeestudios.skbee.config.BoundConfig;
-import com.shanebeestudios.skbee.api.bound.Bound;
 import com.shanebeestudios.skbee.config.Config;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -25,202 +26,198 @@ import org.bukkit.event.vehicle.VehicleDestroyEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
+import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
 public class BoundBorderListener implements Listener {
 
-    private final SkBee plugin;
     private final BoundConfig boundConfig;
-    private final boolean PLAYER_MOVE;
-    private final boolean PLAYER_TELEPORT;
-    private final boolean PLAYER_BED_LEAVE;
-    private final boolean PLAYER_BED_ENTER;
-    private final boolean PLAYER_RESPAWN;
-    private final boolean ENTITY_MOUNT;
-    private final boolean ENTITY_DISMOUNT;
-    private final boolean VEHICLE_MOVE;
-    private final boolean VEHICLE_DESTROY;
-    private final boolean VEHICLE_EXIT;
-    private final boolean VEHICLE_ENTER;
+
+    // Bukkit 1.20.5 moved these events from Spigot package to Bukkit package
+    private static final boolean HAS_MOUNT_EVENT = Skript.classExists("org.bukkit.event.entity.EntityMountEvent");
+    private static final boolean HAS_DISMOUNT_EVENT = Skript.classExists("org.bukkit.event.entity.EntityDismountEvent");
 
     public BoundBorderListener(SkBee plugin) {
         Config config = plugin.getPluginConfig();
-        this.plugin = plugin;
         this.boundConfig = plugin.getBoundConfig();
-        this.PLAYER_MOVE = config.BOUND_EVENTS_PLAYER_MOVE;
-        this.PLAYER_TELEPORT = config.BOUND_EVENTS_PLAYER_TELEPORT;
-        this.PLAYER_RESPAWN = config.BOUND_EVENTS_PLAYER_RESPAWN;
-        this.PLAYER_BED_ENTER = config.BOUND_EVENTS_PLAYER_BED_ENTER;
-        this.PLAYER_BED_LEAVE = config.BOUND_EVENTS_PLAYER_BED_LEAVE;
-        this.ENTITY_MOUNT = config.BOUND_EVENTS_ENTITY_MOUNT;
-        this.ENTITY_DISMOUNT = config.BOUND_EVENTS_ENTITY_DISMOUNT;
-        this.VEHICLE_ENTER = config.BOUND_EVENTS_VEHICLE_ENTER;
-        this.VEHICLE_EXIT = config.BOUND_EVENTS_VEHICLE_EXIT;
-        this.VEHICLE_MOVE = config.BOUND_EVENTS_VEHICLE_MOVE;
-        this.VEHICLE_DESTROY = config.BOUND_EVENTS_VEHICLE_DESTROY;
+        setupListeners(plugin, config);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onBoundBorder(PlayerMoveEvent event) {
-        if (!this.PLAYER_MOVE) return;
-        Player player = event.getPlayer();
-        Location from = event.getFrom();
-        Location to = event.getTo();
-        if (preventBoundMovement(player, from, to)) {
-            event.setCancelled(true);
-            Entity vehicle = player.getVehicle();
-            if (vehicle != null) {
-                vehicle.removePassenger(player);
-                vehicle.teleport(from);
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onPlayerTeleport(PlayerTeleportEvent event) {
-        if (!this.PLAYER_TELEPORT) return;
-        Player player = event.getPlayer();
-        Location from = event.getFrom();
-        Location to = event.getTo();
-        if (preventBoundMovement(player, from, to, false)) {
-            event.setCancelled(true);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onRespawn(PlayerRespawnEvent event) {
-        if (!this.PLAYER_RESPAWN) return;
-        Player player = event.getPlayer();
-        Location from = player.getLocation();
-        Location to = event.getRespawnLocation();
-        if (preventBoundMovement(player, from, to)) {
-            event.setRespawnLocation(Bukkit.getWorlds().get(0).getSpawnLocation());
-            if (event.isBedSpawn() || event.isAnchorSpawn()) {
-                player.setBedSpawnLocation(null);
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onEnterBed(PlayerBedEnterEvent event) {
-        if (!this.PLAYER_BED_ENTER) return;
-        Player player = event.getPlayer();
-        Location from = player.getLocation();
-        Location to = event.getBed().getLocation();
-        if (preventBoundMovement(player, from, to)) {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onExitBed(PlayerBedLeaveEvent event) {
-        if (!this.PLAYER_BED_LEAVE) return;
-        Player player = event.getPlayer();
-        Location from = event.getBed().getLocation();
-        Bukkit.getScheduler().runTaskLater(this.plugin, () -> {
-            // Find player's new location after leaving bed
-            // have to add a delay as this isn't determinded in the event
-            Location to = player.getLocation();
-            if (preventBoundMovement(player, from, to)) {
-                player.teleport(from.clone().add(0, 1, 0));
-            }
-        }, 1);
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onMount(EntityMountEvent event) {
-        if (!this.ENTITY_MOUNT) return;
-        if (event.getEntity() instanceof Player player) {
-            Location from = player.getLocation();
-            Location to = event.getMount().getLocation();
-            if (preventBoundMovement(player, from, to)) {
-                event.setCancelled(true);
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onDismount(EntityDismountEvent event) {
-        if (!this.ENTITY_DISMOUNT) return;
-        if (event.getEntity() instanceof Player player) {
-            Location from = event.getDismounted().getLocation().clone();
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                Location to = player.getLocation();
-                if (preventBoundMovement(player, from, to)) {
-                    from.setYaw(player.getLocation().getYaw());
-                    from.setPitch(player.getLocation().getPitch());
-                    player.teleport(from);
-                }
-            }, 1);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onVehicleEnter(VehicleEnterEvent event) {
-        if (!this.VEHICLE_ENTER) return;
-        if (event.getEntered() instanceof Player player) {
-            Location from = player.getLocation();
-            Location to = event.getVehicle().getLocation();
-            if (preventBoundMovement(player, from, to)) {
-                event.setCancelled(true);
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onVehicleExit(VehicleExitEvent event) {
-        if (!this.VEHICLE_EXIT) return;
-        Location from = event.getVehicle().getLocation().clone();
-        if (event.getExited() instanceof Player player) {
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                Location to = player.getLocation();
-                if (preventBoundMovement(player, from, to)) {
-                    from.setYaw(player.getLocation().getYaw());
-                    from.setPitch(player.getLocation().getPitch());
-                    player.teleport(from);
-                }
-            }, 1);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onVehicleMove(VehicleMoveEvent event) {
-        if (!this.VEHICLE_MOVE) return;
-        Vehicle vehicle = event.getVehicle();
-        vehicle.getPassengers().forEach(entity -> {
-            if (entity instanceof Player player) {
-                Location from = event.getFrom().clone();
+    private void setupListeners(SkBee plugin, Config config) {
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        if (config.BOUND_EVENTS_PLAYER_MOVE) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onBoundBorder(PlayerMoveEvent event) {
+                Player player = event.getPlayer();
+                Location from = event.getFrom();
                 Location to = event.getTo();
                 if (preventBoundMovement(player, from, to)) {
-                    vehicle.removePassenger(player);
-                    // Keep the player looking the same direction
-                    from.setYaw(player.getLocation().getYaw());
-                    from.setPitch(player.getLocation().getPitch());
-                    player.teleport(from);
-                }
-            }
-        });
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    private void onVehicleDestroy(VehicleDestroyEvent event) {
-        if (!this.VEHICLE_DESTROY) return;
-        Location from = event.getVehicle().getLocation().clone();
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            for (Entity passenger : event.getVehicle().getPassengers()) {
-                Location to = passenger.getLocation();
-                if (passenger instanceof Player player) {
-                    if (preventBoundMovement(player, from, to)) {
-                        from.setYaw(player.getLocation().getYaw());
-                        from.setPitch(player.getLocation().getPitch());
-                        player.teleport(from);
+                    event.setCancelled(true);
+                    Entity vehicle = player.getVehicle();
+                    if (vehicle != null) {
+                        vehicle.removePassenger(player);
+                        vehicle.teleport(from);
                     }
                 }
             }
-        }, 1);
+        }, plugin);
+
+        if (config.BOUND_EVENTS_PLAYER_TELEPORT) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onPlayerTeleport(PlayerTeleportEvent event) {
+                Player player = event.getPlayer();
+                Location from = event.getFrom();
+                Location to = event.getTo();
+                if (preventBoundMovement(player, from, to, false)) {
+                    event.setCancelled(true);
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_PLAYER_RESPAWN) pluginManager.registerEvents(new Listener() {
+            @SuppressWarnings("deprecation")
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onRespawn(PlayerRespawnEvent event) {
+                Player player = event.getPlayer();
+                Location from = player.getLocation();
+                Location to = event.getRespawnLocation();
+                if (preventBoundMovement(player, from, to)) {
+                    event.setRespawnLocation(Bukkit.getWorlds().getFirst().getSpawnLocation());
+                    if (event.isBedSpawn() || event.isAnchorSpawn()) {
+                        player.setBedSpawnLocation(null);
+                    }
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_PLAYER_BED_ENTER) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onEnterBed(PlayerBedEnterEvent event) {
+                Player player = event.getPlayer();
+                Location from = player.getLocation();
+                Location to = event.getBed().getLocation();
+                if (preventBoundMovement(player, from, to)) {
+                    event.setCancelled(true);
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_PLAYER_BED_LEAVE) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onExitBed(PlayerBedLeaveEvent event) {
+                Player player = event.getPlayer();
+                Location from = event.getBed().getLocation();
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    // Find player's new location after leaving bed
+                    // have to add a delay as this isn't determinded in the event
+                    Location to = player.getLocation();
+                    if (preventBoundMovement(player, from, to)) {
+                        player.teleport(from.clone().add(0, 1, 0));
+                    }
+                }, 1);
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_ENTITY_MOUNT && HAS_MOUNT_EVENT) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onMount(EntityMountEvent event) {
+                if (event.getEntity() instanceof Player player) {
+                    Location from = player.getLocation();
+                    Location to = event.getMount().getLocation();
+                    if (preventBoundMovement(player, from, to)) {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_ENTITY_DISMOUNT && HAS_DISMOUNT_EVENT) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onDismount(EntityDismountEvent event) {
+                if (event.getEntity() instanceof Player player) {
+                    Location from = event.getDismounted().getLocation().clone();
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        Location to = player.getLocation();
+                        if (preventBoundMovement(player, from, to)) {
+                            from.setYaw(player.getLocation().getYaw());
+                            from.setPitch(player.getLocation().getPitch());
+                            player.teleport(from);
+                        }
+                    }, 1);
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_VEHICLE_ENTER) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onVehicleEnter(VehicleEnterEvent event) {
+                if (event.getEntered() instanceof Player player) {
+                    Location from = player.getLocation();
+                    Location to = event.getVehicle().getLocation();
+                    if (preventBoundMovement(player, from, to)) {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_VEHICLE_EXIT) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onVehicleExit(VehicleExitEvent event) {
+                Location from = event.getVehicle().getLocation().clone();
+                if (event.getExited() instanceof Player player) {
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        Location to = player.getLocation();
+                        if (preventBoundMovement(player, from, to)) {
+                            from.setYaw(player.getLocation().getYaw());
+                            from.setPitch(player.getLocation().getPitch());
+                            player.teleport(from);
+                        }
+                    }, 1);
+                }
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_VEHICLE_MOVE) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onVehicleMove(VehicleMoveEvent event) {
+                Vehicle vehicle = event.getVehicle();
+                vehicle.getPassengers().forEach(entity -> {
+                    if (entity instanceof Player player) {
+                        Location from = event.getFrom().clone();
+                        Location to = event.getTo();
+                        if (preventBoundMovement(player, from, to)) {
+                            vehicle.removePassenger(player);
+                            // Keep the player looking the same direction
+                            from.setYaw(player.getLocation().getYaw());
+                            from.setPitch(player.getLocation().getPitch());
+                            player.teleport(from);
+                        }
+                    }
+                });
+            }
+        }, plugin);
+
+        if (config.BOUND_EVENTS_VEHICLE_DESTROY) pluginManager.registerEvents(new Listener() {
+            @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+            private void onVehicleDestroy(VehicleDestroyEvent event) {
+                Location from = event.getVehicle().getLocation().clone();
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    for (Entity passenger : event.getVehicle().getPassengers()) {
+                        Location to = passenger.getLocation();
+                        if (passenger instanceof Player player) {
+                            if (preventBoundMovement(player, from, to)) {
+                                from.setYaw(player.getLocation().getYaw());
+                                from.setPitch(player.getLocation().getPitch());
+                                player.teleport(from);
+                            }
+                        }
+                    }
+                }, 1);
+            }
+        }, plugin);
     }
 
     private boolean preventBoundMovement(@NotNull Player player, @NotNull Location from, @NotNull Location to) {

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
@@ -40,7 +40,6 @@ public class NBTApi {
     @SuppressWarnings("ConstantConditions")
     private static boolean ENABLED;
     private static boolean DEBUG;
-    private static boolean ADMIN_ERROR;
     public static final boolean HAS_ITEM_COMPONENTS = Skript.isRunningMinecraft(1, 20, 5);
     static final String TAG_NAME = HAS_ITEM_COMPONENTS ? "components" : "tag";
 
@@ -65,7 +64,6 @@ public class NBTApi {
         }
         Config pluginConfig = SkBee.getPlugin().getPluginConfig();
         DEBUG = pluginConfig.SETTINGS_DEBUG;
-        ADMIN_ERROR = pluginConfig.NBT_ADMIN_ERRORS;
     }
 
     /**
@@ -104,9 +102,7 @@ public class NBTApi {
                 cause = cause.replace("com.mojang.brigadier.exceptions.CommandSyntaxException", "MalformedNBT");
                 Util.skriptError("&cMessage: &e%s", cause);
             }
-            if (ADMIN_ERROR) {
-                Util.errorForAdmins("Invalid NBT, please check console for more details.");
-            }
+            Util.errorForAdmins("Invalid NBT, please check console for more details.");
             return null;
         }
         return compound;

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
@@ -6,6 +6,7 @@ import ch.njol.skript.registrations.Classes;
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.Pair;
 import com.shanebeestudios.skbee.api.util.Util;
+import com.shanebeestudios.skbee.config.Config;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTCompoundList;
 import de.tr7zw.changeme.nbtapi.NBTContainer;
@@ -39,6 +40,7 @@ public class NBTApi {
     @SuppressWarnings("ConstantConditions")
     private static boolean ENABLED;
     private static boolean DEBUG;
+    private static boolean ADMIN_ERROR;
     public static final boolean HAS_ITEM_COMPONENTS = Skript.isRunningMinecraft(1, 20, 5);
     static final String TAG_NAME = HAS_ITEM_COMPONENTS ? "components" : "tag";
 
@@ -61,7 +63,9 @@ public class NBTApi {
             new NBTContainer("{a:1}").toString();
             ENABLED = true;
         }
-        DEBUG = SkBee.getPlugin().getPluginConfig().SETTINGS_DEBUG;
+        Config pluginConfig = SkBee.getPlugin().getPluginConfig();
+        DEBUG = pluginConfig.SETTINGS_DEBUG;
+        ADMIN_ERROR = pluginConfig.NBT_ADMIN_ERRORS;
     }
 
     /**
@@ -100,7 +104,9 @@ public class NBTApi {
                 cause = cause.replace("com.mojang.brigadier.exceptions.CommandSyntaxException", "MalformedNBT");
                 Util.skriptError("&cMessage: &e%s", cause);
             }
-            Util.errorForAdmins("Invalid NBT, please check console for more details.");
+            if (ADMIN_ERROR) {
+                Util.errorForAdmins("Invalid NBT, please check console for more details.");
+            }
             return null;
         }
         return compound;

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
@@ -274,10 +274,13 @@ public class NBTApi {
 
         Object singleObject = object[0];
         switch (type) {
-            case NBTTagByte:
+            case NBTTagBoolean:
                 if (singleObject instanceof Boolean bool) {
-                    compound.setByte(tag, (byte) (bool ? 1 : 0));
-                } else if (singleObject instanceof Number number) {
+                    compound.setBoolean(tag, bool);
+                }
+                break;
+            case NBTTagByte:
+                if (singleObject instanceof Number number) {
                     compound.setByte(tag, number.byteValue());
                 }
                 break;
@@ -773,6 +776,9 @@ public class NBTApi {
                     }
                 } catch (NbtApiException ignore) {
                 }
+            }
+            case NBTTagBoolean -> {
+                return compound.getBoolean(tag);
             }
             case NBTTagByte -> {
                 return compound.getByte(tag);

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
@@ -27,6 +27,7 @@ public enum NBTCustomType {
     NBTTagCompound("compound", NBTType.NBTTagCompound, NBTCompound.class),
     // Custom
     NBTTagUUID("uuid", NBTType.NBTTagIntArray, String.class),
+    NBTTagBoolean("boolean", NBTType.NBTTagByte, Boolean.class),
     // Lists and Arrays
     NBTTagByteArray("byte array", NBTType.NBTTagByteArray, Number[].class),
     NBTTagIntArray("int array", NBTType.NBTTagIntArray, Number[].class),

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.util.StringUtils;
 import com.shanebeestudios.skbee.api.reflection.ReflectionUtils;
+import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -141,6 +142,8 @@ public class ParticleUtil {
             return "number(int)";
         } else if (dataType == Float.class) {
             return "number(float)";
+        } else if (dataType == Color.class) {
+            return "color";
         }
         // For future particle data additions that haven't been added here yet
         return "UNKNOWN";
@@ -182,6 +185,8 @@ public class ParticleUtil {
             return data;
         } else if (dataType == Vibration.class && data instanceof Vibration) {
             return data;
+        } else if (dataType == Color.class && data instanceof ch.njol.skript.util.Color skriptColor) {
+            return skriptColor.asBukkitColor();
         } else if (dataType == BlockData.class) {
             if (data instanceof BlockData) {
                 return data;

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.util.StringUtils;
 import com.shanebeestudios.skbee.api.reflection.ReflectionUtils;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -146,6 +147,7 @@ public class ParticleUtil {
             return "color";
         }
         // For future particle data additions that haven't been added here yet
+        Util.debug("Missing particle data type: '&e" + dataType.getName() + "&7'");
         return "UNKNOWN";
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -144,7 +144,7 @@ public class ParticleUtil {
         } else if (dataType == Float.class) {
             return "number(float)";
         } else if (dataType == Color.class) {
-            return "color";
+            return "color/bukkitcolor";
         }
         // For future particle data additions that haven't been added here yet
         Util.debug("Missing particle data type: '&e" + dataType.getName() + "&7'");
@@ -189,6 +189,8 @@ public class ParticleUtil {
             return data;
         } else if (dataType == Color.class && data instanceof ch.njol.skript.util.Color skriptColor) {
             return skriptColor.asBukkitColor();
+        } else if (dataType == Color.class && data instanceof Color) {
+            return data;
         } else if (dataType == BlockData.class) {
             if (data instanceof BlockData) {
                 return data;

--- a/src/main/java/com/shanebeestudios/skbee/api/util/ObjectConverter.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/ObjectConverter.java
@@ -39,6 +39,7 @@ import java.util.Map;
  *
  * @param <T> {@link ClassInfo} class for conversion type
  */
+@SuppressWarnings("deprecation")
 public abstract class ObjectConverter<T> {
 
     private static final Map<Class<?>, ObjectConverter<?>> CONVERTERS = new HashMap<>();

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -2,6 +2,7 @@ package com.shanebeestudios.skbee.api.util;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.log.ErrorQuality;
+import ch.njol.skript.util.Version;
 import com.shanebeestudios.skbee.SkBee;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
@@ -30,6 +31,9 @@ public class Util {
 
     // QuickLinks
     public static final String MCWIKI_TICK_COMMAND = "See [**Tick Command**](https://minecraft.wiki/w/Commands/tick) on McWiki for more details.";
+
+    // Shortcut for finding stuff to remove later
+    public static final boolean IS_RUNNING_SKRIPT_2_9 = Skript.getVersion().compareTo(new Version(2,9)) <= 0;
 
     @SuppressWarnings("deprecation") // Paper deprecation
     public static String getColString(String string) {

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -29,7 +29,7 @@ public class Util {
     private static final String SETTINGS_NAMESPACE = SkBee.getPlugin().getPluginConfig().SETTINGS_NAMESPACE;
 
     // QuickLinks
-    public static final String MCWIKI_TICK_COMMAND = "See <link>https://minecraft.wiki/w/Commands/tick</link> for more details.";
+    public static final String MCWIKI_TICK_COMMAND = "See [**Tick Command**](https://minecraft.wiki/w/Commands/tick) on McWiki for more details.";
 
     @SuppressWarnings("deprecation") // Paper deprecation
     public static String getColString(String string) {

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/ComponentWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/ComponentWrapper.java
@@ -499,8 +499,12 @@ public class ComponentWrapper {
      * @param alwaysVisible Whether or not always visible
      */
     public void setEntityName(Entity entity, boolean alwaysVisible) {
-        entity.customName(this.component);
-        entity.setCustomNameVisible(alwaysVisible);
+        if (entity instanceof Player player && alwaysVisible) {
+            player.displayName(this.component);
+        } else {
+            entity.customName(this.component);
+            entity.setCustomNameVisible(alwaysVisible);
+        }
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryWrapper.java
@@ -22,7 +22,7 @@ import java.util.List;
  *
  * @param <T> Type of item in the registry
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public class RegistryWrapper<T extends Keyed> {
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -21,7 +21,6 @@ public class Config {
     public String SETTINGS_NAMESPACE;
     public boolean SETTINGS_SCOREBOARD_LINES;
     public boolean ELEMENTS_NBT;
-    public boolean NBT_ADMIN_ERRORS;
     public boolean NBT_EVENTS_BREAK_BLOCK;
     public boolean NBT_EVENTS_PISTON_EXTEND;
     public boolean NBT_EVENTS_ENTITY_CHANGE_BLOCK;
@@ -137,7 +136,6 @@ public class Config {
         this.SETTINGS_SCOREBOARD_LINES = getSetting("scoreboard-reverse-lines");
 
         this.ELEMENTS_NBT = getElement("nbt");
-        this.NBT_ADMIN_ERRORS = getElement("nbt-admin-errors");
         this.NBT_EVENTS_BREAK_BLOCK = getNBTEvent("block-break");
         this.NBT_EVENTS_PISTON_EXTEND = getNBTEvent("piston-extend");
         this.NBT_EVENTS_ENTITY_CHANGE_BLOCK = getNBTEvent("entity-change-block");

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -21,6 +21,7 @@ public class Config {
     public String SETTINGS_NAMESPACE;
     public boolean SETTINGS_SCOREBOARD_LINES;
     public boolean ELEMENTS_NBT;
+    public boolean NBT_ADMIN_ERRORS;
     public boolean NBT_EVENTS_BREAK_BLOCK;
     public boolean NBT_EVENTS_PISTON_EXTEND;
     public boolean NBT_EVENTS_ENTITY_CHANGE_BLOCK;
@@ -136,6 +137,7 @@ public class Config {
         this.SETTINGS_SCOREBOARD_LINES = getSetting("scoreboard-reverse-lines");
 
         this.ELEMENTS_NBT = getElement("nbt");
+        this.NBT_ADMIN_ERRORS = getElement("nbt-admin-errors");
         this.NBT_EVENTS_BREAK_BLOCK = getNBTEvent("block-break");
         this.NBT_EVENTS_PISTON_EXTEND = getNBTEvent("piston-extend");
         this.NBT_EVENTS_ENTITY_CHANGE_BLOCK = getNBTEvent("entity-change-block");

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementCriteriaAward.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/effects/EffAdvancementCriteriaAward.java
@@ -11,8 +11,8 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Advancement - Progress Criteria")
 @Description("Award or revoke criteria of an advancement progress.")
@@ -22,7 +22,7 @@ public class EffAdvancementCriteriaAward extends Effect {
 
     static {
         Skript.registerEffect(EffAdvancementCriteriaAward.class,
-                "(award|1¦revoke) criteria %string% of %advancementpros%");
+                "(award|1:revoke) criteria %string% of %advancementpros%");
     }
 
     private boolean award;

--- a/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgressAwarded.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/advancement/expressions/ExprAdvancementProgressAwarded.java
@@ -12,8 +12,8 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Advancement - Progress Criteria")
 @Description("Get the awarded/remaining criteria of an advancement progress.")
@@ -23,7 +23,7 @@ public class ExprAdvancementProgressAwarded extends SimpleExpression<String> {
 
     static {
         Skript.registerExpression(ExprAdvancementProgressAwarded.class, String.class, ExpressionType.SIMPLE,
-                "(awarded|1¦remaining) criteria of %advancementpro%");
+                "(awarded|1:remaining) criteria of %advancementpro%");
     }
 
     private boolean awarded;

--- a/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarByID.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarByID.java
@@ -20,16 +20,16 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("BossBar - From ID")
-@Description("Get a BossBar from ID.")
+@Description("Get an already created BossBar from ID (this will NOT create a new one).")
 @Examples({"delete boss bar with id \"le-bar\"",
-        "set {_bar} to boss bar with id \"le-bar\"",
-        "add all players to {_bar}"})
+    "set {_bar} to boss bar with id \"le-bar\"",
+    "add all players to {_bar}"})
 @Since("2.14.1")
 public class ExprBossBarByID extends SimpleExpression<BossBar> {
 
     static {
         Skript.registerExpression(ExprBossBarByID.class, BossBar.class, ExpressionType.COMBINED,
-                "boss[ ]bar (named|with id|from id) %string%");
+            "boss[ ]bar (named|with id|from id) %string%");
     }
 
     private Expression<String> key;
@@ -43,7 +43,7 @@ public class ExprBossBarByID extends SimpleExpression<BossBar> {
 
     @SuppressWarnings("NullableProblems")
     @Override
-    protected @Nullable BossBar[] get(Event event) {
+    protected BossBar @Nullable [] get(Event event) {
         String name = this.key.getSingle(event);
         if (name == null) return null;
         NamespacedKey key = Util.getNamespacedKey(name, true);
@@ -65,7 +65,7 @@ public class ExprBossBarByID extends SimpleExpression<BossBar> {
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(Event e, boolean d) {
         return "bossbar with id " + this.key.toString(e, d);
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundCoords.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundCoords.java
@@ -14,12 +14,12 @@ import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.SkBee;
-import com.shanebeestudios.skbee.config.BoundConfig;
-import org.bukkit.World;
-import org.bukkit.event.Event;
 import com.shanebeestudios.skbee.api.bound.Bound;
 import com.shanebeestudios.skbee.api.bound.Bound.Axis;
 import com.shanebeestudios.skbee.api.bound.Bound.Corner;
+import com.shanebeestudios.skbee.config.BoundConfig;
+import org.bukkit.World;
+import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 @Name("Bound - Coords")
@@ -32,8 +32,8 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
 
     static {
         Skript.registerExpression(ExprBoundCoords.class, Object.class, ExpressionType.PROPERTY,
-                "lesser (0¦x|1¦y|2¦z) coord[inate] of [bound] %bound%",
-                "greater (0¦x|1¦y|2¦z) coord[inate] of [bound] %bound%",
+                "lesser (x|1:y|2:z) coord[inate] of [bound] %bound%",
+                "greater (x|1:y|2:z) coord[inate] of [bound] %bound%",
                 "world of bound %bound%");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundOwnerMember.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundOwnerMember.java
@@ -36,7 +36,7 @@ public class ExprBoundOwnerMember extends SimpleExpression<OfflinePlayer> {
 
     static {
         Skript.registerExpression(ExprBoundOwnerMember.class, OfflinePlayer.class, ExpressionType.PROPERTY,
-                "bound (owner[s]|1¦member[s]) of %bound%");
+                "bound (owner[s]|1:member[s]) of %bound%");
     }
 
     private Expression<Bound> bound;

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundValue.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundValue.java
@@ -20,8 +20,8 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Bound - Values")
 @Description({"Get/set/delete custom values for bounds.",
@@ -43,7 +43,7 @@ public class ExprBoundValue extends SimpleExpression<Object> {
     static {
         Skript.registerExpression(ExprBoundValue.class, Object.class, ExpressionType.COMBINED,
                 "bound value %string% (of|from) %bound%",
-                "all [[of] the] bound (values|1¦keys) (of|from) %bound%");
+                "all [[of] the] bound (values|1:keys) (of|from) %bound%");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/damagesource/expressions/ExprDamageSourceEvent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/damagesource/expressions/ExprDamageSourceEvent.java
@@ -14,28 +14,38 @@ import ch.njol.util.Kleenean;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("DamageSource - Event Value")
-@Description("Get the damage source of a damage event.")
+@Description("Get the damage source of a damage/death event.")
 @Examples({"on damage of player:",
-        "\tif damage type of damage source = arrow:",
-        "\t\tbroadcast \"OUCHIE\"",
-        "\tif causing entity of damage source is a chicken:",
-        "\t\tbroadcast \"YOU JERK\""})
+    "\tif damage type of damage source = arrow:",
+    "\t\tbroadcast \"OUCHIE\"",
+    "\tif causing entity of damage source is a chicken:",
+    "\t\tbroadcast \"YOU JERK\""})
 @Since("3.3.0")
 public class ExprDamageSourceEvent extends SimpleExpression<DamageSource> {
 
+    private static final boolean DEATH_EVENT_HAS_DAMAGE_SOURCE = Skript.methodExists(EntityDeathEvent.class, "getDamageSource");
+
     static {
         Skript.registerExpression(ExprDamageSourceEvent.class, DamageSource.class, ExpressionType.SIMPLE,
-                "damage source");
+            "[the] damage source");
     }
 
     @SuppressWarnings("NullableProblems")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        return ParserInstance.get().isCurrentEvent(EntityDamageEvent.class);
+        if (DEATH_EVENT_HAS_DAMAGE_SOURCE) {
+            if (ParserInstance.get().isCurrentEvent(EntityDamageEvent.class, EntityDeathEvent.class)) return true;
+            Skript.error("'damage source' can only be used in a death/damage event");
+            return false;
+        }
+        if (ParserInstance.get().isCurrentEvent(EntityDamageEvent.class)) return true;
+        Skript.error("'damage source' can only be used in a damage event");
+        return false;
     }
 
     @SuppressWarnings("NullableProblems")
@@ -43,6 +53,8 @@ public class ExprDamageSourceEvent extends SimpleExpression<DamageSource> {
     protected DamageSource @Nullable [] get(Event event) {
         if (event instanceof EntityDamageEvent entityDamageEvent) {
             return new DamageSource[]{entityDamageEvent.getDamageSource()};
+        } else if (DEATH_EVENT_HAS_DAMAGE_SOURCE && event instanceof EntityDeathEvent entityDeathEvent) {
+            return new DamageSource[]{entityDeathEvent.getDamageSource()};
         }
         return null;
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/damagesource/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/damagesource/type/Types.java
@@ -18,7 +18,7 @@ public class Types {
                     .user("damage ?types?")
                     .name("Damage Type")
                     .description("Represents a type of damage.",
-                        "See <link>https://minecraft.wiki/w/Damage_type</link> for more details.",
+                        "See [**DamageType**](https://minecraft.wiki/w/Damage_type) on McWiki for more details.",
                         "Requires MC 1.20.4+",
                         "NOTE: These are auto-generated and may differ between server versions.")
                     .usage(DAMAGE_TYPE_REGISTRY.getNames())

--- a/src/main/java/com/shanebeestudios/skbee/elements/display/types/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/display/types/Types.java
@@ -11,7 +11,6 @@ import ch.njol.skript.registrations.DefaultClasses;
 import com.shanebeestudios.skbee.api.util.MathUtil;
 import com.shanebeestudios.skbee.api.util.SkriptUtils;
 import com.shanebeestudios.skbee.api.wrapper.EnumWrapper;
-import org.bukkit.Color;
 import org.bukkit.entity.Display.Billboard;
 import org.bukkit.entity.Display.Brightness;
 import org.bukkit.entity.ItemDisplay.ItemDisplayTransform;
@@ -73,35 +72,6 @@ public class Types {
                 .parser(SkriptUtils.getDefaultParser());
         Classes.registerClass(TRANSFORMATION);
 
-        Classes.registerClass(new ClassInfo<>(Color.class, "bukkitcolor")
-                .user("bukkit ?colors?")
-                .name("Bukkit Color")
-                .description("Represents a Bukkit color. This is different than a Skript color",
-                        "as it adds an alpha channel.")
-                .since("2.8.0")
-                .parser(new Parser<>() {
-
-                    @SuppressWarnings("NullableProblems")
-                    @Override
-                    public boolean canParse(ParseContext context) {
-                        return false;
-                    }
-
-                    @Override
-                    public @NotNull String toString(Color bukkitColor, int flags) {
-                        int alpha = bukkitColor.getAlpha();
-                        int red = bukkitColor.getRed();
-                        int green = bukkitColor.getGreen();
-                        int blue = bukkitColor.getBlue();
-                        return String.format("BukkitColor(a=%s,r=%s,g=%s,b=%s)", alpha, red, green, blue);
-                    }
-
-                    @Override
-                    public @NotNull String toVariableNameString(Color bukkitColor) {
-                        return toString(bukkitColor, 0);
-                    }
-                }));
-
         QUATERNION = new ClassInfo<>(Quaternionf.class, "quaternion")
                 .user("quaternions?")
                 .name("Quaternion")
@@ -156,32 +126,6 @@ public class Types {
                 .description("Creates a new display brightness object for use on a Display Entity.",
                         "Number values must be between 0 and 15.", McWIKI)
                 .examples("set {_db} to displayBrightness(10,10)")
-                .since("2.8.0"));
-
-        //noinspection DataFlowIssue
-        Functions.registerFunction(new SimpleJavaFunction<>("bukkitColor", new Parameter[]{
-                new Parameter<>("alpha", DefaultClasses.NUMBER, true, null),
-                new Parameter<>("red", DefaultClasses.NUMBER, true, null),
-                new Parameter<>("green", DefaultClasses.NUMBER, true, null),
-                new Parameter<>("blue", DefaultClasses.NUMBER, true, null)
-        }, Classes.getExactClassInfo(Color.class), true) {
-            @SuppressWarnings("NullableProblems")
-            @Override
-            public @Nullable Color[] executeSimple(Object[][] params) {
-                int alpha = ((Number) params[0][0]).intValue();
-                int red = ((Number) params[1][0]).intValue();
-                int green = ((Number) params[2][0]).intValue();
-                int blue = ((Number) params[3][0]).intValue();
-                alpha = MathUtil.clamp(alpha, 0, 255);
-                red = MathUtil.clamp(red, 0, 255);
-                green = MathUtil.clamp(green, 0, 255);
-                blue = MathUtil.clamp(blue, 0, 255);
-                return new Color[]{Color.fromARGB(alpha, red, green, blue)};
-            }
-        }
-                .description("Creates a new Bukkit Color using alpha, red, green and blue channels.",
-                        "Number values must be between 0 and 255.")
-                .examples("set {_color} to bukkitColor(50,155,100,10)")
                 .since("2.8.0"));
 
         Functions.registerFunction(new SimpleJavaFunction<>("vector4", new Parameter[]{

--- a/src/main/java/com/shanebeestudios/skbee/elements/display/types/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/display/types/Types.java
@@ -26,8 +26,8 @@ import org.joml.Vector3f;
 
 public class Types {
 
-    public static final String McWIKI = "See <link>https://minecraft.wiki/w/Display#Entity_data</link> for more details.";
-    public static final String McWiki_INTERACTION = "See <link>https://minecraft.wiki/w/Interaction#Entity_data</link> for more details.";
+    public static final String McWIKI = "See [**Display Entity Data**](https://minecraft.wiki/w/Display#Entity_data) on McWiki for more details.";
+    public static final String McWiki_INTERACTION = "See [**Interaction Entity Data**](https://minecraft.wiki/w/Interaction#Entity_data) on McWiki for more details.";
     public static ClassInfo<Transformation> TRANSFORMATION;
     public static ClassInfo<Quaternionf> QUATERNION;
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/gameevent/type/Types.java
@@ -36,7 +36,7 @@ public class Types {
             .name("Game Event")
             .user("game ?events?")
             .description("Represents a Minecraft 'GameEvent', mainly used by Skulk Sensors. Requires MC 1.17+.",
-                "See McWiki for more details -> https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes",
+                "See [**GameEvents**](https://minecraft.wiki/w/Sculk_Sensor#Vibration_amplitudes) on McWiki for more details.",
                 "NOTE: These are auto-generated and may differ between server versions.")
             .usage(namesString)
             .after("itemtype")

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/structure/StrucChunkGen.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/structure/StrucChunkGen.java
@@ -44,7 +44,7 @@ import org.skriptlang.skript.lang.structure.Structure;
         "NOTES:",
         "- `chunk-generator` needs to be enabled in the config (disabled by default)",
         "- `world-creator` needs to be enabled in the config",
-        "- Please see the Chunk Generator wiki for further details <link>https://github.com/ShaneBeee/SkBee/wiki/Chunk-Generator</link>"})
+        "- Please see the [**Chunk Generator**](https://github.com/ShaneBeee/SkBee/wiki/Chunk-Generator) wiki for further details."})
 @Examples({"register chunk generator with id \"mars\":",
         "\tvanilla decor: false",
         "\tvanilla caves: false",

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprNBTUuid.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprNBTUuid.java
@@ -10,11 +10,11 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
-import com.shanebeestudios.skbee.api.util.Util;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class ExprNBTUuid extends SimpleExpression<Object> {
 
     static {
         Skript.registerExpression(ExprNBTUuid.class, Object.class, ExpressionType.SIMPLE,
-                "uuid (int array[(1¦ as string)]|2¦most[ bits]|3¦least[ bits]) [(from|of) %-offlineplayer/entity%]");
+                "uuid (int array[(1: as string)]|2:most[ bits]|3:least[ bits]) [(from|of) %-offlineplayer/entity%]");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprNbtCompound.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprNbtCompound.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.NotNull;
     "\\- (1.20.4-) This will return the 'tag' portion of an items full NBT.",
     "\\- (1.20.5+) This will return the 'minecraft:custom_data' component container of an item's NBT.",
     "`components nbt of %item%` = Returns the components container of an item's NBT. Modifying this will modify the original item. (This is an MC 1.20.5+ feature).",
-    "Please see <link>https://minecraft.wiki/w/Data_component_format</link> for more information on item NBT components.",
+    "Please see [**Data Component Format**](https://minecraft.wiki/w/Data_component_format) on McWiki for more information on item NBT components.",
     "`nbt copy of %objects%` = Returns a copy of the original NBT compound. This way you can modify it without",
     "actually modifying the original NBT compound, for example when grabbing the compound from an entity, modifying it and applying to other entities.",
     "",

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
@@ -83,15 +83,18 @@ import java.util.ArrayList;
     "set {_b} to byte tag \"someBytes[10]\" of {_nbt}",
     "",
     "# Minecraft 1.20.5+ item component stuff",
-    "set int tag \"minecraft:max_damage\" of nbt of player's tool to 500",
-    "set int tag \"minecraft:max_stack_size\" of nbt of player's tool to 25",
-    "set byte tag \"minecraft:enchantment_glint_override\" of nbt of player's tool to 1",
-    "set compound tag \"minecraft:fire_resistant\" of nbt of player's tool to nbt from \"{}\"",
-    "set string tag \"minecraft:rarity\" of nbt of player's tool to \"epic\"",
+    "set int tag \"minecraft:max_damage\" of component nbt of player's tool to 500",
+    "set int tag \"minecraft:max_stack_size\" of component nbt of player's tool to 25",
+    "set byte tag \"minecraft:enchantment_glint_override\" of component nbt of player's tool to 1",
+    "set compound tag \"minecraft:fire_resistant\" of component nbt of player's tool to nbt from \"{}\"",
+    "set string tag \"minecraft:rarity\" of component nbt of player's tool to \"epic\"",
     "",
     "# All custom data must be within the \"minecraft:custom_data\" compound",
-    "set byte tag \"minecraft:custom_data;Points\" of nbt of player's tool to 10",
-    "set int tag \"minecraft:custom_data;MyBloop\" of nbt of player's tool to 152"})
+    "# See NBT Compound expression for futher details on the `component nbt` expression",
+    "set byte tag \"Points\" of nbt of player's tool to 10",
+    "set int tag \"MyBloop\" of nbt of player's tool to 152",
+    "set byte tag \"minecraft:custom_data;Points\" of component nbt of player's tool to 10",
+    "set int tag \"minecraft:custom_data;MyBloop\" of component nbt of player's tool to 152"})
 @Since("1.0.0")
 public class ExprTagOfNBT extends SimpleExpression<Object> {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
@@ -29,9 +29,9 @@ import java.util.ArrayList;
     "\nNOTE: Entities/blocks can not natively hold custom NBT tags. SkBee allows you to put custom nbt",
     "data in the \"custom\" compound tag of a block/entity's NBT compound. Due to Minecraft not supporting this, I had to use some hacky methods to make this happen.",
     "That said, this system is a tad convoluted, see the SkBee WIKI for more details.",
-    "\nNOTE 1.20.5+: All custom data on items must be stored in the \"minecraft:custom_data\" compound ",
-    "(see examples and McWiki <link>https://minecraft.wiki/w/Data_component_format#custom_data</link>).",
-    "For more info regarding 1.20.5+ components please see McWiki <link>https://minecraft.wiki/w/Data_component_format</link>.",
+    "\nNOTE 1.20.5+: All custom data on items must be stored in the \"minecraft:custom_data\" compound " +
+    "(see examples and [**McWiki**](https://minecraft.wiki/w/Data_component_format#custom_data)).",
+    "For more info regarding 1.20.5+ components please see [**Data Component Format**](https://minecraft.wiki/w/Data_component_format) on McWiki.",
     "\nADD: You can add numbers to number type tags, you can also add numbers/strings/compounds to lists type tags.",
     "\nREMOVE: You can remove numbers from number type tags, you can also remove numbers/strings from lists type tags.",
     "(You can NOT remove compounds from lists type tags)",

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/types/SkriptTypes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/types/SkriptTypes.java
@@ -57,8 +57,8 @@ public class SkriptTypes {
                 .name("NBT - Tag Type")
                 .description("Represents a type of NBT tag.",
                         "You can read more about NBT types:",
-                        "\nMcWiki <link>https://minecraft.wiki/w/NBT_format#Data_types</link>",
-                        "\nSkBee Wiki <link>https://github.com/ShaneBeee/SkBee/wiki/NBT-Intro#datatypes-in-nbt</link>")
+                        "\nMcWiki [**NBT Data Types**](https://minecraft.wiki/w/NBT_format#Data_types)",
+                        "\nSkBee Wiki [**NBT Data Types**](https://github.com/ShaneBeee/SkBee/wiki/NBT-Intro#datatypes-in-nbt)")
                 .usage(NBTCustomType.getNames())
                 .examples("set byte tag \"points\" of {_nbt} to 1",
                         "set compound tag \"tool\" of {_nbt} to nbt compound of player's tool")

--- a/src/main/java/com/shanebeestudios/skbee/elements/objective/expressions/ExprCriteriaCreate.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/objective/expressions/ExprCriteriaCreate.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Name("Scoreboard - Criteria Create")
 @Description({"Get one of the default Minecraft scoreboard criterias",
-        "(see McWiki <link>https://minecraft.wiki/w/Scoreboard#Criteria</link>) or create your own."})
+        "(see [**Scoreboard Criteria**](https://minecraft.wiki/w/Scoreboard#Criteria) on McWiki) or create your own."})
 @Examples("set {_c} to criteria with id \"health\"")
 @Since("2.6.0")
 public class ExprCriteriaCreate extends SimpleExpression<Criteria> {

--- a/src/main/java/com/shanebeestudios/skbee/elements/objective/expressions/ExprObjNumberFormat.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/objective/expressions/ExprObjNumberFormat.java
@@ -31,7 +31,7 @@ import java.util.List;
     "`set` = You can set the format to any string you'd like (fixed) or a json component (styled number).",
     "`delete` = Will leave it blank (nothing will be there, just nothing).",
     "`reset` = Will reset back to its original format.",
-    "Json Formatting: <link>https://minecraft.wiki/w/Raw_JSON_text_format</link>",
+    "See [**Json Formatting**](https://minecraft.wiki/w/Raw_JSON_text_format) on McWiki for more details.",
     "Requires Paper 1.20.4+"})
 @Examples({"# Format to a string",
     "set number format of {-obj} to \"Look Im Fancy!!\"",

--- a/src/main/java/com/shanebeestudios/skbee/elements/objective/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/objective/type/Types.java
@@ -67,7 +67,7 @@ public class Types {
                     .user("criterias?")
                     .name("Scoreboard - Criteria")
                     .description("Represents a criteria for a scoreboard objective.",
-                            "More info: <link>https://minecraft.wiki/w/Scoreboard#Criteria</link>")
+                            "See [**Scoreboard Criteria**](https://minecraft.wiki/w/Scoreboard#Criteria) on McWiki for more details.")
                     .since("2.6.0")
                     .parser(new Parser<>() {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondPlayerIsConnected.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/conditions/CondPlayerIsConnected.java
@@ -6,6 +6,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 public class CondPlayerIsConnected extends PropertyCondition<OfflinePlayer> {
 
     static {
-       if (Skript.methodExists(OfflinePlayer.class, "isConnected")) {
+       if (Skript.methodExists(OfflinePlayer.class, "isConnected") && !Util.IS_RUNNING_SKRIPT_2_9) {
            register(CondPlayerIsConnected.class, PropertyType.BE, "connected", "offlineplayers");
        }
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
@@ -23,6 +23,7 @@ import io.papermc.paper.event.packet.PlayerChunkLoadEvent;
 import io.papermc.paper.event.packet.PlayerChunkUnloadEvent;
 import io.papermc.paper.event.player.PlayerChangeBeaconEffectEvent;
 import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
+import io.papermc.paper.event.player.PlayerTrackEntityEvent;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -368,6 +369,27 @@ public class PaperEvents extends SimpleEvent {
                 @Override
                 public Item get(PlayerAttemptPickupItemEvent event) {
                     return event.getItem();
+                }
+            }, EventValues.TIME_NOW);
+        }
+
+        // PlayerTrackEntityEvent
+        if (Skript.classExists("io.papermc.paper.event.player.PlayerTrackEntityEvent")) {
+            Skript.registerEvent("Player Track Entity", PaperEvents.class, PlayerTrackEntityEvent.class, "player track entity")
+                .description("Called when a Player tracks an Entity (This means the entity is sent to the client).",
+                    "If cancelled entity is not shown to the player and interaction in both directions is not possible.",
+                    "(This is copied from Paper javadocs and does not seem true. When testing on a zombie, the zombie still attacked me)",
+                    "Adding or removing entities from the world at the point in time this event is called is completely unsupported and should be avoided.",
+                    "Requires PaperMC 1.19+.")
+                .examples("on player track entity:",
+                    "\tif event-entity is a zombie:",
+                    "\t\tcancel event")
+                .since("INSERT VERSION");
+
+            EventValues.registerEventValue(PlayerTrackEntityEvent.class, Entity.class, new Getter<>() {
+                @Override
+                public Entity get(PlayerTrackEntityEvent event) {
+                    return event.getEntity();
                 }
             }, EventValues.TIME_NOW);
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprArmorChange.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprArmorChange.java
@@ -1,6 +1,5 @@
 package com.shanebeestudios.skbee.elements.other.expressions;
 
-import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Changer;
@@ -37,7 +36,7 @@ public class ExprArmorChange extends SimpleExpression<ItemType> {
     static {
         if (Skript.classExists("com.destroystokyo.paper.event.player.PlayerArmorChangeEvent")) {
             Skript.registerExpression(ExprArmorChange.class, ItemType.class, ExpressionType.SIMPLE,
-                    "[(0¦new|1¦old)] armor item");
+                    "[(new|1:old)] armor item");
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
@@ -26,6 +26,7 @@ import org.bukkit.Registry;
 import org.bukkit.Statistic;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.damage.DamageType;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -45,12 +46,12 @@ import java.util.stream.Collectors;
 
 @Name("Available Objects")
 @Description({"Get a list of all available materials (will return as an itemtype, but it's a mix of blocks and items),",
-        "itemtypes, block types (will return as an item type, but only materials which can be placed as a block), block datas,",
-        "entity types, enchantments, potion effect types, biomes, game rules, particles (SkBee particles), sounds (as string),",
-        "game events, statistics, entity effects, trim materials, and trim patterns."})
+    "itemtypes, block types (will return as an item type, but only materials which can be placed as a block), block datas,",
+    "entity types, enchantments, potion effect types, biomes, game rules, particles (SkBee particles), sounds (as string),",
+    "game events, statistics, entity effects, trim materials, trim patterns, damage types."})
 @Examples({"give player random element of all available itemtypes",
-        "set {_blocks::*} to all available blocktypes",
-        "set target block to random element of all available blockdatas"})
+    "set {_blocks::*} to all available blocktypes",
+    "set target block to random element of all available blockdatas"})
 @Since("1.15.0")
 @SuppressWarnings({"NullableProblems", "rawtypes"})
 public class ExprAvailableMaterials extends SimpleExpression<Object> {
@@ -63,7 +64,7 @@ public class ExprAvailableMaterials extends SimpleExpression<Object> {
         List<ItemType> blockTypes = new ArrayList<>();
         List<BlockData> blockDatas = new ArrayList<>();
 
-        bukkitMaterials = bukkitMaterials.stream().sorted(Comparator.comparing(Enum::toString)).collect(Collectors.toList());
+        bukkitMaterials = bukkitMaterials.stream().sorted(Comparator.comparing(Enum::toString)).toList();
         for (Material material : bukkitMaterials) {
             ItemType itemType = new ItemType(material);
             materials.add(itemType);
@@ -120,10 +121,13 @@ public class ExprAvailableMaterials extends SimpleExpression<Object> {
         Registration.registerList("entity effects", EntityEffect.class, entityEffects);
 
         // Register registries
-        Registration.registerRegistry("enchantments", Enchantment.class, Registry.ENCHANTMENT);
         Registration.registerRegistry("biomes", Biome.class, Registry.BIOME);
-        Registration.registerRegistry("statistics", Statistic.class, Registry.STATISTIC);
+        if (Skript.fieldExists(Registry.class, "DAMAGE_TYPE")) {
+            Registration.registerRegistry("damage types", DamageType.class, Registry.DAMAGE_TYPE);
+        }
+        Registration.registerRegistry("enchantments", Enchantment.class, Registry.ENCHANTMENT);
         Registration.registerRegistry("game events", GameEvent.class, Registry.GAME_EVENT);
+        Registration.registerRegistry("statistics", Statistic.class, Registry.STATISTIC);
 
         if (Types.HAS_ARMOR_TRIM) {
             Registration.registerRegistry("trim materials", TrimMaterial.class, Registry.TRIM_MATERIAL);
@@ -134,7 +138,7 @@ public class ExprAvailableMaterials extends SimpleExpression<Object> {
         Registration.registerStrings("sounds", Registry.SOUNDS);
 
         Skript.registerExpression(ExprAvailableMaterials.class, Object.class, ExpressionType.SIMPLE,
-                Registration.getPatterns());
+            Registration.getPatterns());
     }
 
     private Registration registration;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
     "set {_blocks::*} to all available blocktypes",
     "set target block to random element of all available blockdatas"})
 @Since("1.15.0")
-@SuppressWarnings({"NullableProblems", "rawtypes"})
+@SuppressWarnings({"NullableProblems", "rawtypes", "deprecation"})
 public class ExprAvailableMaterials extends SimpleExpression<Object> {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
@@ -111,7 +111,7 @@ public class ExprAvailableMaterials extends SimpleExpression<Object> {
 
         List<LootTable> lootTables = new ArrayList<>();
         Registry.LOOT_TABLES.forEach(lt -> lootTables.add(lt.getLootTable()));
-        Registration.registerList("loot tables", LootTable.class, lootTables.stream().sorted(Comparator.comparing(Keyed::getKey)).toList());
+        Registration.registerList("loot tables", LootTable.class, lootTables.stream().sorted(Comparator.comparing(lootTable -> lootTable.getKey().getKey())).toList());
 
         List<Particle> particles = ParticleUtil.getAvailableParticles();
         particles = particles.stream().sorted(Comparator.comparing(ParticleUtil::getName)).collect(Collectors.toList());

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBreedEntities.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBreedEntities.java
@@ -15,8 +15,8 @@ import ch.njol.util.Kleenean;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityBreedEvent;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Breed Event Entities")
 @Description("Get the entities involved in a breed event.")
@@ -29,7 +29,7 @@ public class ExprBreedEntities extends SimpleExpression<Entity> {
     static {
         Skript.registerExpression(ExprBreedEntities.class, Entity.class, ExpressionType.SIMPLE,
                 "[the] breed[ing] parents",
-                "[the] breed[ing] (mother|1¦father|2¦baby|3¦player)");
+                "[the] breed[ing] (mother|1:father|2:baby|3:player)");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTabCompletionArgs.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTabCompletionArgs.java
@@ -1,6 +1,5 @@
 package com.shanebeestudios.skbee.elements.other.expressions;
 
-import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -32,7 +31,7 @@ public class ExprTabCompletionArgs extends SimpleExpression<String> {
 
     static {
         Skript.registerExpression(ExprTabCompletionArgs.class, String.class, ExpressionType.SIMPLE,
-                "tab [complete] arg[ument](0¦s|1¦[(-| )]%number%)");
+                "tab [complete] arg[ument](s|1:[(-| )]%number%)");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTargetBlockExact.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTargetBlockExact.java
@@ -8,6 +8,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.ExpressionType;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.block.Block;
 import org.bukkit.entity.LivingEntity;
@@ -16,17 +17,19 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("Target Block Exact")
 @Description({"Returns the exact target block of a living entity.",
-        "Unlike Skript's target block expression, this takes the blocks' precise collision shapes into account.",
-        "An example would be a torch, Skript's expression won't account for the actual shape of the block.",
-        "Will also ignore fluids. Skript's expression is only for players, this one is for all living entities."})
+    "Unlike Skript's target block expression, this takes the blocks' precise collision shapes into account.",
+    "An example would be a torch, Skript's expression won't account for the actual shape of the block.",
+    "Will also ignore fluids. Skript's expression is only for players, this one is for all living entities."})
 @Examples({"set exact target block of player to stone",
-        "set {_t} to exact target block of last spawned entity"})
+    "set {_t} to exact target block of last spawned entity"})
 @Since("1.15.0")
 public class ExprTargetBlockExact extends SimplePropertyExpression<LivingEntity, Block> {
 
     static {
-        Skript.registerExpression(ExprTargetBlockExact.class, Block.class, ExpressionType.PROPERTY,
+        if (!Util.IS_RUNNING_SKRIPT_2_9) {
+            Skript.registerExpression(ExprTargetBlockExact.class, Block.class, ExpressionType.PROPERTY,
                 "exact target[ed] block [of %livingentities%]");
+        }
     }
 
     @Nullable

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTimeSpanNumbers.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTimeSpanNumbers.java
@@ -9,6 +9,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,8 +20,10 @@ import org.jetbrains.annotations.Nullable;
 public class ExprTimeSpanNumbers extends SimplePropertyExpression<Timespan, Number> {
 
     static {
-        register(ExprTimeSpanNumbers.class, Number.class,
+        if (!Util.IS_RUNNING_SKRIPT_2_9) {
+            register(ExprTimeSpanNumbers.class, Number.class,
                 "(ticks|1:seconds|2:minutes|3:hours)", "timespan");
+        }
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTimeSpanNumbers.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTimeSpanNumbers.java
@@ -9,8 +9,8 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("TimeSpan - Numbers")
 @Description("Get the ticks/seconds/minutes/hours of a timespan.")
@@ -20,7 +20,7 @@ public class ExprTimeSpanNumbers extends SimplePropertyExpression<Timespan, Numb
 
     static {
         register(ExprTimeSpanNumbers.class, Number.class,
-                "(ticks|1¦seconds|2¦minutes|3¦hours)", "timespan");
+                "(ticks|1:seconds|2:minutes|3:hours)", "timespan");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -5,13 +5,19 @@ import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.classes.Serializer;
 import ch.njol.skript.lang.ParseContext;
+import ch.njol.skript.lang.function.Functions;
+import ch.njol.skript.lang.function.Parameter;
+import ch.njol.skript.lang.function.SimpleJavaFunction;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.registrations.DefaultClasses;
 import ch.njol.yggdrasil.Fields;
+import com.shanebeestudios.skbee.api.util.MathUtil;
 import com.shanebeestudios.skbee.api.util.Util;
 import com.shanebeestudios.skbee.api.wrapper.EnumWrapper;
 import com.shanebeestudios.skbee.api.wrapper.RegistryWrapper;
 import org.bukkit.Chunk.LoadLevel;
+import org.bukkit.Color;
 import org.bukkit.EntityEffect;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -344,6 +350,64 @@ public class Types {
                 .since("3.5.0")
                 .parser(ENTITY_TYPE.getParser()));
         }
+
+        Classes.registerClass(new ClassInfo<>(Color.class, "bukkitcolor")
+            .user("bukkit ?colors?")
+            .name("Bukkit Color")
+            .description("Represents a Bukkit color. This is different than a Skript color",
+                "as it adds an alpha channel.")
+            .since("2.8.0")
+            .parser(new Parser<>() {
+
+                @SuppressWarnings("NullableProblems")
+                @Override
+                public boolean canParse(ParseContext context) {
+                    return false;
+                }
+
+                @Override
+                public @NotNull String toString(Color bukkitColor, int flags) {
+                    int alpha = bukkitColor.getAlpha();
+                    int red = bukkitColor.getRed();
+                    int green = bukkitColor.getGreen();
+                    int blue = bukkitColor.getBlue();
+                    return String.format("BukkitColor(a=%s,r=%s,g=%s,b=%s)", alpha, red, green, blue);
+                }
+
+                @Override
+                public @NotNull String toVariableNameString(Color bukkitColor) {
+                    return toString(bukkitColor, 0);
+                }
+            }));
+    }
+
+    // FUNCTIONS
+    static {
+        //noinspection DataFlowIssue
+        Functions.registerFunction(new SimpleJavaFunction<>("bukkitColor", new Parameter[]{
+            new Parameter<>("alpha", DefaultClasses.NUMBER, true, null),
+            new Parameter<>("red", DefaultClasses.NUMBER, true, null),
+            new Parameter<>("green", DefaultClasses.NUMBER, true, null),
+            new Parameter<>("blue", DefaultClasses.NUMBER, true, null)
+        }, Classes.getExactClassInfo(Color.class), true) {
+            @SuppressWarnings("NullableProblems")
+            @Override
+            public @Nullable Color[] executeSimple(Object[][] params) {
+                int alpha = ((Number) params[0][0]).intValue();
+                int red = ((Number) params[1][0]).intValue();
+                int green = ((Number) params[2][0]).intValue();
+                int blue = ((Number) params[3][0]).intValue();
+                alpha = MathUtil.clamp(alpha, 0, 255);
+                red = MathUtil.clamp(red, 0, 255);
+                green = MathUtil.clamp(green, 0, 255);
+                blue = MathUtil.clamp(blue, 0, 255);
+                return new Color[]{Color.fromARGB(alpha, red, green, blue)};
+            }
+        }
+            .description("Creates a new Bukkit Color using alpha, red, green and blue channels.",
+                "Number values must be between 0 and 255.")
+            .examples("set {_color} to bukkitColor(50,155,100,10)")
+            .since("2.8.0"));
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -404,7 +404,7 @@ public class Types {
                 return new Color[]{Color.fromARGB(alpha, red, green, blue)};
             }
         }
-            .description("Creates a new Bukkit Color using alpha, red, green and blue channels.",
+            .description("Creates a new Bukkit Color using alpha (transparency), red, green and blue channels.",
                 "Number values must be between 0 and 255.")
             .examples("set {_color} to bukkitColor(50,155,100,10)")
             .since("2.8.0"));

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -97,7 +97,7 @@ public class Types {
                 .name("NamespacedKey")
                 .description("NamespacedKeys are a way to declare and specify game objects in Minecraft,",
                     "which can identify built-in and user-defined objects without potential ambiguity or conflicts.",
-                    "For more information see Resource Location on McWiki <link>https://minecraft.wiki/w/Resource_location</link>")
+                    "For more information see [**Resource Location**](https://minecraft.wiki/w/Resource_location) on McWiki.")
                 .since("2.6.0")
                 .serializer(new Serializer<>() {
                     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
@@ -47,7 +47,7 @@ public class EffParticle extends Effect {
     static {
         Skript.registerEffect(EffParticle.class,
                 "(lerp|draw|make) %number% [of] %particle% [particle] [using %-itemtype/blockdata/dustoption/dusttransition/vibration" +
-                        "/number/color%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
+                        "/number/color/bukkitcolor%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
     }
 
     private Expression<Number> count;

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
@@ -47,7 +47,7 @@ public class EffParticle extends Effect {
     static {
         Skript.registerEffect(EffParticle.class,
                 "(lerp|draw|make) %number% [of] %particle% [particle] [using %-itemtype/blockdata/dustoption/dusttransition/vibration" +
-                        "/number%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
+                        "/number/color%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
     }
 
     private Expression<Number> count;

--- a/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/particle/effects/EffParticle.java
@@ -47,7 +47,7 @@ public class EffParticle extends Effect {
     static {
         Skript.registerEffect(EffParticle.class,
                 "(lerp|draw|make) %number% [of] %particle% [particle] [using %-itemtype/blockdata/dustoption/dusttransition/vibration" +
-                        "/number/color/bukkitcolor%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1¦with force)] [(for|to) %-players%]");
+                        "/number/color/bukkitcolor%] %directions% %locations% [with offset %-vector%] [with extra %-number%] [(1:with force)] [(for|to) %-players%]");
     }
 
     private Expression<Number> count;

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCookingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCookingRecipe.java
@@ -13,8 +13,8 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.SkBee;
-import com.shanebeestudios.skbee.config.Config;
 import com.shanebeestudios.skbee.api.recipe.RecipeUtil;
+import com.shanebeestudios.skbee.config.Config;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -49,7 +49,7 @@ public class EffCookingRecipe extends Effect {
 
     static {
         Skript.registerEffect(EffCookingRecipe.class,
-                "register [new] (0¦furnace|1¦(blast furnace|blasting)|2¦smok(er|ing)|3¦campfire) recipe for %itemtype% " +
+                "register [new] (furnace|1:(blast furnace|blasting)|2:smok(er|ing)|3:campfire) recipe for %itemtype% " +
                         "(using|with ingredient) %itemtype/recipechoice% with id %string% [[and ]with exp[erience] %-number%] " +
                         "[[and ]with cook[ ]time %-timespan%] [in group %-string%]");
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCraftingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCraftingRecipe.java
@@ -53,7 +53,7 @@ public class EffCraftingRecipe extends Effect {
 
     static {
         Skript.registerEffect(EffCraftingRecipe.class,
-                "register [new] (shaped|1¦shapeless) recipe for %itemtype% (using|with ingredients) " +
+                "register [new] (shaped|1:shapeless) recipe for %itemtype% (using|with ingredients) " +
                         "%itemtypes/recipechoices% with id %string% [in group %-string%]");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffKnowledgeBook.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffKnowledgeBook.java
@@ -35,8 +35,8 @@ public class EffKnowledgeBook extends Effect {
 
     static {
         Skript.registerEffect(EffKnowledgeBook.class,
-                "add [(custom|1¦(mc|minecraft))] recipe[s] [with id[s]] %strings% [from plugin %-string%] to %itemtype%",
-                "remove [(custom|1¦(mc|minecraft))] recipe[s] [with id[s]] %strings% [from plugin %-string%] from %itemtype%");
+                "add [(custom|1:(mc|minecraft))] recipe[s] [with id[s]] %strings% [from plugin %-string%] to %itemtype%",
+                "remove [(custom|1:(mc|minecraft))] recipe[s] [with id[s]] %strings% [from plugin %-string%] from %itemtype%");
     }
 
     private Expression<String> recipes;

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffRecipeDiscovery.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffRecipeDiscovery.java
@@ -28,8 +28,8 @@ public class EffRecipeDiscovery extends Effect {
 
     static {
         Skript.registerEffect(EffRecipeDiscovery.class,
-                "(discover|unlock) [(custom|1¦(mc|minecraft))] recipe[s] [with id[s]] %strings% for %players%",
-                "(undiscover|lock) [(custom|1¦(mc|minecraft))] recipe[s] [with id[s]] %strings% for %players%");
+                "(discover|unlock) [(custom|1:(mc|minecraft))] recipe[s] [with id[s]] %strings% for %players%",
+                "(undiscover|lock) [(custom|1:(mc|minecraft))] recipe[s] [with id[s]] %strings% for %players%");
     }
 
     @SuppressWarnings("null")

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffRemoveRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffRemoveRecipe.java
@@ -10,8 +10,8 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.SkBee;
-import com.shanebeestudios.skbee.config.Config;
 import com.shanebeestudios.skbee.api.recipe.RecipeUtil;
+import com.shanebeestudios.skbee.config.Config;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.Event;
@@ -38,8 +38,8 @@ public class EffRemoveRecipe extends Effect {
 
     static {
         Skript.registerEffect(EffRemoveRecipe.class,
-                "remove [(custom|1¦(mc|minecraft))] recipe[s] %strings%",
-                "remove all [(1¦(mc|minecraft))] recipe[s]");
+                "remove [(custom|1:(mc|minecraft))] recipe[s] %strings%",
+                "remove all [(1:(mc|minecraft))] recipe[s]");
     }
 
     @SuppressWarnings("null")

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprAllRecipes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprAllRecipes.java
@@ -33,7 +33,7 @@ public class ExprAllRecipes extends SimpleExpression<String> {
     static {
         if (Skript.classExists("org.bukkit.Keyed")) {
             Skript.registerExpression(ExprAllRecipes.class, String.class, ExpressionType.COMBINED,
-                    "[(all [[of] the]|the)] [(1¦(mc|minecraft)|2¦custom)] recipe[s] [(for|of) %-itemtypes%]");
+                    "[(all [[of] the]|the)] [(1:(mc|minecraft)|2:custom)] recipe[s] [(for|of) %-itemtypes%]");
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/scoreboard/effects/EffScoreboardToggle.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/scoreboard/effects/EffScoreboardToggle.java
@@ -9,12 +9,12 @@ import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import com.shanebeestudios.skbee.api.scoreboard.FastBoardWrapper;
 import com.shanebeestudios.skbee.api.scoreboard.BoardManager;
+import com.shanebeestudios.skbee.api.scoreboard.FastBoardWrapper;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Scoreboard - Toggle")
 @Description("Toggle a scoreboard on or off.")
@@ -25,8 +25,8 @@ public class EffScoreboardToggle extends Effect {
 
     static {
         Skript.registerEffect(EffScoreboardToggle.class,
-                "toggle [score]board[s] of %players% [[to ](1¦(on|true)|2¦(off|false))]",
-                "toggle %players%'[s] [score]board[s] [[to ](1¦(on|true)|2¦(off|false))]");
+                "toggle [score]board[s] of %players% [[to ](1:(on|true)|2:(off|false))]",
+                "toggle %players%'[s] [score]board[s] [[to ](1:(on|true)|2:(off|false))]");
     }
 
     private Expression<Player> player;

--- a/src/main/java/com/shanebeestudios/skbee/elements/structure/effects/EffStructureSave.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/structure/effects/EffStructureSave.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 public class EffStructureSave extends Effect {
 
     static {
-        Skript.registerEffect(EffStructureSave.class, "(save|1¦delete) structure[s] %structures%");
+        Skript.registerEffect(EffStructureSave.class, "(save|1:delete) structure[s] %structures%");
     }
 
     private Expression<StructureWrapper> structures;

--- a/src/main/java/com/shanebeestudios/skbee/elements/structure/expressions/ExprStructureObject.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/structure/expressions/ExprStructureObject.java
@@ -37,7 +37,7 @@ public class ExprStructureObject extends SimpleExpression<StructureWrapper> {
     static {
         STRUCTURE_MANAGER = SkBee.getPlugin().getStructureManager();
         Skript.registerExpression(ExprStructureObject.class, StructureWrapper.class, ExpressionType.SIMPLE,
-                "structure[s] (named|with id) %strings%");
+                "structure[s] (named|with id|with key) %strings%");
     }
 
     @SuppressWarnings("null")

--- a/src/main/java/com/shanebeestudios/skbee/elements/tag/expressions/ExprTagAll.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/tag/expressions/ExprTagAll.java
@@ -15,8 +15,8 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -34,7 +34,7 @@ public class ExprTagAll extends SimpleExpression<Tag> {
 
     static {
         Skript.registerExpression(ExprTagAll.class, Tag.class, ExpressionType.SIMPLE,
-                "[all] minecraft [(item|1¦block|2¦entity)] tags");
+                "[all] minecraft [(item|1:block|2:entity)] tags");
     }
 
     private int parse;

--- a/src/main/java/com/shanebeestudios/skbee/elements/tag/expressions/ExprTagGet.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/tag/expressions/ExprTagGet.java
@@ -39,7 +39,7 @@ public class ExprTagGet extends SimpleExpression<Tag> {
 
     static {
         Skript.registerExpression(ExprTagGet.class, Tag.class, ExpressionType.COMBINED,
-                "minecraft [(item|1¦block|2¦entity[[ ]type])] tag[s] %strings/namespacedkeys%");
+                "minecraft [(item|1:block|2:entity[[ ]type])] tag[s] %strings/namespacedkeys%");
     }
 
     private int parse;

--- a/src/main/java/com/shanebeestudios/skbee/elements/team/effects/EffTeamRegister.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/team/effects/EffTeamRegister.java
@@ -24,7 +24,7 @@ public class EffTeamRegister extends Effect {
 
     static {
         // TODO DEPRECATED in 2.11.0
-        Skript.registerEffect(EffTeamRegister.class, "(|1¦un)register [new] team %string%");
+        Skript.registerEffect(EffTeamRegister.class, "[1:un]register [new] team %string%");
     }
 
     private Expression<String> name;

--- a/src/main/java/com/shanebeestudios/skbee/elements/team/expressions/ExprTeamPrefix.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/team/expressions/ExprTeamPrefix.java
@@ -13,8 +13,8 @@ import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.reflection.ChatReflection;
 import org.bukkit.event.Event;
 import org.bukkit.scoreboard.Team;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("NullableProblems")
 @Name("Team - Prefix/Suffix")
@@ -28,7 +28,7 @@ public class ExprTeamPrefix extends SimplePropertyExpression<Team, String> {
 
     static {
         register(ExprTeamPrefix.class, String.class,
-                "team (0¦prefix|1¦suffix)", "team");
+                "team (prefix|1:suffix)", "team");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/team/expressions/ExprTeamState.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/team/expressions/ExprTeamState.java
@@ -12,8 +12,8 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.bukkit.scoreboard.Team;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Team - State")
 @Description("Represents the friendly fire and can see friendly invisibles states of a team.")
@@ -24,7 +24,7 @@ public class ExprTeamState extends SimplePropertyExpression<Team, Boolean> {
 
     static {
         register(ExprTeamState.class, Boolean.class,
-                "(0¦allow friendly fire|1¦can see friendly invisibles) team state", "teams");
+                "(allow friendly fire|1:can see friendly invisibles) team state", "teams");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffSendComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffSendComponent.java
@@ -34,7 +34,7 @@ public class EffSendComponent extends Effect {
 
     static {
         Skript.registerEffect(EffSendComponent.class,
-                "send [(text|1¦action[[ ]bar])] component[s] %objects% [to %commandsenders%] [from %-player%]",
+                "send [(text|1:action[[ ]bar])] component[s] %objects% [to %commandsenders%] [from %-player%]",
                 "broadcast [text] component[s] %objects% [from %-player%]");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprComponentFormat.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprComponentFormat.java
@@ -35,11 +35,11 @@ public class ExprComponentFormat extends PropertyExpression<ComponentWrapper, Ob
     static {
         if (Skript.methodExists(ComponentWrapper.class, "setInsertion", String.class)) {
             register(ExprComponentFormat.class, Object.class,
-                    "(color|1¦bold|2¦italic|3¦(obfuscate[d]|magic)|4¦strikethrough|5¦underline[d]|6¦font|7¦insert[ion]) format",
+                    "(color|1:bold|2:italic|3:(obfuscate[d]|magic)|4:strikethrough|5:underline[d]|6:font|7:insert[ion]) format",
                     "textcomponents");
         } else {
             register(ExprComponentFormat.class, Object.class,
-                    "(color|1¦bold|2¦italic|3¦(obfuscate[d]|magic)|4¦strikethrough|5¦underline[d]|6¦font) format",
+                    "(color|1:bold|2:italic|3:(obfuscate[d]|magic)|4:strikethrough|5:underline[d]|6:font) format",
                     "textcomponents");
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprHoverEvent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprHoverEvent.java
@@ -1,7 +1,6 @@
 package com.shanebeestudios.skbee.elements.text.expressions;
 
 import ch.njol.skript.Skript;
-import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -13,13 +12,13 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEvent.Action;
 import net.kyori.adventure.text.event.HoverEvent.ShowEntity;
-import net.kyori.adventure.text.event.HoverEvent.ShowItem;
+import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -30,10 +29,10 @@ import java.util.UUID;
 @SuppressWarnings("rawtypes")
 @Name("Text Component - Hover Event")
 @Description({"Create a new hover event. Can show texts, text components, an item or an entity to a player.",
-        "'showing %itemtype%' requires Minecraft 1.18.2+"})
+    "'showing %itemtype%' requires Minecraft 1.18.2+"})
 @Examples({"set {_t} to text component from \"Check out my cool tool!\"",
-        "add hover event showing player's tool to {_t}",
-        "send component {_t} to player"})
+    "add hover event showing player's tool to {_t}",
+    "send component {_t} to player"})
 @Since("1.5.0")
 public class ExprHoverEvent extends SimpleExpression<HoverEvent> {
 
@@ -41,7 +40,7 @@ public class ExprHoverEvent extends SimpleExpression<HoverEvent> {
 
     static {
         Skript.registerExpression(ExprHoverEvent.class, HoverEvent.class, ExpressionType.COMBINED,
-                "[a] [new] hover event showing %strings/textcomponents/itemtypes/entities%");
+            "[a] [new] hover event showing %strings/textcomponents/itemstacks/entities%");
     }
 
     private Expression<?> object;
@@ -64,12 +63,11 @@ public class ExprHoverEvent extends SimpleExpression<HoverEvent> {
             if (HAS_SHOW_ENITY) showEntity = ShowEntity.showEntity(key, uuid);
             else showEntity = ShowEntity.of(key, uuid);
             return new HoverEvent[]{HoverEvent.hoverEvent(Action.SHOW_ENTITY, showEntity)};
-        } else if (this.object.isSingle() && this.object.getSingle(event) instanceof ItemType itemType) {
-            Key key = itemType.getMaterial().key();
-            int amount = itemType.getAmount();
-            BinaryTagHolder nbt = BinaryTagHolder.binaryTagHolder(itemType.getItemMeta().getAsString());
-            ShowItem showItem = ShowItem.of(key, amount, nbt);
-            return new HoverEvent[]{HoverEvent.hoverEvent(Action.SHOW_ITEM, showItem)};
+        } else if (this.object.isSingle() && this.object.getSingle(event) instanceof ItemStack itemStack) {
+            if (itemStack.getType().isAir() || !itemStack.getType().isItem()) {
+                itemStack = new ItemStack(Material.STONE);
+            }
+            return new HoverEvent[]{itemStack.asHoverEvent()};
         } else {
             List<ComponentWrapper> components = new ArrayList<>();
             for (Object object : this.object.getArray(event)) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprMiniMessage.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprMiniMessage.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
         "These messages are still components, which you can still apply hover/click events to.",
         "You can also add optional tag resolvers. Essential you create a resolver to replace `<someString>` ",
         "in mini message with something else (See examples for more details).",
-        "For more info check out the mini message page <link>https://docs.adventure.kyori.net/minimessage/format.html</link>"})
+        "For more info check out the [**Mini Message Format**](https://docs.adventure.kyori.net/minimessage/format.html) page."})
 @Examples({"set {_m} to mini message from \"<rainbow>this is a rainbow message\"",
         "set {_m} to mini message from \"<gradient:##F30A0A:##0A2AF3>PRETTY MESSAGE FROM RED TO BLUE\"",
         "set {_m} to mini message from \"<red>This is a <green>test!\"",

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprNameEntity.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprNameEntity.java
@@ -13,8 +13,8 @@ import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Text Component - Entity Name")
 @Description({"Get/set the component name of an entity.",
@@ -26,7 +26,7 @@ public class ExprNameEntity extends SimplePropertyExpression<Entity, ComponentWr
 
     static {
         register(ExprNameEntity.class, ComponentWrapper.class,
-                "component entity (name|1¦display name)", "entities");
+                "component entity (name|1:display name)", "entities");
     }
 
     private boolean alwaysOn;

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprNameEntity.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprNameEntity.java
@@ -12,21 +12,22 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Text Component - Entity Name")
 @Description({"Get/set the component name of an entity.",
-        "\nNAME = the name will only show when crosshair is on entity.",
-        "\nDISPLAY NAME = the name will always show."})
+    "\nNAME = the name will only show when crosshair is on entity.",
+    "\nDISPLAY NAME = the name will always show (for a player, this will get/set their display name)."})
 @Examples("set component entity name of target entity to translate component from \"entity.minecraft.llama\"")
 @Since("2.4.0")
 public class ExprNameEntity extends SimplePropertyExpression<Entity, ComponentWrapper> {
 
     static {
         register(ExprNameEntity.class, ComponentWrapper.class,
-                "component entity (name|1:display name)", "entities");
+            "component entity (name|1:display name)", "entities");
     }
 
     private boolean alwaysOn;
@@ -40,12 +41,14 @@ public class ExprNameEntity extends SimplePropertyExpression<Entity, ComponentWr
 
     @Override
     public @Nullable ComponentWrapper convert(Entity entity) {
+        if (entity instanceof Player player && this.alwaysOn)
+            return ComponentWrapper.fromComponent(player.displayName());
         return ComponentWrapper.fromComponent(entity.name());
     }
 
     @SuppressWarnings("NullableProblems")
     @Override
-    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
         if (mode == ChangeMode.SET) {
             return CollectionUtils.array(ComponentWrapper.class);
         }
@@ -58,7 +61,7 @@ public class ExprNameEntity extends SimplePropertyExpression<Entity, ComponentWr
         if (mode == ChangeMode.SET) {
             if (delta[0] instanceof ComponentWrapper component) {
                 for (Entity entity : getExpr().getArray(event)) {
-                    component.setEntityName(entity, alwaysOn);
+                    component.setEntityName(entity, this.alwaysOn);
                 }
             }
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprTeamPrefixComp.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprTeamPrefixComp.java
@@ -14,8 +14,8 @@ import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import org.bukkit.event.Event;
 import org.bukkit.scoreboard.Team;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Text Component - Team Prefix/Suffix")
 @Description("Get/set prefix/suffix of teams using components.")
@@ -25,7 +25,7 @@ public class ExprTeamPrefixComp extends SimplePropertyExpression<Team, Component
 
     static {
         if (SkBee.getPlugin().getPluginConfig().ELEMENTS_TEAM) {
-            register(ExprTeamPrefixComp.class, ComponentWrapper.class, "component team (prefix|1¦suffix)", "teams");
+            register(ExprTeamPrefixComp.class, ComponentWrapper.class, "component team (prefix|1:suffix)", "teams");
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/type/Types.java
@@ -1,5 +1,6 @@
 package com.shanebeestudios.skbee.elements.text.type;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
@@ -53,34 +54,35 @@ public class Types {
         };
 
         Classes.registerClass(new ClassInfo<>(ComponentWrapper.class, "textcomponent")
-                .user("text ?components?")
-                .name("Text Component - Text Component")
-                .description("Text components used for hover/click events. Due to the complexity of these, ",
-                        "they can NOT be long term stored in variables. \n\bRequires a PaperMC server.")
-                .examples("set {_t} to text component from \"CLICK FOR OUR DISCORD\"",
-                        "add hover event showing \"Clicky Clicky!\" to {_t}",
-                        "add click event to open url \"https://OurDiscord.com\" to {_t}",
-                        "send component {_t} to player")
-                .since("1.5.0")
-                .parser(new Parser<>() {
-                    @Override
-                    public @NotNull String toString(@NotNull ComponentWrapper o, int flags) {
-                        return o.toString();
-                    }
+            .user("text ?components?")
+            .name("Text Component - Text Component")
+            .description("Text components used for hover/click events. Due to the complexity of these, ",
+                "they can NOT be long term stored in variables. \n\bRequires a PaperMC server.")
+            .examples("set {_t} to text component from \"CLICK FOR OUR DISCORD\"",
+                "add hover event showing \"Clicky Clicky!\" to {_t}",
+                "add click event to open url \"https://OurDiscord.com\" to {_t}",
+                "send component {_t} to player")
+            .since("1.5.0")
+            .parser(new Parser<>() {
+                @Override
+                public @NotNull String toString(@NotNull ComponentWrapper o, int flags) {
+                    return o.toString();
+                }
 
-                    @Override
-                    public boolean canParse(@NotNull ParseContext context) {
-                        return false;
-                    }
+                @Override
+                public boolean canParse(@NotNull ParseContext context) {
+                    return false;
+                }
 
-                    @Override
-                    public @NotNull String toVariableNameString(@NotNull ComponentWrapper o) {
-                        return o.toString();
-                    }
-                }).changer(COMP_CHANGER)
+                @Override
+                public @NotNull String toVariableNameString(@NotNull ComponentWrapper o) {
+                    return o.toString();
+                }
+            }).changer(COMP_CHANGER)
         );
 
-        Classes.registerClass(new ClassInfo<>(SignedMessage.class, "signedmessage")
+        if (Skript.classExists("net.kyori.adventure.chat.SignedMessage")) {
+            Classes.registerClass(new ClassInfo<>(SignedMessage.class, "signedmessage")
                 .user("signed ?messages?")
                 .name("Signed Chat Message")
                 .description("Represents a signed chat message.")
@@ -111,24 +113,25 @@ public class Types {
                         }
                     }
                 }));
+        }
 
         Classes.registerClass(new ClassInfo<>(TagResolver.class, "tagresolver")
-                .user("tag ?resolvers?")
-                .description("Represents an object to replace text in a mini message.")
-                .examples("# Create a component",
-                        "set {_i} to translate component of player's tool",
-                        "# Use this comonent in the resolver to replace \"<item>\" in the mini message",
-                        "set {_r::1} to resolver(\"item\", {_i})",
-                        "# setup the mini message with the replacement placeholder",
-                        "set {_m} to mini message from \"<rainbow> Hey guys check out my <item> aint she a beaut?\" with {_r::*}",
-                        "send component {_m}")
-                .since("3.5.0"));
+            .user("tag ?resolvers?")
+            .description("Represents an object to replace text in a mini message.")
+            .examples("# Create a component",
+                "set {_i} to translate component of player's tool",
+                "# Use this comonent in the resolver to replace \"<item>\" in the mini message",
+                "set {_r::1} to resolver(\"item\", {_i})",
+                "# setup the mini message with the replacement placeholder",
+                "set {_m} to mini message from \"<rainbow> Hey guys check out my <item> aint she a beaut?\" with {_r::*}",
+                "send component {_m}")
+            .since("3.5.0"));
 
         // Functions
         //noinspection DataFlowIssue
         Functions.registerFunction(new SimpleJavaFunction<>("resolver", new Parameter[]{
-                new Parameter<>("placeholder", DefaultClasses.STRING, true, null),
-                new Parameter<>("replacement", DefaultClasses.OBJECT, true, null)
+            new Parameter<>("placeholder", DefaultClasses.STRING, true, null),
+            new Parameter<>("replacement", DefaultClasses.OBJECT, true, null)
         }, Classes.getExactClassInfo(TagResolver.class), true) {
             @SuppressWarnings({"NullableProblems", "PatternValidation"})
             @Override
@@ -150,18 +153,18 @@ public class Types {
                 return new TagResolver[]{Placeholder.component(string, component.getComponent())};
             }
         }
-                .description("Creates a tag resolver for replacements in mini message.",
-                        "`placeholder` = The string that will be replaced in the mini message.",
-                        "In the mini message itself this part needs to be surrounded by <>. See examples!",
-                        "`replacement` = A string/text component that will replace the first string.")
-                .examples("# Create a component",
-                        "set {_i} to translate component of player's tool",
-                        "# Use this comonent in the resolver to replace \"<item>\" in the mini message",
-                        "set {_r::1} to resolver(\"item\", {_i})",
-                        "# setup the mini message with the replacement placeholder",
-                        "set {_m} to mini message from \"<rainbow> Hey guys check out my <item> aint she a beaut?\" with {_r::*}",
-                        "send component {_m}")
-                .since("3.5.0"));
+            .description("Creates a tag resolver for replacements in mini message.",
+                "`placeholder` = The string that will be replaced in the mini message.",
+                "In the mini message itself this part needs to be surrounded by <>. See examples!",
+                "`replacement` = A string/text component that will replace the first string.")
+            .examples("# Create a component",
+                "set {_i} to translate component of player's tool",
+                "# Use this comonent in the resolver to replace \"<item>\" in the mini message",
+                "set {_r::1} to resolver(\"item\", {_i})",
+                "# setup the mini message with the replacement placeholder",
+                "set {_m} to mini message from \"<rainbow> Hey guys check out my <item> aint she a beaut?\" with {_r::*}",
+                "send component {_m}")
+            .since("3.5.0"));
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/event/SimpleEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/event/SimpleEvents.java
@@ -67,8 +67,8 @@ public class SimpleEvents extends SimpleEvent {
 
         if (Skript.classExists("io.papermc.paper.event.player.PlayerPurchaseEvent")) {
             Skript.registerEvent("Player Purchase", SimpleEvents.class, PlayerPurchaseEvent.class,
-                            "player (purchase|trade)")
-                    .description("Called when a player trades with a standalone merchant/villager GUI.")
+                            "player purchase")
+                    .description("Called when a player trades with a standalone merchant/villager GUI. Requires PaperMC.")
                     .examples("on player purchase:",
                             "\tignite event-entity for 1 minute")
                     .since("1.17.1");

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipe.java
@@ -14,8 +14,8 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.MerchantRecipe;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Merchant Recipe - Create")
 @Description({"Create a merchant recipe.",
@@ -39,7 +39,7 @@ public class ExprMerchantRecipe extends SimpleExpression<MerchantRecipe> {
     private static final boolean SUPPORTS_SPECIAL_PRICE = Skript.methodExists(MerchantRecipe.class, "getDemand");
     static {
         String pattern = "[new] merchant recipe with result %itemtype% with max uses %number% [with uses %-number%] " +
-                "[(|1¦with experience reward)] [with villager experience %-number%] [with price multiplier %-number%]";
+                "[(|1:with experience reward)] [with villager experience %-number%] [with price multiplier %-number%]";
         if (SUPPORTS_SPECIAL_PRICE) {
             Skript.registerExpression(ExprMerchantRecipe.class, MerchantRecipe.class, ExpressionType.SIMPLE,
                     pattern + " [with demand %-number%] [with special price %-number%]");

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipeIngredients.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprMerchantRecipeIngredients.java
@@ -16,8 +16,8 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.MerchantRecipe;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +35,7 @@ public class ExprMerchantRecipeIngredients extends SimpleExpression<ItemType> {
 
     static {
         Skript.registerExpression(ExprMerchantRecipeIngredients.class, ItemType.class, ExpressionType.SIMPLE,
-                "(ingredients|1¦result [item]) of merchant recipe %merchantrecipe%");
+                "(ingredients|1:result [item]) of merchant recipe %merchantrecipe%");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerLevel.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/expressions/ExprVillagerLevel.java
@@ -13,8 +13,8 @@ import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Villager - Level/Experience")
 @Description({"Represents the level/experience of a villager.",
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 public class ExprVillagerLevel extends SimplePropertyExpression<LivingEntity, Number> {
 
     static {
-        register(ExprVillagerLevel.class, Number.class, "villager (level|1¦experience)", "livingentities");
+        register(ExprVillagerLevel.class, Number.class, "villager (level|1:experience)", "livingentities");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/virtualfurnace/effects/EffFurnaceRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/virtualfurnace/effects/EffFurnaceRecipe.java
@@ -11,13 +11,13 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.vf.api.RecipeManager;
 import com.shanebeestudios.vf.api.recipe.FurnaceRecipe;
 import com.shanebeestudios.vf.api.util.Util;
 import org.bukkit.Material;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
-import com.shanebeestudios.skbee.SkBee;
 
 import java.util.List;
 
@@ -37,7 +37,7 @@ public class EffFurnaceRecipe extends Effect {
     static {
         Skript.registerEffect(EffFurnaceRecipe.class,
                 "register virtual furnace recipe for %itemtype% using %itemtype% [with cooktime %-timespan%]",
-                "register all virtual (0¦furnace|1¦smoker|2¦blast furnace) recipes");
+                "register all virtual (furnace|1:smoker|2:blast furnace) recipes");
     }
 
     private Expression<ItemType> ingredient;

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/effects/EffWorldBorderExpand.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/effects/EffWorldBorderExpand.java
@@ -12,8 +12,8 @@ import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("WorldBorder - Expand/Shrink")
 @Description({"Expand or shrink a world border.",
@@ -27,8 +27,8 @@ public class EffWorldBorderExpand extends Effect {
 
     static {
         Skript.registerEffect(EffWorldBorderExpand.class,
-                "(expand|1¦shrink) %worldborders% by %number% [in %-timespan%]",
-                "(expand|1¦shrink) %worldborders% to %number% [in %-timespan%]");
+                "(expand|1:shrink) %worldborders% by %number% [in %-timespan%]",
+                "(expand|1:shrink) %worldborders% to %number% [in %-timespan%]");
     }
 
     private boolean expand;

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderNumbers.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldborder/expressions/ExprWorldBorderNumbers.java
@@ -12,8 +12,8 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("WorldBorder - Stats")
 @Description({"Get/set different stats of a world border.",
@@ -28,7 +28,7 @@ public class ExprWorldBorderNumbers extends SimplePropertyExpression<WorldBorder
 
     static {
         register(ExprWorldBorderNumbers.class, Number.class,
-                "[border] (damage amount|1¦damage buffer|2¦size|3¦warning distance)",
+                "[border] (damage amount|1:damage buffer|2:size|3:warning distance)",
                 "worldborders");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/conditions/CondWorldExists.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/conditions/CondWorldExists.java
@@ -23,7 +23,7 @@ import java.io.File;
 public class CondWorldExists extends Condition {
 
     static {
-        Skript.registerCondition(CondWorldExists.class, "world file %string% (0¦exists|1¦(does not|doesn't) exist)");
+        Skript.registerCondition(CondWorldExists.class, "world file %string% (exists|1:(does not|doesn't) exist)");
     }
 
     private Expression<String> world;

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/effects/EffLoadWorld.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/effects/EffLoadWorld.java
@@ -44,7 +44,7 @@ public class EffLoadWorld extends Effect {
         Skript.registerEffect(EffLoadWorld.class,
                 "load world from [[world] creator] %worldcreator%",
                 "load world %string%",
-                "unload [world] %world% [and (0¦save|1¦(do not|don't) save)]",
+                "unload [world] %world% [and (save|1:(do not|don't) save)]",
                 "delete world file for [world] %string%");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprWorldCreator.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprWorldCreator.java
@@ -37,7 +37,7 @@ public class ExprWorldCreator extends SimpleExpression<BeeWorldCreator> {
     static {
         Skript.registerExpression(ExprWorldCreator.class, BeeWorldCreator.class, ExpressionType.SIMPLE,
                 "[a] [new] world creator (with name|named) %string%",
-                "[a] [new] world creator (with name|named) %string% to (0¦copy|1¦clone) %world% [save:without saving]");
+                "[a] [new] world creator (with name|named) %string% to (copy|1:clone) %world% [save:without saving]");
     }
 
     private int pattern;

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprWorldCreatorOption.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprWorldCreatorOption.java
@@ -32,8 +32,8 @@ public class ExprWorldCreatorOption extends SimplePropertyExpression<BeeWorldCre
 
     static {
         register(ExprWorldCreatorOption.class, Object.class,
-                "(0¦environment|1¦world type|2¦world seed|3¦gen[erator] settings|4¦generator" +
-                        "|5¦should gen[erate] structures|6¦[is] hardcore|7¦keep spawn loaded|8¦load on start) [option]",
+                "(environment|1:world type|2:world seed|3:gen[erator] settings|4:generator" +
+                        "|5:should gen[erate] structures|6:[is] hardcore|7:keep spawn loaded|8:load on start) [option]",
                 "worldcreator");
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,9 +28,6 @@ settings:
 elements:
     # Enable NBT elements
     nbt: true
-    # Whether to send errors to admins if NBT fails to parse at runtime
-    # Errors will still be provided in console if disabled
-    nbt-admin-errors: true
 
     # Enable Scoreboard elements
     scoreboard: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,9 @@ settings:
 elements:
     # Enable NBT elements
     nbt: true
+    # Whether to send errors to admins if NBT fails to parse at runtime
+    # Errors will still be provided in console if disabled
+    nbt-admin-errors: true
 
     # Enable Scoreboard elements
     scoreboard: true

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -76,3 +76,6 @@ types:
 	signedmessage: signed message¦s
 	tagresolver: tag resolver¦s
 	minecraftentitytype: minecraft entity type¦s
+	chunkloadlevel: chunk load level¦s
+	entityeffect: entity effect¦s
+	blockaction: block action¦s

--- a/src/test/scripts/general/nbt-test.sk
+++ b/src/test/scripts/general/nbt-test.sk
@@ -23,11 +23,11 @@ test "SkBee - simple nbt compound":
     delete {_n}
 
     set {_i} to diamond sword with custom model data 1
-    set {_n} to nbt of {_i}
+    set {_n} to component nbt of {_i}
 
     # Test that tag of item nbt is set
-    assert int tag "CustomModelData" of {_n} is set with "tag ""CustomModelData"" of an item should be set"
-    assert int tag "CustomModelData" of {_n} = 1 with "tag ""CustomModelData"" of an item should be 1"
+    assert int tag "minecraft:custom_model_data" of {_n} is set with "tag ""minecraft:custom_model_data"" of an item should be set"
+    assert int tag "minecraft:custom_model_data" of {_n} = 1 with "tag ""minecraft:custom_model_data"" of an item should be 1"
 
 test "SkBee - NBTCustomBlock":
     set {_l} to location(1,1,1)

--- a/src/test/scripts/general/recipe-test.sk
+++ b/src/test/scripts/general/recipe-test.sk
@@ -92,7 +92,7 @@ test "SkBee - cooking recipe section":
 test "SkBee - brewer recipe section":
     register brewing recipe:
         id: "custom:brew_glow_diamond"
-        result: diamond of unbreaking with all flags hidden
+        result: diamond of unbreaking with all item flags
         ingredient: glowstone dust
         input: potato
 


### PR DESCRIPTION
Temp Changelog:

## ADDED:
- Added `color/bukkitcolor` option for particles (used with "entity_effect" particle in MC 1.20.5+)
- Added damage types, attributes and loot tables to available materials expression
- Added player track entity event
- Added support for `damage source` expression in death event (requires very recent builds of MC 1.20.6)
- Added support for `boolean tag` NBT type (note: this is still stored as a 0/1 byte tag)

## FIXED:
- Fixed an issue with the component entity name expression not working for players
- Fixed hover event showing item not working on MC 1.20.5+
- Fixed an issue with tab completions where setting a position to a null/empty value broke all positions
- Fixed an error with bound border listeners on MC versions below 1.20.5

## REMOVED IF RUNNING SKRIPT 2.9+:
(Skript added some things so these elements will be removed from SkBee)
(These will only be removed if running Skript 2.9+)
- Timespan numbers expression (ticks/seconds/minutes of %timespan%)
- Player is connected condition
- Exact target block expression

> [!CAUTION]
> ## Breaking change with bound border listeners
> In Spigot 1.20.5, they moved the entity dismount events from the spigot package to the bukkit package.
> SkBee is using the 1.20.6 API and therefor does not have access to the old events for 1.20.4 and below.
> If you are running a server on 1.20.4 and below, things may not work as expected as the mount/dismount events won't trigger the bound enter/exit events.

## INTERNAL:
- Replace all outdated broken pipes with modern colons (this also fixes an encoding bug on some machines) (thanks @Fusezion)