### PR TITLE
Fix 2.9 condition working in reverse

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -33,7 +33,7 @@ public class Util {
     public static final String MCWIKI_TICK_COMMAND = "See [**Tick Command**](https://minecraft.wiki/w/Commands/tick) on McWiki for more details.";
 
     // Shortcut for finding stuff to remove later
-    public static final boolean IS_RUNNING_SKRIPT_2_9 = Skript.getVersion().compareTo(new Version(2,9)) <= 0;
+    public static final boolean IS_RUNNING_SKRIPT_2_9 = Skript.getVersion().compareTo(new Version(2,9)) >= 0;
 
     @SuppressWarnings("deprecation") // Paper deprecation
     public static String getColString(String string) {


### PR DESCRIPTION
This PR aims to fix the `Util#IS_RUNNING_2_9` field to correctly function and prevent registration on 2.9+ rather than 2.9<
Code was tested by author of #639 and confirmed to work.