### PR TITLE
Dev/Patch - Future Release

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/RegistryWrapper.java
@@ -113,11 +113,17 @@ public class RegistryWrapper<T extends Keyed> {
      * @param object Item to put into string
      * @return String form of item
      */
-    public String toString(T object) {
-        String key = object.getKey().getKey();
+    public @NotNull String toString(T object) {
+        NamespacedKey namespacedKey;
+        try {
+            namespacedKey = object.getKey();
+        } catch (IllegalArgumentException ignore) {
+            return "invalid key for: " + object;
+        }
+        String key = namespacedKey.getKey();
         if (this.prefix != null && !this.prefix.isEmpty()) key = prefix + "_" + key;
         if (this.suffix != null && !this.suffix.isEmpty()) key = key + "_" + suffix;
-        return object.getKey().getNamespace() + ":" + key;
+        return namespacedKey.getNamespace() + ":" + key;
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffChunkDataStructurePlace.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffChunkDataStructurePlace.java
@@ -9,25 +9,27 @@ import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import com.shanebeestudios.skbee.api.structure.StructureWrapper;
 import com.shanebeestudios.skbee.api.generator.event.BlockPopulateEvent;
+import com.shanebeestudios.skbee.api.structure.StructureWrapper;
+import com.shanebeestudios.skbee.api.util.MathUtil;
 import org.bukkit.event.Event;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 @Name("ChunkGenerator - Structure Place")
 @Description({"Place a structure in a block populator.",
-        "Due to the chunk not being finalized yet,",
-        "the standard structure place effect will not work during generation.",
-        "Since the chunk isn't finalized yet, we use a vector instead of a location,",
-        "but it's treated the same as a location."})
-@Examples("place chunkdata structure {-s} at vector({_x}, {_y}, {_z})")
+    "Due to the chunk not being finalized yet,",
+    "the standard structure place effect will not work during generation.",
+    "Since the chunk isn't finalized yet, we use a vector instead of a location,",
+    "the vector will represent a chunk position not a world position."})
+@Examples({"place chunkdata structure {-s} at vector({_x}, {_y}, {_z})",
+    "place chunkdata structure {-s} at vector(0,64,0)"})
 @Since("3.5.0")
 public class EffChunkDataStructurePlace extends Effect {
 
     static {
         Skript.registerEffect(EffChunkDataStructurePlace.class,
-                "place chunk[ ]data structure %structure% at %vector%");
+            "place chunk[ ]data structure %structure% at %vector%");
     }
 
     private Expression<StructureWrapper> structure;
@@ -44,12 +46,14 @@ public class EffChunkDataStructurePlace extends Effect {
     @SuppressWarnings("NullableProblems")
     @Override
     protected void execute(Event event) {
-        if (!(event instanceof BlockPopulateEvent populateEvent)) return;
+        if (!(event instanceof BlockPopulateEvent popEvent)) return;
         StructureWrapper structure = this.structure.getSingle(event);
         Vector vector = this.vector.getSingle(event);
         if (structure == null || vector == null) return;
 
-        structure.place(populateEvent.getLimitedRegion(), vector);
+        vector.setX((popEvent.getChunkX() << 4) + MathUtil.clamp(vector.getBlockX(), 0, 15));
+        vector.setZ((popEvent.getChunkZ() << 4) + MathUtil.clamp(vector.getBlockZ(), 0, 15));
+        structure.place(popEvent.getLimitedRegion(), vector);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffPopulateTree.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffPopulateTree.java
@@ -26,12 +26,12 @@ import java.util.Random;
     "The vector represents chunk position not world position."})
 @Examples("populate cherry tree at vector(0, 64, 15)")
 @Since("INSERT VERSION")
-public class EffTreeGenerate extends Effect {
+public class EffPopulateTree extends Effect {
 
     private static final Random RANDOM = new Random();
 
     static {
-        Skript.registerEffect(EffTreeGenerate.class,
+        Skript.registerEffect(EffPopulateTree.class,
             "populate %bukkittreetype% at %vectors%");
     }
 
@@ -64,9 +64,7 @@ public class EffTreeGenerate extends Effect {
             int z = (popEvent.getChunkZ() << 4) + MathUtil.clamp(vector.getBlockZ(), 0, 15);
             Location location = new Location(null, x, vector.getBlockY(), z);
             region.generateTree(location, RANDOM, treeType);
-
         }
-
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffTreeGenerate.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffTreeGenerate.java
@@ -1,0 +1,77 @@
+package com.shanebeestudios.skbee.elements.generator.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.generator.event.BlockPopulateEvent;
+import com.shanebeestudios.skbee.api.util.MathUtil;
+import org.bukkit.Location;
+import org.bukkit.TreeType;
+import org.bukkit.event.Event;
+import org.bukkit.generator.LimitedRegion;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Random;
+
+@Name("ChunkGenerator - Populate Tree")
+@Description({"Grow a tree in a ChunkGenerator `block pop` section.",
+    "The vector represents chunk position not world position."})
+@Examples("populate cherry tree at vector(0, 64, 15)")
+@Since("INSERT VERSION")
+public class EffTreeGenerate extends Effect {
+
+    private static final Random RANDOM = new Random();
+
+    static {
+        Skript.registerEffect(EffTreeGenerate.class,
+            "populate %bukkittreetype% at %vectors%");
+    }
+
+    private Expression<TreeType> treeType;
+    private Expression<Vector> vector;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.treeType = (Expression<TreeType>) exprs[0];
+        this.vector = (Expression<Vector>) exprs[1];
+        if (!ParserInstance.get().isCurrentEvent(BlockPopulateEvent.class)) {
+            Skript.error("Grow effect using a vector will only work in a 'block pop' section.");
+            return false;
+        }
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        if (!(event instanceof BlockPopulateEvent popEvent)) return;
+
+        TreeType treeType = this.treeType.getSingle(event);
+        if (treeType == null) return;
+
+        LimitedRegion region = popEvent.getLimitedRegion();
+        for (Vector vector : this.vector.getArray(event)) {
+            int x = (popEvent.getChunkX() << 4) + MathUtil.clamp(vector.getBlockX(), 0, 15);
+            int z = (popEvent.getChunkZ() << 4) + MathUtil.clamp(vector.getBlockZ(), 0, 15);
+            Location location = new Location(null, x, vector.getBlockY(), z);
+            region.generateTree(location, RANDOM, treeType);
+
+        }
+
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "populate " + this.treeType.toString(e, d) + " at " + this.vector.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataBiome.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataBiome.java
@@ -13,10 +13,10 @@ import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
-import com.shanebeestudios.skbee.api.util.MathUtil;
 import com.shanebeestudios.skbee.api.generator.event.BiomeGenEvent;
 import com.shanebeestudios.skbee.api.generator.event.BlockPopulateEvent;
 import com.shanebeestudios.skbee.api.generator.event.ChunkGenEvent;
+import com.shanebeestudios.skbee.api.util.MathUtil;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.event.Event;
@@ -28,23 +28,23 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("ChunkGenerator - ChunkData Biome")
 @Description({"Represents the biome in ChunkData.",
-        "The first pattern is used to set the biome in the `biome gen` section.",
-        "The second pattern is used to retrieve biomes in the `chunk gen` and `block pop` sections.",
-        "NOTE: The vector represents the position of the biome in the chunk, not the world."})
+    "The first pattern is used to set the biome in the `biome gen` section.",
+    "The second pattern is used to retrieve biomes in the `chunk gen` and `block pop` sections.",
+    "NOTE: The vector represents the position of the biome in the chunk, not the world."})
 @Examples({"biome gen:",
-        "\tset chunkdata biome to plains",
-        "",
-        "chunk gen:",
-        "\tset {_biome} to chunkdata biome at vector(0,0,0)",
-        "\tif {_biome} is plains:",
-        "\t\tset chunkdata block at vector(0,0,0) to grass[]"})
+    "\tset chunkdata biome to plains",
+    "",
+    "chunk gen:",
+    "\tset {_biome} to chunkdata biome at vector(0,0,0)",
+    "\tif {_biome} is plains:",
+    "\t\tset chunkdata block at vector(0,0,0) to grass[]"})
 @Since("3.5.0")
 public class ExprChunkDataBiome extends SimpleExpression<Biome> {
 
     static {
         Skript.registerExpression(ExprChunkDataBiome.class, Biome.class, ExpressionType.COMBINED,
-                "chunk[ ]data biome",
-                "chunk[ ]data biome at %vector%");
+            "chunk[ ]data biome",
+            "chunk[ ]data biome at %vector%");
     }
 
     private Expression<Vector> vector;
@@ -70,17 +70,19 @@ public class ExprChunkDataBiome extends SimpleExpression<Biome> {
         if (this.vector != null) {
             Vector vector = this.vector.getSingle(event);
             if (vector != null) {
-                int x = vector.getBlockX();
+                int x = MathUtil.clamp(vector.getBlockX(), 0, 15);
                 int y = vector.getBlockY();
-                int z = vector.getBlockZ();
+                int z = MathUtil.clamp(vector.getBlockZ(), 0, 15);
                 if (event instanceof ChunkGenEvent chunkGenEvent) {
                     ChunkData chunkData = chunkGenEvent.getChunkData();
                     Biome biome = chunkData.getBiome(x, y, z);
                     return new Biome[]{biome};
                 } else if (event instanceof BlockPopulateEvent populateEvent) {
+                    int chunkX = populateEvent.getChunkX();
+                    int chunkZ = populateEvent.getChunkZ();
                     LimitedRegion limitedRegion = populateEvent.getLimitedRegion();
                     y = clamp(limitedRegion, y);
-                    Biome biome = limitedRegion.getBiome(x, y, z);
+                    Biome biome = limitedRegion.getBiome((chunkX << 4) + x, y, (chunkZ << 4) + z);
                     return new Biome[]{biome};
                 }
             }

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataHighestY.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataHighestY.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.generator.event.BlockPopulateEvent;
+import org.bukkit.HeightMap;
 import org.bukkit.event.Event;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +45,7 @@ public class ExprChunkDataHighestY extends SimpleExpression<Number> {
         if (event instanceof BlockPopulateEvent popEvent) {
             int x = (popEvent.getChunkX() << 4) + vector.getBlockX();
             int z = (popEvent.getChunkZ() << 4) + vector.getBlockZ();
-            int highest = popEvent.getLimitedRegion().getHighestBlockYAt(x, z);
+            int highest = popEvent.getLimitedRegion().getHighestBlockYAt(x, z, HeightMap.WORLD_SURFACE_WG);
             return new Number[]{highest};
         }
         return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataHighestY.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataHighestY.java
@@ -1,0 +1,68 @@
+package com.shanebeestudios.skbee.elements.generator.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.generator.event.BlockPopulateEvent;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("ChunkGenerator - Highest Block Y")
+@Description("Get the highest block y at a position in a chunk in a `block pop` section.")
+@Examples("set {_y} to chunkdata highest y at vector(1,0,1)")
+@Since("INSERT VERSION")
+public class ExprChunkDataHighestY extends SimpleExpression<Number> {
+
+    static {
+        Skript.registerExpression(ExprChunkDataHighestY.class, Number.class, ExpressionType.SIMPLE,
+            "chunk[ ]data highest [block] y at %vector%");
+    }
+
+    private Expression<Vector> vector;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.vector = (Expression<Vector>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected Number @Nullable [] get(Event event) {
+        Vector vector = this.vector.getSingle(event);
+        if (vector == null) return null;
+        if (event instanceof BlockPopulateEvent popEvent) {
+            int x = (popEvent.getChunkX() << 4) + vector.getBlockX();
+            int z = (popEvent.getChunkZ() << 4) + vector.getBlockZ();
+            int highest = popEvent.getLimitedRegion().getHighestBlockYAt(x, z);
+            return new Number[]{highest};
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "chunkdata highest y at " + vector.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataHighestY.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataHighestY.java
@@ -45,7 +45,7 @@ public class ExprChunkDataHighestY extends SimpleExpression<Number> {
         if (event instanceof BlockPopulateEvent popEvent) {
             int x = (popEvent.getChunkX() << 4) + vector.getBlockX();
             int z = (popEvent.getChunkZ() << 4) + vector.getBlockZ();
-            int highest = popEvent.getLimitedRegion().getHighestBlockYAt(x, z, HeightMap.WORLD_SURFACE_WG);
+            int highest = popEvent.getLimitedRegion().getHighestBlockYAt(x, z, HeightMap.WORLD_SURFACE_WG) - 1;
             return new Number[]{highest};
         }
         return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
     "data in the \"custom\" compound tag of a block/entity's NBT compound. Due to Minecraft not supporting this, I had to use some hacky methods to make this happen.",
     "That said, this system is a tad convoluted, see the SkBee WIKI for more details.",
     "\nNOTE 1.20.5+: All custom data on items must be stored in the \"minecraft:custom_data\" compound " +
-    "(see examples and [**McWiki**](https://minecraft.wiki/w/Data_component_format#custom_data)).",
+        "(see examples and [**McWiki**](https://minecraft.wiki/w/Data_component_format#custom_data)).",
     "For more info regarding 1.20.5+ components please see [**Data Component Format**](https://minecraft.wiki/w/Data_component_format) on McWiki.",
     "\nADD: You can add numbers to number type tags, you can also add numbers/strings/compounds to lists type tags.",
     "\nREMOVE: You can remove numbers from number type tags, you can also remove numbers/strings from lists type tags.",
@@ -134,6 +134,10 @@ public class ExprTagOfNBT extends SimpleExpression<Object> {
         if (object instanceof ArrayList<?> arrayList) {
             return arrayList.toArray();
         }
+        if (object instanceof NBTCompound compound) return new NBTCompound[]{compound};
+        else if (object instanceof String string) return new String[]{string};
+        else if (object instanceof Number number) return new Number[]{number};
+        else if (object instanceof Boolean bool) return new Boolean[]{bool};
         return new Object[]{object};
     }
 
@@ -208,9 +212,8 @@ public class ExprTagOfNBT extends SimpleExpression<Object> {
         return Object.class;
     }
 
-    @SuppressWarnings("DataFlowIssue")
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(Event e, boolean d) {
         String type = this.nbtType.toString(e, d);
         String tag = this.tag.toString(e, d);
         String nbt = this.nbt.toString(e, d);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffTransferCookieRetrieve.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffTransferCookieRetrieve.java
@@ -3,7 +3,6 @@ package com.shanebeestudios.skbee.elements.other.effects;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
@@ -20,13 +19,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Transfer - Retrieve Cookie")
-@Description({"Retrieve a cookie from a player and store it in a variable. Requires Minecraft 1.20.5+",
-    "Due to the retrieval process happening async, this needs to be stored in a variable.",
-    "While the cookie is being retrieved, your proceeding code will wait.",
-    "NOTE: Cookies are stored across server transfers."})
-@Examples({"retrieve cookie with key \"my_id:super_mom_cookie\" from player and store in {_cookie}",
-    "broadcast {_cookie}"})
+@Description({"DEPRECATED - Use retrieve cookie section."})
 @Since("3.5.0")
+@Deprecated(forRemoval = true, since = "May 25/2024")
 public class EffTransferCookieRetrieve extends Effect {
 
     static {
@@ -46,6 +41,7 @@ public class EffTransferCookieRetrieve extends Effect {
         this.key = exprs[0];
         this.player = (Expression<Player>) exprs[1];
         this.object = exprs[2];
+        Skript.warning("DEPRECATED - Use retrieve cookie section.");
         return true;
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTransferCookie.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprTransferCookie.java
@@ -1,0 +1,75 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Transfer - Transfer Cookie")
+@Description("Represents the cookie data in a transfer section.")
+@Examples({"command /server <string>:",
+    "\ttrigger:",
+    "\t\tstore cookie \"%uuid of player%-transfer\" with key \"transfer\" on player",
+    "\t\ttransfer player to arg-1",
+    "",
+    "on join:",
+    "\t# only do a cookie check if player was transferred",
+    "\tif player is transferred:",
+    "\t\tretrieve cookie with key \"transfer\" from player:",
+    "\t\t\tif transfer cookie = \"%uuid of player%-transfer\":",
+    "\t\t\t\t# stop code if cookie is correct",
+    "\t\t\t\tstop",
+    "\t\t# kick player if cookie is missing or incorrect",
+    "\t\tkick player due to \"&cIllegal Transfer\""})
+@Since("INSERT VERSION")
+public class ExprTransferCookie extends SimpleExpression<String> {
+
+    static {
+        Skript.registerExpression(ExprTransferCookie.class, String.class, ExpressionType.SIMPLE,
+            "transfer cookie");
+    }
+
+    private static String lastTransferCookie = null;
+
+    public static void setLastTransferCookie(String transferCookie) {
+        lastTransferCookie = transferCookie;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected String @Nullable [] get(Event event) {
+        if (lastTransferCookie != null) return new String[]{lastTransferCookie};
+        return null;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends String> getReturnType() {
+        return String.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean debug) {
+        return "transfer cookie";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/sections/SecTransferCookieRetrieve.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/sections/SecTransferCookieRetrieve.java
@@ -1,0 +1,129 @@
+package com.shanebeestudios.skbee.elements.other.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.Util;
+import com.shanebeestudios.skbee.elements.other.expressions.ExprTransferCookie;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@Name("Transfer - Retrieve Cookie")
+@Description({"Retrieve a cookie from a player. Requires Minecraft 1.20.5+",
+    "Due to the retrieval process happening async, this will delay proceeding code.",
+    "While the cookie is being retrieved, the following code will wait.",
+    "If there is no available cookie, the section will not execute.",
+    "NOTE: Cookies are stored across server transfers."})
+@Examples({"command /server <string>:",
+    "\ttrigger:",
+    "\t\tstore cookie \"%uuid of player%-transfer\" with key \"transfer\" on player",
+    "\t\ttransfer player to arg-1",
+    "",
+    "on join:",
+    "\t# only do a cookie check if player was transferred",
+    "\tif player is transferred:",
+    "\t\tretrieve cookie with key \"transfer\" from player:",
+    "\t\t\tif transfer cookie = \"%uuid of player%-transfer\":",
+    "\t\t\t\t# stop code if cookie is correct",
+    "\t\t\t\tstop",
+    "\t\t# kick player if cookie is missing or incorrect",
+    "\t\tkick player due to \"&cIllegal Transfer\""})
+@Since("INSERT VERSION")
+public class SecTransferCookieRetrieve extends Section {
+
+    static {
+        Skript.registerSection(SecTransferCookieRetrieve.class,
+            "retrieve cookie with key %namespacedkey/string% from %player%");
+    }
+
+    private Expression<?> key;
+    private Expression<Player> player;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        this.key = exprs[0];
+        this.player = (Expression<Player>) exprs[1];
+        ParserInstance parserInstance = ParserInstance.get();
+        Kleenean hasDelayBefore = parserInstance.getHasDelayBefore();
+        parserInstance.setHasDelayBefore(Kleenean.TRUE);
+        assert parserInstance.getCurrentEvents() != null;
+        loadCode(sectionNode);
+        parserInstance.setHasDelayBefore(hasDelayBefore);
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable TriggerItem walk(Event event) {
+        TriggerItem next = getNext();
+
+        //Let's save you guys for later after the cookie has loaded
+        Object localVars = Variables.removeLocals(event);
+
+        Player player = this.player.getSingle(event);
+        Object keyObject = this.key.getSingle(event);
+        if (player == null || keyObject == null) return next;
+
+        NamespacedKey key;
+        if (keyObject instanceof String string) {
+            key = Util.getNamespacedKey(string, false);
+        } else if (keyObject instanceof NamespacedKey namespacedKey) {
+            key = namespacedKey;
+        } else {
+            return next;
+        }
+        if (key == null) return next;
+
+        player.retrieveCookie(key).thenAccept(bytes -> {
+            String cookie = new String(bytes);
+            ExprTransferCookie.setLastTransferCookie(cookie);
+            walkNext(localVars, event, first, next);
+        }).exceptionally(throwable -> {
+            walkNext(localVars, event, null, next);
+            return null;
+        });
+        return null;
+    }
+
+    private static void walkNext(Object localVars, Event event, @Nullable TriggerItem sec, TriggerItem next) {
+        //re-set local variables
+        if (localVars != null) Variables.setLocalVariables(event, localVars);
+
+        // walk section
+        if (sec != null) {
+            // walk the section
+            TriggerItem.walk(sec, event);
+            // Clear cookie data before moving on
+            ExprTransferCookie.setLastTransferCookie(null);
+        }
+
+        // walk next trigger
+        else if (next != null) TriggerItem.walk(next, event);
+
+        // remove local vars as we're now done
+        Variables.removeLocals(event);
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return String.format("retrieve cookie with key %s from %s",
+            this.key.toString(e, d), this.player.toString(e, d));
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -21,6 +21,7 @@ import org.bukkit.Color;
 import org.bukkit.EntityEffect;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
+import org.bukkit.TreeType;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.EntityType;
@@ -43,7 +44,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.StreamCorruptedException;
 
-@SuppressWarnings({"rawtypes", "deprecation", "removal"})
+@SuppressWarnings({"rawtypes", "removal"})
 public class Types {
 
     public static boolean HAS_ARMOR_TRIM = Skript.classExists("org.bukkit.inventory.meta.trim.ArmorTrim");
@@ -379,6 +380,14 @@ public class Types {
                     return toString(bukkitColor, 0);
                 }
             }));
+
+        EnumWrapper<TreeType> TREE_TYPE = new EnumWrapper<>(TreeType.class, "", "tree");
+        Classes.registerClass(TREE_TYPE.getClassInfo("bukkittreetype")
+            .user("bukkit ?tree ?types?")
+            .name("Bukkit Tree Type")
+            .description("Represents the different types of trees.")
+            .after("structuretype")
+            .since("INSERT VERSION"));
     }
 
     // FUNCTIONS

--- a/src/main/java/com/shanebeestudios/skbee/elements/team/expressions/ExprTeamColor.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/team/expressions/ExprTeamColor.java
@@ -13,14 +13,14 @@ import com.shanebeestudios.skbee.api.util.ChatUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.event.Event;
 import org.bukkit.scoreboard.Team;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("deprecation")
 @Name("Team - Color")
 @Description("Get/set the color of a team.")
 @Examples({"set team color of {_team} to blue",
-        "set team color of team of player to red"})
+    "set team color of team of player to red"})
 @Since("1.16.0")
 public class ExprTeamColor extends SimplePropertyExpression<Team, SkriptColor> {
 
@@ -35,21 +35,20 @@ public class ExprTeamColor extends SimplePropertyExpression<Team, SkriptColor> {
 
     @SuppressWarnings("NullableProblems")
     @Override
-    public @Nullable Class<?>[] acceptChange(ChangeMode mode) {
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
         return switch (mode) {
             case SET, RESET -> CollectionUtils.array(Color.class);
             default -> null;
         };
     }
 
-    @SuppressWarnings("NullableProblems")
+    @SuppressWarnings({"NullableProblems", "ConstantValue"})
     @Override
     public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-        Object object = delta[0];
-        SkriptColor color = object instanceof SkriptColor ? (SkriptColor) object : null;
+        SkriptColor color = delta != null && delta[0] instanceof SkriptColor skriptColor ? skriptColor : null;
 
         for (Team team : getExpr().getArray(event)) {
-            if (mode == ChangeMode.SET && color != null) {
+            if (color != null) {
                 team.setColor(color.asChatColor());
             } else {
                 team.setColor(ChatColor.WHITE);

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprAsyncChatViewers.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprAsyncChatViewers.java
@@ -1,0 +1,115 @@
+package com.shanebeestudios.skbee.elements.text.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.audience.Audience;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Async Chat Viewers")
+@Description({"Represents the viewers that this chat message will be displayed to.",
+    "NOTE: Can only be used in an `async chat event`. Requires PaperMC"})
+@Examples({"on async chat:",
+    "\tclear chat viewers",
+    "\tadd player to chat viewers",
+    "",
+    "on async chat:",
+    "\tset chat viewers to players in world of player",
+    "",
+    "on async chat:",
+    "\tremove (all players where [input doesn't have permission \"staff.chat\"]) from chat viewers"})
+@Since("INSERT VERSION")
+public class ExprAsyncChatViewers extends SimpleExpression<CommandSender> {
+
+    static {
+        Skript.registerExpression(ExprAsyncChatViewers.class, CommandSender.class, ExpressionType.SIMPLE,
+            "[async] chat viewers");
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!(ParserInstance.get().isCurrentEvent(AsyncChatEvent.class))) {
+            Skript.error("'" + parseResult.expr + "' can only be used in the Async Chat Event.");
+            return false;
+        }
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems", "SuspiciousToArrayCall"})
+    @Override
+    protected CommandSender @Nullable [] get(Event event) {
+        if (event instanceof AsyncChatEvent chatEvent) {
+            return chatEvent.viewers().toArray(new CommandSender[0]);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case ADD, REMOVE, SET -> CollectionUtils.array(CommandSender[].class);
+            case DELETE -> CollectionUtils.array();
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantValue"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        if (!(event instanceof AsyncChatEvent chatEvent)) return;
+        if (mode == ChangeMode.DELETE) {
+            chatEvent.viewers().clear();
+            return;
+        }
+        // Failsafe just incase
+        if (delta == null) return;
+
+        List<Audience> viewers = new ArrayList<>();
+        for (Object object : delta) {
+            if (object instanceof CommandSender sender) viewers.add(sender);
+        }
+        switch (mode) {
+            case ADD -> chatEvent.viewers().addAll(viewers);
+            case REMOVE -> viewers.forEach(chatEvent.viewers()::remove);
+            case SET -> {
+                chatEvent.viewers().clear();
+                chatEvent.viewers().addAll(viewers);
+            }
+        }
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends CommandSender> getReturnType() {
+        return CommandSender.class;
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "async chat viewers";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprLoadedCustomWorlds.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprLoadedCustomWorlds.java
@@ -1,0 +1,58 @@
+package com.shanebeestudios.skbee.elements.worldcreator.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.SkBee;
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Loaded Custom Worlds")
+@Description({"Represents all loaded custom worlds created using SkBee.",
+    "This will not include worlds created by other plugins, such as MultiVerse."})
+@Examples("loop all loaded custom worlds:")
+@Since("INSERT VERSION")
+public class ExprLoadedCustomWorlds extends SimpleExpression<World> {
+
+    static {
+        Skript.registerExpression(ExprLoadedCustomWorlds.class, World.class, ExpressionType.SIMPLE,
+            "[all] loaded (custom|skbee) worlds");
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable World[] get(Event event) {
+        return SkBee.getPlugin().getBeeWorldConfig().getLoadedCustomWorlds().toArray(new World[0]);
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends World> getReturnType() {
+        return World.class;
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "all loaded custom worlds";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldConfig.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldConfig.java
@@ -1,18 +1,22 @@
 package com.shanebeestudios.skbee.elements.worldcreator.objects;
 
+import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.WorldType;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import com.shanebeestudios.skbee.SkBee;
-import com.shanebeestudios.skbee.api.util.Util;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -22,7 +26,7 @@ public class BeeWorldConfig {
     private final SkBee plugin;
     private FileConfiguration worldConfig;
     private File worldConfigFile;
-    private boolean autoLoadWorlds;
+    private final boolean autoLoadWorlds;
 
     private final Map<String, BeeWorldCreator> WORLDS = new HashMap<>();
 
@@ -46,7 +50,7 @@ public class BeeWorldConfig {
         ConfigurationSection section = worldConfig.getConfigurationSection("worlds");
         if (section != null) {
             Set<String> keys = section.getKeys(false);
-            if (keys.size() == 0) {
+            if (keys.isEmpty()) {
                 return;
             }
             Util.log("&6Loading custom worlds...");
@@ -62,7 +66,7 @@ public class BeeWorldConfig {
         }
     }
 
-    public BeeWorldCreator loadWorld(String name) {
+    public @Nullable BeeWorldCreator loadWorld(String name) {
         String path = "worlds." + name + ".";
         BeeWorldCreator worldCreator = new BeeWorldCreator(name);
 
@@ -186,6 +190,20 @@ public class BeeWorldConfig {
             Util.skriptError(" - &7Default to NORMAL");
             return Environment.NORMAL;
         }
+    }
+
+    /**
+     * Get all loaded custom worlds
+     *
+     * @return All loaded custom worlds
+     */
+    public List<World> getLoadedCustomWorlds() {
+        List<World> worlds = new ArrayList<>();
+        WORLDS.forEach((string, beeWorldCreator) -> {
+            World world = Bukkit.getWorld(beeWorldCreator.getWorldName());
+            if (world != null) worlds.add(world);
+        });
+        return worlds;
     }
 
 }


### PR DESCRIPTION
Preparation for future patch release.

Temp changelog:
## FIXED:
- Fixed a long standing casting issue when using the NBT tag expression nested within other expressions
- Fixed an error when attempting to get key of an invalid registry wrapper object (this can happen with reflect)
- Fixed an issue with the chunkdata biome expression not being properly shifted

## ADDED:
- Added a section for retrieving cookies
- Added an expression to get the cookie in a cookie retrieval section
- Added an expression for chat viewers in the async chat event
- Added an expression to get all loaded custom worlds
- Added an effect/type to populate trees in a chunk generator
- Added an expression to get the highest block Y in a chunk generator block pop section

## CHANGED:
- Deprecated cookie retrieval effect (using section instead)
- ChunkData structure place effect now uses chunk position rather than world position (for consistency with other effects/expressions)
- Changed chunkdata block expression to use chunk position rather than world position