### PR TITLE
Dev/Patch - Prepare for future release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("org.apache.commons:commons-text:1.10.0")
 
     // NBT-API
-    implementation("de.tr7zw:item-nbt-api:2.13.0") {
+    implementation("de.tr7zw:item-nbt-api:2.13.1-SNAPSHOT") {
         transitive = false
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     // Paper
-    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
 
     // Skript
     compileOnly(group: 'com.github.SkriptLang', name: 'Skript', version: '2.7.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly("org.apache.commons:commons-text:1.10.0")
 
     // NBT-API
-    implementation("de.tr7zw:item-nbt-api:2.12.4") {
+    implementation("de.tr7zw:item-nbt-api:2.13.0") {
         transitive = false
     }
 
@@ -100,7 +100,7 @@ shadowJar {
 tasks.register('server', Copy) {
     from shadowJar
     // Change this to wherever you want your jar to build
-    into '/Users/ShaneBee/Desktop/Server/Skript/1-20-6/plugins'
+    into '/Users/ShaneBee/Desktop/Server/Skript/1-21/plugins'
 }
 
 publishing {

--- a/src/main/java/com/shanebeestudios/skbee/api/generator/ChunkGenerator.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/generator/ChunkGenerator.java
@@ -112,7 +112,7 @@ public class ChunkGenerator extends org.bukkit.generator.ChunkGenerator {
             @Override
             public void populate(@NotNull WorldInfo worldInfo, @NotNull Random random, int chunkX, int chunkZ, @NotNull LimitedRegion limitedRegion) {
                 if (ChunkGenerator.this.blockPopTrigger != null) {
-                    BlockPopulateEvent populateEvent = new BlockPopulateEvent(limitedRegion, chunkX, chunkZ);
+                    BlockPopulateEvent populateEvent = new BlockPopulateEvent(limitedRegion, chunkX, chunkZ, random);
                     ChunkGenerator.this.blockPopTrigger.execute(populateEvent);
                 }
             }

--- a/src/main/java/com/shanebeestudios/skbee/api/generator/event/BlockPopulateEvent.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/generator/event/BlockPopulateEvent.java
@@ -2,15 +2,19 @@ package com.shanebeestudios.skbee.api.generator.event;
 
 import org.bukkit.generator.LimitedRegion;
 
+import java.util.Random;
+
 public class BlockPopulateEvent extends BaseGenEvent {
 
     private final LimitedRegion limitedRegion;
     private final int chunkX, chunkZ;
+    private final Random random;
 
-    public BlockPopulateEvent(LimitedRegion limitedRegion, int chunkX, int chunkZ) {
+    public BlockPopulateEvent(LimitedRegion limitedRegion, int chunkX, int chunkZ, Random random) {
         this.limitedRegion = limitedRegion;
         this.chunkX = chunkX;
         this.chunkZ = chunkZ;
+        this.random = random;
     }
 
     public LimitedRegion getLimitedRegion() {
@@ -25,4 +29,7 @@ public class BlockPopulateEvent extends BaseGenEvent {
         return this.chunkZ;
     }
 
+    public Random getRandom() {
+        return this.random;
+    }
 }

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 /**
  * Main NBT api for SkBee
  */
+@SuppressWarnings("deprecation")
 public class NBTApi {
 
     @SuppressWarnings("ConstantConditions")

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomEntity.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomEntity.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
+@SuppressWarnings("deprecation")
 public class NBTCustomEntity extends NBTEntity implements NBTCustom {
 
     private final Entity entity;

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomItemStack.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomItemStack.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.ItemStack;
  * <p>This is used due to a deprecation in NBTItem, as well as a protected constructor,
  * as well as funny changes in NBT-API due to MC 1.20.5</p>
  */
+@SuppressWarnings("deprecation")
 public class NBTCustomItemStack extends NBTContainer {
 
     private final ItemStack originalItemStack;

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomTileEntity.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomTileEntity.java
@@ -10,6 +10,7 @@ import org.bukkit.block.TileState;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
+@SuppressWarnings("deprecation")
 public class NBTCustomTileEntity extends NBTTileEntity implements NBTCustom {
 
     private final BlockState blockState;

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
@@ -25,9 +25,6 @@ public enum NBTCustomType {
     // Other
     NBTTagString("string", NBTType.NBTTagString, String.class),
     NBTTagCompound("compound", NBTType.NBTTagCompound, NBTCompound.class),
-    // Custom
-    NBTTagUUID("uuid", NBTType.NBTTagIntArray, String.class),
-    NBTTagBoolean("boolean", NBTType.NBTTagByte, Boolean.class),
     // Lists and Arrays
     NBTTagByteArray("byte array", NBTType.NBTTagByteArray, Number[].class),
     NBTTagIntArray("int array", NBTType.NBTTagIntArray, Number[].class),
@@ -36,7 +33,10 @@ public enum NBTCustomType {
     NBTTagLongList("long list", NBTType.NBTTagList, Number[].class),
     NBTTagIntList("int list", NBTType.NBTTagList, Number[].class),
     NBTTagCompoundList("compound list", NBTType.NBTTagList, NBTCompound[].class),
-    NBTTagStringList("string list", NBTType.NBTTagList, String[].class);
+    NBTTagStringList("string list", NBTType.NBTTagList, String[].class),
+    // Custom
+    NBTTagUUID("uuid", NBTType.NBTTagIntArray, String.class),
+    NBTTagBoolean("boolean", NBTType.NBTTagByte, Boolean.class);
 
     final String name;
     final NBTType nbtType;
@@ -69,9 +69,11 @@ public enum NBTCustomType {
 
     static {
         for (NBTCustomType type : NBTCustomType.values()) {
-            if (type != NBTTagEnd)
+            if (type != NBTTagEnd) {
                 BY_NAME.put(type.name, type);
-            BY_TYPE.put(type.nbtType, type);
+                // Only register if type isn't registered yet
+                if (!BY_TYPE.containsKey(type.nbtType)) BY_TYPE.put(type.nbtType, type);
+            }
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/api/util/ObjectConverter.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/ObjectConverter.java
@@ -48,11 +48,11 @@ public abstract class ObjectConverter<T> {
         CONVERTERS.put(c, converter);
     }
 
-    private static <E extends Keyed> void register(Class<E> c, Registry<E> registery) {
+    private static <E extends Keyed> void register(Class<E> c, Registry<E> registry) {
         ObjectConverter<E> objectConverter = new ObjectConverter<>() {
             @Override
             public E get(NamespacedKey key) {
-                return registery.get(key);
+                return registry.get(key);
             }
         };
         CONVERTERS.put(c, objectConverter);

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -34,6 +34,7 @@ public class Util {
 
     // Shortcut for finding stuff to remove later
     public static final boolean IS_RUNNING_SKRIPT_2_9 = Skript.getVersion().isLargerThan(new Version(2,8,999));
+    public static final boolean IS_RUNNING_MC_1_21 = Skript.isRunningMinecraft(1,21);
 
     @SuppressWarnings("deprecation") // Paper deprecation
     public static String getColString(String string) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffPopulateTree.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffPopulateTree.java
@@ -28,8 +28,6 @@ import java.util.Random;
 @Since("3.5.3")
 public class EffPopulateTree extends Effect {
 
-    private static final Random RANDOM = new Random();
-
     static {
         Skript.registerEffect(EffPopulateTree.class,
             "populate %bukkittreetype% at %vectors%");
@@ -59,11 +57,12 @@ public class EffPopulateTree extends Effect {
         if (treeType == null) return;
 
         LimitedRegion region = popEvent.getLimitedRegion();
+        Random random = popEvent.getRandom();
         for (Vector vector : this.vector.getArray(event)) {
             int x = (popEvent.getChunkX() << 4) + MathUtil.clamp(vector.getBlockX(), 0, 15);
             int z = (popEvent.getChunkZ() << 4) + MathUtil.clamp(vector.getBlockZ(), 0, 15);
             Location location = new Location(null, x, vector.getBlockY(), z);
-            region.generateTree(location, RANDOM, treeType);
+            region.generateTree(location, random, treeType);
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataBlock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataBlock.java
@@ -18,6 +18,7 @@ import com.shanebeestudios.skbee.api.generator.event.ChunkGenEvent;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.event.Event;
 import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.LimitedRegion;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -115,7 +116,11 @@ public class ExprChunkDataBlock extends SimpleExpression<BlockData> {
                     int x = (popEvent.getChunkX() << 4) + vec.getBlockX();
                     int y = vec.getBlockY();
                     int z = (popEvent.getChunkZ() << 4) + vec.getBlockZ();
-                    popEvent.getLimitedRegion().setBlockData(x, y, z, blockData);
+                    LimitedRegion region = popEvent.getLimitedRegion();
+                    if (region.isInRegion(x,y,z)) {
+                        // Make sure we are setting within the available region
+                        region.setBlockData(x, y, z, blockData);
+                    }
                 }
             }
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataBlock.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/expressions/ExprChunkDataBlock.java
@@ -15,7 +15,6 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.generator.event.BlockPopulateEvent;
 import com.shanebeestudios.skbee.api.generator.event.ChunkGenEvent;
-import com.shanebeestudios.skbee.api.util.MathUtil;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.event.Event;
 import org.bukkit.generator.ChunkGenerator;
@@ -27,7 +26,8 @@ import org.jetbrains.annotations.Nullable;
 @Description({"Represents blocks in a ChunkData.",
     "The first pattern is used to set a block in a `chunk gen` or `block pop` section.",
     "The second pattern is used to fill blocks between 2 points in a `chunk gen` section.",
-    "NOTE: The vector represents the position in a chunk, not a world."})
+    "NOTE: The vector represents the position in a chunk, not a world.",
+    "NOTE: You CAN reach into neighbouring chunks going below 0/above 15 in the vector. I don't know how far you can safely reach though."})
 @Examples({"chunk gen:",
     "\tset chunkdata blocks within vector({_x}, 0, {_z}) and vector({_x}, {_y}, {_z}) to red_concrete[]",
     "\tset chunkdata block at vector({_x}, {_y}, {_z}) to red_concrete_powder[]"})
@@ -72,9 +72,9 @@ public class ExprChunkDataBlock extends SimpleExpression<BlockData> {
             int z = vec.getBlockZ();
             return new BlockData[]{chunkGenEvent.getChunkData().getBlockData(x, y, z)};
         } else if (event instanceof BlockPopulateEvent popEvent) {
-            int x = (popEvent.getChunkX() << 4) + MathUtil.clamp(vec.getBlockX(), 0, 15);
+            int x = (popEvent.getChunkX() << 4) + vec.getBlockX();
             int y = vec.getBlockY();
-            int z = (popEvent.getChunkZ() << 4) + MathUtil.clamp(vec.getBlockZ(), 0, 15);
+            int z = (popEvent.getChunkZ() << 4) + vec.getBlockZ();
             return new BlockData[]{popEvent.getLimitedRegion().getBlockData(x, y, z)};
         }
         return null;
@@ -112,9 +112,9 @@ public class ExprChunkDataBlock extends SimpleExpression<BlockData> {
                         chunkGenEvent.getChunkData().setBlock(x, y, z, blockData);
                     }
                 } else if (event instanceof BlockPopulateEvent popEvent) {
-                    int x = (popEvent.getChunkX() << 4) + MathUtil.clamp(vec.getBlockX(), 0, 15);
+                    int x = (popEvent.getChunkX() << 4) + vec.getBlockX();
                     int y = vec.getBlockY();
-                    int z = (popEvent.getChunkZ() << 4) + MathUtil.clamp(vec.getBlockZ(), 0, 15);
+                    int z = (popEvent.getChunkZ() << 4) + vec.getBlockZ();
                     popEvent.getLimitedRegion().setBlockData(x, y, z, blockData);
                 }
             }

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprItemFromNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprItemFromNBT.java
@@ -17,6 +17,7 @@ import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("deprecation")
 @Name("NBT - Item from NBT")
 @Description({"This expression allows you to grab an item from NBT compounds.",
     "This can be useful when wanting to grab items from file nbt, or nbt of an entity or an inventory holding block (like a chest or furnace).",

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprNbtCompound.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprNbtCompound.java
@@ -36,6 +36,7 @@ import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("deprecation")
 @Name("NBT - Compound of Object")
 @Description({"Get the NBT compound of a block/entity/item/file/chunk.",
     "",

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/types/SkriptTypes.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/types/SkriptTypes.java
@@ -41,10 +41,9 @@ public class SkriptTypes {
                 }
             } else if (mode == ChangeMode.DELETE || mode == ChangeMode.RESET) {
                 for (NBTCompound nbtCompound : what) {
+                    nbtCompound.clearNBT();
                     if (nbtCompound instanceof NBTFile nbtFile && mode == ChangeMode.DELETE) {
                         nbtFile.getFile().delete();
-                    } else {
-                        nbtCompound.clearNBT();
                     }
                 }
             }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffEquipmentChange.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffEquipmentChange.java
@@ -21,17 +21,17 @@ import org.jetbrains.annotations.Nullable;
 @Name("Send Equipment Change")
 @Description("Send an equipment change for an entity. This will not actually change the entity's equipment in any way.")
 @Examples({"make player see hand slot of target entity as diamond sword",
-        "make all players see off hand slot of player as shield"})
+    "make all players see off hand slot of player as shield"})
 @Since("3.4.0")
 public class EffEquipmentChange extends Effect {
 
     static {
         Skript.registerEffect(EffEquipmentChange.class,
-                "make %players% see %equipmentslot% of %livingentities% as %itemtype%");
+            "make %players% see %equipmentslots% of %livingentities% as %itemtype%");
     }
 
     private Expression<Player> players;
-    private Expression<EquipmentSlot> slot;
+    private Expression<EquipmentSlot> slots;
     private Expression<LivingEntity> entities;
     private Expression<ItemType> itemtype;
 
@@ -39,7 +39,7 @@ public class EffEquipmentChange extends Effect {
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         this.players = (Expression<Player>) exprs[0];
-        this.slot = (Expression<EquipmentSlot>) exprs[1];
+        this.slots = (Expression<EquipmentSlot>) exprs[1];
         this.entities = (Expression<LivingEntity>) exprs[2];
         this.itemtype = (Expression<ItemType>) exprs[3];
         return true;
@@ -49,13 +49,14 @@ public class EffEquipmentChange extends Effect {
     @Override
     protected void execute(Event event) {
         ItemType itemType = this.itemtype.getSingle(event);
-        EquipmentSlot slot = this.slot.getSingle(event);
-        if (itemType == null || slot == null) return;
+        if (itemType == null) return;
         ItemStack itemStack = itemType.getRandom();
 
         for (Player player : this.players.getArray(event)) {
             for (LivingEntity livingEntity : this.entities.getArray(event)) {
-                player.sendEquipmentChange(livingEntity, slot, itemStack);
+                for (EquipmentSlot slot : this.slots.getArray(event)) {
+                    player.sendEquipmentChange(livingEntity, slot, itemStack);
+                }
             }
         }
     }
@@ -64,7 +65,7 @@ public class EffEquipmentChange extends Effect {
     @Override
     public @NotNull String toString(@Nullable Event e, boolean d) {
         String players = this.players.toString(e, d);
-        String slot = this.slot.toString(e, d);
+        String slot = this.slots.toString(e, d);
         String entities = this.entities.toString(e, d);
         String item = this.itemtype.toString(e, d);
         return String.format("make %s see %s of %s as %s", players, slot, entities, item);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffLootTableFillInv.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffLootTableFillInv.java
@@ -10,6 +10,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -25,18 +26,18 @@ import java.util.Random;
 
 @Name("LootTable - Fill Inventory")
 @Description({"Fill an inventory with a predefined LootTable.",
-        "This inventory must belong to a block or entity (custom inventories will not work).",
-        "Optionals:",
-        "Some loot tables will require some of these values whereas others may not.",
-        "`seed` = Represents the random seed used to generate loot (if not provided will generate randomly).",
-        "`looting modifier` = Set the looting enchant level equivalent to use when generating loot.",
-        "Values less than or equal to 0 will force the LootTable to only return a single Item per pool.",
-        "`luck` = How much luck to have when generating loot.",
-        "`killer/looter` = The Player that killed/looted. This Player will be used to get the looting level if looting modifier is not set.",
-        "`looted entity` = The Entity that was killed/looted."})
+    "This inventory must belong to a block or entity (custom inventories will not work).",
+    "Optionals:",
+    "Some loot tables will require some of these values whereas others may not.",
+    "`seed` = Represents the random seed used to generate loot (if not provided will generate randomly).",
+    "`looting modifier` = Set the looting enchant level equivalent to use when generating loot.",
+    "Values less than or equal to 0 will force the LootTable to only return a single Item per pool.",
+    "`luck` = How much luck to have when generating loot.",
+    "`killer/looter` = The Player that killed/looted. This Player will be used to get the looting level if looting modifier is not set.",
+    "`looted entity` = The Entity that was killed/looted."})
 @Examples({"set {_loottable} to loottable from key \"minecraft:chests/ancient_city\"",
-        "fill inventory of target block from {_loottable}",
-        "fill inventory of player from (loottable from key \"minecraft:gameplay/fishing\")"})
+    "fill inventory of target block from {_loottable}",
+    "fill inventory of player from (loottable from key \"minecraft:gameplay/fishing\")"})
 @Since("3.4.0")
 public class EffLootTableFillInv extends Effect {
 
@@ -44,8 +45,8 @@ public class EffLootTableFillInv extends Effect {
 
     static {
         Skript.registerEffect(EffLootTableFillInv.class,
-                "fill %inventories% from %loottable% [with seed %-number%] [with looting modifier %-number%] " +
-                        "[with luck %-number%] [with (killer|looter) %-player%] [with looted entity %-entity%]");
+            "fill %inventories% from %loottable% [with seed %-number%] [with looting modifier %-number%] " +
+                "[with luck %-number%] [with (killer|looter) %-player%] [with looted entity %-entity%]");
     }
 
     private Expression<Inventory> inventories;
@@ -63,13 +64,17 @@ public class EffLootTableFillInv extends Effect {
         this.lootTable = (Expression<LootTable>) exprs[1];
         this.seed = (Expression<Number>) exprs[2];
         this.lootingModifier = (Expression<Number>) exprs[3];
+        if (Util.IS_RUNNING_MC_1_21 && this.lootingModifier != null) {
+            Skript.error("'with looting modifier' is no longer functional!");
+            return false;
+        }
         this.luck = (Expression<Number>) exprs[4];
         this.killer = (Expression<Player>) exprs[5];
         this.lootedEntity = (Expression<Entity>) exprs[6];
         return true;
     }
 
-    @SuppressWarnings({"NullableProblems", "CallToPrintStackTrace"})
+    @SuppressWarnings({"NullableProblems", "CallToPrintStackTrace", "deprecation"})
     @Override
     protected void execute(Event event) {
         LootTable lootTable = this.lootTable.getSingle(event);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
@@ -13,6 +13,7 @@ import com.destroystokyo.paper.event.entity.EntityPathfindEvent;
 import com.destroystokyo.paper.event.entity.EntityZapEvent;
 import com.destroystokyo.paper.event.entity.ExperienceOrbMergeEvent;
 import com.destroystokyo.paper.event.entity.SkeletonHorseTrapEvent;
+import com.destroystokyo.paper.event.entity.SlimePathfindEvent;
 import com.destroystokyo.paper.event.player.PlayerElytraBoostEvent;
 import com.destroystokyo.paper.event.player.PlayerPickupExperienceEvent;
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "unchecked"})
 public class PaperEvents extends SimpleEvent {
 
     static {
@@ -195,7 +196,7 @@ public class PaperEvents extends SimpleEvent {
 
         // Entity Pathfind Event
         if (Skript.classExists("com.destroystokyo.paper.event.entity.EntityPathfindEvent")) {
-            Skript.registerEvent("Entity Pathfind Event", PaperEvents.class, EntityPathfindEvent.class, "entity start[s] pathfinding")
+            Skript.registerEvent("Entity Pathfind Event", PaperEvents.class, new Class[]{EntityPathfindEvent.class, SlimePathfindEvent.class}, "entity start[s] pathfinding")
                     .description("Called when an Entity decides to start moving towards a location. This event does not fire for the entities " +
                             "actual movement. Only when it is choosing to start moving to a location. Requires Paper.")
                     .examples("on entity starts pathfinding:",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAvailableMaterials.java
@@ -110,7 +110,12 @@ public class ExprAvailableMaterials extends SimpleExpression<Object> {
         Registration.registerList("game[ ]rules", GameRule.class, gameRules);
 
         List<LootTable> lootTables = new ArrayList<>();
-        Registry.LOOT_TABLES.forEach(lt -> lootTables.add(lt.getLootTable()));
+        Registry.LOOT_TABLES.forEach(lt -> {
+            LootTable lootTable = lt.getLootTable();
+            // Bukkit claims this is NotNull but the method it grabs from is indeed Nullable
+            //noinspection ConstantValue
+            if (lootTable != null) lootTables.add(lootTable);
+        });
         Registration.registerList("loot tables", LootTable.class, lootTables.stream().sorted(Comparator.comparing(lootTable -> lootTable.getKey().getKey())).toList());
 
         List<Particle> particles = ParticleUtil.getAvailableParticles();

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAverageTickTime.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAverageTickTime.java
@@ -1,0 +1,59 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Average Tick Time")
+@Description("Represents the average amount of time (in milliseconds) it takes for the server to finish a tick. Requires PaperMC.")
+@Examples({"set {_avg} to average tick time",
+    "if average tick time > 40:"})
+@Since("INSERT VERSION")
+public class ExprAverageTickTime extends SimpleExpression<Number> {
+
+    static {
+        if (Skript.methodExists(Bukkit.class, "getAverageTickTime")) {
+            Skript.registerExpression(ExprAverageTickTime.class, Number.class, ExpressionType.SIMPLE,
+                "average tick time");
+        }
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable Number[] get(Event event) {
+        return new Number[]{Bukkit.getAverageTickTime()};
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends Number> getReturnType() {
+        return Number.class;
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "average tick time";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprEntityPose.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprEntityPose.java
@@ -1,0 +1,66 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Pose;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Entity Pose")
+@Description({"Get/set the pose of an entity.",
+    "Note: While poses affect some things like hitboxes, they do not change the entity's state",
+    "(e.g. having sneaking pose does not guarantee `is sneaking` being true). Set requires PaperMC."})
+@Examples({"set {_pose} to pose of player",
+    "set pose of target entity to sleeping pose"})
+@Since("INSERT VERSION")
+public class ExprEntityPose extends SimplePropertyExpression<Entity, Pose> {
+
+    static {
+        register(ExprEntityPose.class, Pose.class, "pose", "entities");
+    }
+
+    @Override
+    public @Nullable Pose convert(Entity entity) {
+        return entity.getPose();
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+        if (!Skript.methodExists(Entity.class, "setPose", Pose.class)) {
+            Skript.error("Setting an entity's pose requires PaperMC.");
+            return null;
+        }
+        if (mode == ChangeMode.SET) return CollectionUtils.array(Pose.class);
+        return null;
+    }
+
+    @SuppressWarnings({"ConstantValue", "NullableProblems"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        if (delta != null && delta[0] instanceof Pose pose) {
+            for (Entity entity : getExpr().getArray(event)) {
+                entity.setPose(pose);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<? extends Pose> getReturnType() {
+        return Pose.class;
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "pose";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLootTableItems.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLootTableItems.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -27,17 +28,17 @@ import java.util.Random;
 
 @Name("LootTable - Items")
 @Description({"Get the items from a predefined LootTable.",
-        "Optionals:",
-        "Some loot tables will require some of these values whereas others may not.",
-        "`seed` = Represents the random seed used to generate loot (if not provided will generate randomly).",
-        "`looting modifier` = Set the looting enchant level equivalent to use when generating loot.",
-        "Values less than or equal to 0 will force the LootTable to only return a single Item per pool.",
-        "`luck` = How much luck to have when generating loot.",
-        "`killer/looter` = The Player that killed/looted. This Player will be used to get the looting level if looting modifier is not set.",
-        "`looted entity` = The Entity that was killed/looted."})
+    "Optionals:",
+    "Some loot tables will require some of these values whereas others may not.",
+    "`seed` = Represents the random seed used to generate loot (if not provided will generate randomly).",
+    "`looting modifier` = Set the looting enchant level equivalent to use when generating loot.",
+    "Values less than or equal to 0 will force the LootTable to only return a single Item per pool.",
+    "`luck` = How much luck to have when generating loot.",
+    "`killer/looter` = The Player that killed/looted. This Player will be used to get the looting level if looting modifier is not set.",
+    "`looted entity` = The Entity that was killed/looted."})
 @Examples({"set {_loottable} to loottable from key \"minecraft:chests/ancient_city\"",
-        "set {_items::*} to looted items from {_loottable}",
-        "give player looted items from (loottable from key \"minecraft:gameplay/fishing\")"})
+    "set {_items::*} to looted items from {_loottable}",
+    "give player looted items from (loottable from key \"minecraft:gameplay/fishing\")"})
 @Since("3.4.0")
 public class ExprLootTableItems extends SimpleExpression<ItemStack> {
 
@@ -46,8 +47,8 @@ public class ExprLootTableItems extends SimpleExpression<ItemStack> {
 
     static {
         Skript.registerExpression(ExprLootTableItems.class, ItemStack.class, ExpressionType.COMBINED,
-                "(looted|lootable) items from %loottable% [with seed %-number%] [with looting modifier %-number%] " +
-                        "[with luck %-number%] [with (killer|looter) %-player%] [with looted entity %-entity%]");
+            "(looted|lootable) items from %loottable% [with seed %-number%] [with looting modifier %-number%] " +
+                "[with luck %-number%] [with (killer|looter) %-player%] [with looted entity %-entity%]");
     }
 
     private Expression<LootTable> lootTable;
@@ -63,13 +64,17 @@ public class ExprLootTableItems extends SimpleExpression<ItemStack> {
         this.lootTable = (Expression<LootTable>) exprs[0];
         this.seed = (Expression<Number>) exprs[1];
         this.lootingModifier = (Expression<Number>) exprs[2];
+        if (Util.IS_RUNNING_MC_1_21 && this.lootingModifier != null) {
+            Skript.error("'with looting modifier' is no longer functional!");
+            return false;
+        }
         this.luck = (Expression<Number>) exprs[3];
         this.killer = (Expression<Player>) exprs[4];
         this.lootedEntity = (Expression<Entity>) exprs[5];
         return true;
     }
 
-    @SuppressWarnings({"NullableProblems", "CallToPrintStackTrace"})
+    @SuppressWarnings({"NullableProblems", "CallToPrintStackTrace", "deprecation"})
     @Override
     protected ItemStack @Nullable [] get(Event event) {
         LootTable lootTable = this.lootTable.getSingle(event);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNearestEntity.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprNearestEntity.java
@@ -16,24 +16,26 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Name("Nearest Entity")
 @Description({"Returns the nearest entity around a location/entity.",
-        "\nNOTE: When using `around entity`, this will exclude that entity in the search.",
-        "\nNOTE: When radius is excluded, the distance will default to Skript's `maximum target block distance`."})
+    "\nNOTE: When using `around entity`, this will exclude that entity in the search.",
+    "\nNOTE: When radius is excluded, the distance will default to Skript's `maximum target block distance`."})
 @Examples({"kill nearest player in radius 10 around player",
-        "damage nearest mob in radius 5 around player",
-        "set {_near} to nearest entity in radius 50 around {_loc}",
-        "set {_near} to nearest entity in radius 100 around location(100,100,100,world \"world\")",
-        "teleport player to nearest player in radius 10 around player",
-        "damage 10 nearest entity in radius 10 around player by 2"})
+    "damage nearest mob in radius 5 around player",
+    "set {_near} to nearest entity in radius 50 around {_loc}",
+    "set {_near} to nearest entity in radius 100 around location(100,100,100,world \"world\")",
+    "teleport player to nearest player in radius 10 around player",
+    "damage 10 nearest entity in radius 10 around player by 2",
+    "set {_p} to nearest player around player excluding (all player's where [input doesn't have permission \"some.perm\"])"})
 @Since("2.7.2")
 @SuppressWarnings("NullableProblems")
 public class ExprNearestEntity extends SimpleExpression<Entity> {
@@ -42,13 +44,15 @@ public class ExprNearestEntity extends SimpleExpression<Entity> {
 
     static {
         Skript.registerExpression(ExprNearestEntity.class, Entity.class, ExpressionType.COMBINED,
-                "[num:%number%] nearest %entitydata% [in radius %-number%] (at|of|around) %location/entity%");
+            "[num:%number%] nearest %entitydata% [in radius %-number%] (at|of|around) %location/entity%" +
+                " [excluding %entities%]");
     }
 
     private Expression<Number> number;
     private Expression<EntityData<?>> entityData;
     private Expression<Number> radius;
     private Expression<Object> location;
+    private Expression<Entity> excluding;
     private boolean isSingle;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
@@ -58,12 +62,13 @@ public class ExprNearestEntity extends SimpleExpression<Entity> {
         this.entityData = (Expression<EntityData<?>>) exprs[1];
         this.radius = (Expression<Number>) exprs[2];
         this.location = (Expression<Object>) exprs[3];
+        this.excluding = (Expression<Entity>) exprs[4];
         this.isSingle = !parseResult.hasTag("num");
         return true;
     }
 
     @Override
-    protected @Nullable Entity[] get(Event event) {
+    protected Entity @Nullable [] get(Event event) {
         Number number = this.number.getSingle(event);
         EntityData<?> entityData = this.entityData.getSingle(event);
         Number radius = this.radius != null ? this.radius.getSingle(event) : MAX_TARGET_BLOCK_DISTANCE;
@@ -71,11 +76,15 @@ public class ExprNearestEntity extends SimpleExpression<Entity> {
         if (number == null || entityData == null || radius == null || object == null) return null;
         double rad = radius.doubleValue();
 
+        List<Entity> excluding = new ArrayList<>();
+        if (this.excluding != null) {
+            excluding = Arrays.asList(this.excluding.getArray(event));
+        }
         List<Entity> nearby;
         if (object instanceof Entity entity) {
-            nearby = getNearby(entity.getLocation(), entityData, rad, entity);
+            nearby = getNearby(entity.getLocation(), entityData, rad, entity, excluding);
         } else {
-            nearby = getNearby((Location) object, entityData, rad, null);
+            nearby = getNearby((Location) object, entityData, rad, null, excluding);
         }
 
         List<Entity> entities = new ArrayList<>();
@@ -87,13 +96,14 @@ public class ExprNearestEntity extends SimpleExpression<Entity> {
         return entities.toArray(new Entity[0]);
     }
 
-    private List<Entity> getNearby(Location location, EntityData<?> entityData, double radius, Object exclude) {
+    private List<Entity> getNearby(Location location, EntityData<?> entityData, double radius, Object self, List<Entity> excluding) {
         World world = location.getWorld();
         return world.getNearbyEntitiesByType(entityData.getType(), location, radius)
-                .stream()
-                .sorted(Comparator.comparing(entity -> entity.getLocation().distanceSquared(location)))
-                .filter(entity -> entity != exclude)
-                .collect(Collectors.toList());
+            .stream()
+            .sorted(Comparator.comparing(entity -> entity.getLocation().distanceSquared(location)))
+            .filter(entity -> entity != self)
+            .filter(entity -> !excluding.contains(entity))
+            .collect(Collectors.toList());
     }
 
     @Override
@@ -107,12 +117,13 @@ public class ExprNearestEntity extends SimpleExpression<Entity> {
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(Event e, boolean d) {
         String num = this.number != null ? this.number.toString(e, d) + " " : "";
         String data = this.entityData.toString(e, d);
         String radius = this.radius.toString(e, d);
         String loc = this.location.toString(e, d);
-        return num + "nearest " + data + " in radius " + radius + " around " + loc;
+        String excluding = this.excluding != null ? (" excluding " + this.excluding.toString(e,d)) : "";
+        return num + "nearest " + data + " in radius " + radius + " around " + loc + excluding;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -25,6 +25,7 @@ import org.bukkit.TreeType;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Pose;
 import org.bukkit.entity.Spellcaster;
 import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.block.Action;
@@ -388,6 +389,14 @@ public class Types {
             .description("Represents the different types of trees.")
             .after("structuretype")
             .since("3.5.3"));
+
+        EnumWrapper<Pose> POSE = new EnumWrapper<>(Pose.class, "", "pose");
+        Classes.registerClass(POSE.getClassInfo("pose")
+            .user("poses?")
+            .name("Entity Pose")
+            .description("Represents the pose of an entity.",
+                "NOTE: These are auto-generated and may differ between server versions.")
+            .since("INSERT VERSION"));
     }
 
     // FUNCTIONS

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -136,7 +136,7 @@ public class Types {
         }
 
         if (Classes.getExactClassInfo(BlockFace.class) == null) {
-            EnumWrapper<BlockFace> BLOCK_FACE_ENUM = new EnumWrapper<>(BlockFace.class);
+            EnumWrapper<BlockFace> BLOCK_FACE_ENUM = new EnumWrapper<>(BlockFace.class, "", "face");
             Classes.registerClass(BLOCK_FACE_ENUM.getClassInfo("blockface")
                 .user("blockfaces?")
                 .name("BlockFace")

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprWorldCreator.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/expressions/ExprWorldCreator.java
@@ -11,37 +11,40 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.elements.worldcreator.objects.BeeWorldCreator;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @Name("World Creator")
-@Description({"Create a new world creator. This will be used to create a new world. Name will be the name of your new world.",
-        "You can not use the name of one of the default worlds, or a world created by another plugin, such as MultiVerse.",
-        "Copy will create a fresh new world with the same seed and settings. Clone will create a carbon copy of your world, if the world",
-        "is large, this process may take a while. The file copying process will happen on another thread, so this won't freeze your server.",
-        "You can optionally add `without saving` to prevent saving of the world that will be cloned. Saving freezes the server for a bit",
-        "so this can help speed up the process... if you don't need that world saved at this moment in time.",
-        "After creating a world creator you will need to load the world."})
+@Description({"Create a new world creator. This will be used to create a new world.",
+    "Name will be the name of your new world.",
+    "Key will be how your world is represented to Minecraft. Be default this will use the Minecraft namespace. (Keys require PaperMC.)",
+    "You can not use the name of one of the default worlds, or a world created by another plugin, such as MultiVerse.",
+    "Copy will create a fresh new world with the same seed and settings. Clone will create a carbon copy of your world, if the world",
+    "is large, this process may take a while. The file copying process will happen on another thread, so this won't freeze your server.",
+    "You can optionally add `without saving` to prevent saving of the world that will be cloned. Saving freezes the server for a bit",
+    "so this can help speed up the process... if you don't need that world saved at this moment in time.",
+    "After creating a world creator you will need to load the world."})
 @Examples({"set {_w} to a new world creator named \"my-world\"",
-        "set environment of {_w} to nether",
-        "load world from creator {_w}",
-        "",
-        "set {_clone} to a new world creator named \"world_clone\" to clone world \"world\" without saving",
-        "load world from creator {_clone}"})
+    "set environment of {_w} to nether",
+    "load world from creator {_w}",
+    "",
+    "set {_clone} to a new world creator named \"world_clone\" to clone world \"world\" without saving",
+    "load world from creator {_clone}"})
 @Since("1.8.0")
 public class ExprWorldCreator extends SimpleExpression<BeeWorldCreator> {
 
     static {
         Skript.registerExpression(ExprWorldCreator.class, BeeWorldCreator.class, ExpressionType.SIMPLE,
-                "[a] [new] world creator (with name|named) %string%",
-                "[a] [new] world creator (with name|named) %string% to (copy|1:clone) %world% [save:without saving]");
+            "[a] [new] world creator (with name|named) %string% [with key %-namespacedkey%]",
+            "[a] [new] world creator (with name|named) %string% [with key %-namespacedkey%] to (copy|1:clone) %world% [save:without saving]");
     }
 
     private int pattern;
     private Expression<String> name;
+    private Expression<NamespacedKey> key;
     private Expression<World> world;
     private boolean clone;
     private boolean save;
@@ -51,7 +54,8 @@ public class ExprWorldCreator extends SimpleExpression<BeeWorldCreator> {
     public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         this.pattern = matchedPattern;
         this.name = (Expression<String>) exprs[0];
-        this.world = pattern == 1 ? (Expression<World>) exprs[1] : null;
+        this.key = (Expression<NamespacedKey>) exprs[1];
+        this.world = pattern == 1 ? (Expression<World>) exprs[2] : null;
         this.clone = pattern == 1 && parseResult.mark == 1;
         this.save = !parseResult.hasTag("save");
         return true;
@@ -59,17 +63,18 @@ public class ExprWorldCreator extends SimpleExpression<BeeWorldCreator> {
 
     @SuppressWarnings("NullableProblems")
     @Override
-    protected BeeWorldCreator[] get(@NotNull Event e) {
+    protected BeeWorldCreator @Nullable [] get(@NotNull Event e) {
         String name = this.name.getSingle(e);
+        NamespacedKey key = this.key != null ? this.key.getSingle(e) : null;
         if (name == null) {
             return null;
         }
         if (pattern == 0) {
-            return new BeeWorldCreator[]{new BeeWorldCreator(name)};
+            return new BeeWorldCreator[]{new BeeWorldCreator(name, key)};
         } else if (pattern == 1 && this.world != null) {
             World world = this.world.getSingle(e);
             if (world == null) return null;
-            BeeWorldCreator beeWorldCreator = new BeeWorldCreator(world, name, this.clone);
+            BeeWorldCreator beeWorldCreator = new BeeWorldCreator(world, name, key, this.clone);
             beeWorldCreator.setSaveClone(this.save);
             return new BeeWorldCreator[]{beeWorldCreator};
         }
@@ -87,11 +92,12 @@ public class ExprWorldCreator extends SimpleExpression<BeeWorldCreator> {
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(Event e, boolean d) {
         String creator = String.format("new world creator named '%s'", this.name.toString(e, d));
+        String key = this.key != null ? (" with key " + this.key.toString(e,d)) : "";
         String copy = this.pattern == 1 ? " to " + (this.clone ? "clone " : "copy ") + this.world.toString(e, d) : "";
         String withoutSaving = this.save ? "" : " without saving";
-        return creator + copy + withoutSaving;
+        return creator + key + copy + withoutSaving;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldConfig.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldConfig.java
@@ -4,6 +4,7 @@ import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.WorldType;
@@ -21,6 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings("CallToPrintStackTrace")
 public class BeeWorldConfig {
 
     private final SkBee plugin;
@@ -68,7 +70,9 @@ public class BeeWorldConfig {
 
     public @Nullable BeeWorldCreator loadWorld(String name) {
         String path = "worlds." + name + ".";
-        BeeWorldCreator worldCreator = new BeeWorldCreator(name);
+        String keyString = worldConfig.getString(path + "key");
+        NamespacedKey key = keyString != null ? Util.getMCNamespacedKey(keyString, false) : null;
+        BeeWorldCreator worldCreator = new BeeWorldCreator(name, key);
 
         String type = worldConfig.getString(path + "type");
         if (type != null) {
@@ -128,6 +132,7 @@ public class BeeWorldConfig {
             WORLDS.put(worldCreator.getWorldName(), worldCreator);
         }
         String path = "worlds." + worldCreator.getWorldName() + ".";
+        worldConfig.set(path + "key", worldCreator.getKey().toString());
         worldConfig.set(path + "type", worldCreator.getWorldType().toString());
         worldConfig.set(path + "environment", worldCreator.getEnvironment().toString());
         worldConfig.set(path + "seed", worldCreator.seed);

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldCreator.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldCreator.java
@@ -1,9 +1,12 @@
 package com.shanebeestudios.skbee.elements.worldcreator.objects;
 
+import ch.njol.skript.Skript;
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.Keyed;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.WorldCreator;
@@ -11,6 +14,7 @@ import org.bukkit.WorldType;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,10 +22,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public class BeeWorldCreator {
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "CallToPrintStackTrace"})
+public class BeeWorldCreator implements Keyed {
 
     private final String worldName;
+    private final NamespacedKey key;
     private WorldType worldType;
     private Environment environment;
     private String generatorSettings;
@@ -39,16 +44,18 @@ public class BeeWorldCreator {
     private boolean clone;
     private boolean saveClone;
 
-    public BeeWorldCreator(String worldName) {
+    public BeeWorldCreator(@NotNull String worldName, @Nullable NamespacedKey key) {
         this.worldName = worldName;
+        this.key = key;
         this.genStructures = Optional.empty();
         this.hardcore = Optional.empty();
         this.keepSpawnLoaded = Optional.empty();
     }
 
     @SuppressWarnings("deprecation")
-    public BeeWorldCreator(@NotNull World world, String name, boolean clone) {
+    public BeeWorldCreator(@NotNull World world, @NotNull String name, @Nullable NamespacedKey key, boolean clone) {
         this.worldName = name;
+        this.key = key;
         this.worldType = world.getWorldType();
         this.environment = world.getEnvironment();
         this.genStructures = Optional.of(world.canGenerateStructures());
@@ -59,8 +66,12 @@ public class BeeWorldCreator {
         this.clone = clone;
     }
 
-    public String getWorldName() {
+    public @NotNull String getWorldName() {
         return worldName;
+    }
+
+    public @NotNull NamespacedKey getKey() {
+        return this.key != null ? this.key : NamespacedKey.minecraft(this.worldName);
     }
 
     public void setWorldType(WorldType worldType) {
@@ -161,7 +172,7 @@ public class BeeWorldCreator {
         }
         // Create new world
         else {
-            worldCreatorCompletableFuture.complete(new WorldCreator(this.worldName));
+            worldCreatorCompletableFuture.complete(getWorldCreator(this.worldName, this.key));
         }
         worldCreatorCompletableFuture.thenAccept(worldCreator -> {
             World world = null;
@@ -229,7 +240,7 @@ public class BeeWorldCreator {
 
     private CompletableFuture<WorldCreator> copyWorld() {
         CompletableFuture<WorldCreator> worldCreatorCompletableFuture = new CompletableFuture<>();
-        WorldCreator worldCreator = new WorldCreator(this.worldName);
+        WorldCreator worldCreator = getWorldCreator(this.worldName, this.key);
         worldCreator.copy(this.world);
         worldCreatorCompletableFuture.complete(worldCreator);
         return worldCreatorCompletableFuture;
@@ -257,7 +268,7 @@ public class BeeWorldCreator {
                             FileUtils.copyFile(file, new File(cloneDirectory, fileName));
                         }
                     }
-                    WorldCreator creator = new WorldCreator(cloneName);
+                    WorldCreator creator = new WorldCreator(cloneName, this.key);
                     Bukkit.getScheduler().runTaskLater(SkBee.getPlugin(), () -> {
                         // Let's head back to the main thread
                         worldCompletableFuture.complete(creator);
@@ -271,11 +282,18 @@ public class BeeWorldCreator {
         return worldCompletableFuture;
     }
 
-    @SuppressWarnings("StringBufferReplaceableByString")
+    private static final boolean HAS_KEY = Skript.methodExists(WorldCreator.class, "ofNameAndKey", String.class, NamespacedKey.class);
+
+    private static WorldCreator getWorldCreator(@NotNull String name, @Nullable NamespacedKey key) {
+        if (HAS_KEY && key != null) return new WorldCreator(name, key);
+        return new WorldCreator(name);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("WorldCreator{");
         sb.append("worldName='").append(worldName).append('\'');
+        if (this.key != null) sb.append(", key='").append(key).append('\'');
         sb.append(", worldType=").append(worldType);
         sb.append(", environment=").append(environment);
         sb.append(", generatorSettings='").append(generatorSettings).append('\'');

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -79,3 +79,4 @@ types:
 	chunkloadlevel: chunk load level¦s
 	entityeffect: entity effect¦s
 	blockaction: block action¦s
+	pose: pose¦s

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -79,4 +79,5 @@ types:
 	chunkloadlevel: chunk load level¦s
 	entityeffect: entity effect¦s
 	blockaction: block action¦s
+	bukkittreetype: bukkit tree type¦s
 	pose: pose¦s


### PR DESCRIPTION
Temp Changelog:
## ADDED:
- Added an expression to get average tick time 
- Added a type and expression for entity pose
- Added an option to add a namespaced key to world creators
- Added support for multiple slots in the equipment slot effect
- Added support for Minecraft 1.21 NBT

## CHANGED:
- Appended the suffix "face" to the BlockFace type to fix comparison/clashing issues with Direction
- Added `excluding %entities%` to nearest entity expression
- Added slime pathfinding to pathfinding event (for some reason paper made this separate)
- Changed how Random is handled in the populate tree effect (helps for better consistency)
- Internal change with file nbt, clear compound before deleting file (this shouldn't affect anyone)
- Removed clamping in chunkdata block expression (allowing to reach into neighbouring chunks in block pop section)
- Deprecated `with looting modifier` in loot table expressions for MC 1.21+ (apparently no longer functional)

## FIXED:
- Fixed a bug where the tag type of a byte tag was returning as a boolean tag