### PR TITLE
Dev/patch - future release

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/AddonLoader.java
+++ b/src/main/java/com/shanebeestudios/skbee/AddonLoader.java
@@ -111,6 +111,7 @@ public class AddonLoader {
         loadDisplayEntityElements();
         loadFishingElements();
         loadGameEventElements();
+        loadItemComponentElements();
         loadParticleElements();
         loadRayTraceElements();
         loadRecipeElements();
@@ -565,6 +566,24 @@ public class AddonLoader {
         try {
             addon.loadClasses("com.shanebeestudios.skbee.elements.damagesource");
             Util.logLoading("&5Damage Source elements &asuccessfully loaded");
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            pluginManager.disablePlugin(this.plugin);
+        }
+    }
+
+    private void loadItemComponentElements() {
+        if (!this.config.ELEMENTS_ITEM_COMPONENT) {
+            Util.logLoading("&5Item Component elements &cdisabled via config");
+            return;
+        }
+        if (!Skript.classExists("org.bukkit.inventory.meta.components.FoodComponent")) {
+            Util.logLoading("&5Item Component elements &cdisabled &7(&eRequires Minecraft 1.20.5+&7)");
+            return;
+        }
+        try {
+            addon.loadClasses("com.shanebeestudios.skbee.elements.itemcomponent");
+            Util.logLoading("&5Item Component Elements &asuccessfully loaded");
         } catch (IOException ex) {
             ex.printStackTrace();
             pluginManager.disablePlugin(this.plugin);

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -165,7 +165,7 @@ public class ParticleUtil {
         } else {
             for (Player player : players) {
                 assert player != null;
-                player.spawnParticle(particle, location, count, x, y, z, extra, particleData);
+                player.spawnParticle(particle, location, count, x, y, z, extra, particleData, force);
             }
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/api/util/SkriptUtils.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/SkriptUtils.java
@@ -9,8 +9,12 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.lang.parser.ParserInstance;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.inventory.EquipmentSlotGroup;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -112,6 +116,22 @@ public class SkriptUtils {
                 return o.toString();
             }
         };
+    }
+
+    public static Map<String,EquipmentSlotGroup> getEquipmentSlotGroups() {
+        Map<String,EquipmentSlotGroup> groups = new HashMap<>();
+        for (Field declaredField : EquipmentSlotGroup.class.getDeclaredFields()) {
+            if (EquipmentSlotGroup.class.isAssignableFrom(declaredField.getType())) {
+                try {
+                    EquipmentSlotGroup equipmentSlotGroup = (EquipmentSlotGroup) declaredField.get(null);
+                    String name = declaredField.getName().toLowerCase(Locale.ROOT) + "_slot_group";
+                    groups.put(name, equipmentSlotGroup);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return groups;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/EnumWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/EnumWrapper.java
@@ -112,21 +112,21 @@ public final class EnumWrapper<E extends Enum<E>> {
     }
 
     /**
-     * Create ClassInfo with default praser and usage
+     * Create ClassInfo with default parser and usage
      *
      * @param codeName Name for class info
-     * @return ClassInfo with default praser and usage
+     * @return ClassInfo with default parser and usage
      */
     public ClassInfo<E> getClassInfo(String codeName) {
         return new ClassInfo<>(this.enumClass, codeName).usage(getAllNames()).parser(new EnumParser<>(this));
     }
 
     /**
-     * Create ClassInfo with default praser and usage
+     * Create ClassInfo with default parser and usage
      * <p>If using `.usage()` use this method to prevent double call/assertion error</p>
      *
      * @param codeName Name for class info
-     * @return ClassInfo with default praser and usage
+     * @return ClassInfo with default parser and usage
      */
     public ClassInfo<E> getClassInfoWithoutUsage(String codeName) {
         return new ClassInfo<>(this.enumClass, codeName).parser(new EnumParser<>(this));

--- a/src/main/java/com/shanebeestudios/skbee/config/Config.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/Config.java
@@ -58,6 +58,7 @@ public class Config {
     public boolean ELEMENTS_DISPLAY;
     public boolean ELEMENTS_TICK_MANAGER;
     public boolean ELEMENTS_DAMAGE_SOURCE;
+    public boolean ELEMENTS_ITEM_COMPONENT;
     public boolean ELEMENTS_CHUNK_GEN;
     public boolean AUTO_LOAD_WORLDS;
 
@@ -175,6 +176,7 @@ public class Config {
         this.ELEMENTS_TICK_MANAGER = getElement("tick-manager");
         this.ELEMENTS_DAMAGE_SOURCE = getElement("damage-source");
         this.ELEMENTS_CHUNK_GEN = getElement("chunk-generator");
+        this.ELEMENTS_ITEM_COMPONENT = getElement("item-component");
         this.AUTO_LOAD_WORLDS = getElement("auto-load-custom-worlds");
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffWorldCreatorSetGenerator.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/effects/EffWorldCreatorSetGenerator.java
@@ -51,6 +51,8 @@ public class EffWorldCreatorSetGenerator extends Effect {
         if (chunkGen == null) return;
         worldCreator.setChunkGenerator(chunkGen.getChunkGenerator());
         worldCreator.setBiomeProvider(chunkGen.getBiomeGenerator());
+        // Prevent autoloading world before generator is created
+        worldCreator.setLoadOnStart(false);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/structure/StrucChunkGen.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/structure/StrucChunkGen.java
@@ -42,7 +42,6 @@ import org.skriptlang.skript.lang.structure.Structure;
         "`height gen` = Tell Minecraft where the highest block in a chunk is for generating structures.",
         "`block pop` = Used to decorate after initial surface is generated (Structures can be placed during this stage).",
         "NOTES:",
-        "- `chunk-generator` needs to be enabled in the config (disabled by default)",
         "- `world-creator` needs to be enabled in the config",
         "- Please see the [**Chunk Generator**](https://github.com/ShaneBeee/SkBee/wiki/Chunk-Generator) wiki for further details."})
 @Examples({"register chunk generator with id \"mars\":",

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyPotion.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyPotion.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -25,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
     "\teffects:",
     "\t\tapply potion effect of nausea without particles for 10 seconds",
     "\t\tapply potion effect of poison without particles for 5 seconds with probability 50"})
+@Since("INSERT VERSION")
 public class EffApplyPotion extends Effect {
 
     static {

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyPotion.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyPotion.java
@@ -1,0 +1,68 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.MathUtil;
+import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecFoodComponent.FoodComponentApplyEvent;
+import org.bukkit.event.Event;
+import org.bukkit.potion.PotionEffect;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Component - Food Component Apply Potion Effect")
+@Description({"Apply a potion effect to a food component. This works in the `effects` section of a food component section.",
+    "Probability is an optional value between 0 and 100. This is the chance the player will get this effect when eaten."})
+@Examples({"apply food component to player's tool:",
+    "\tnutrition: 5",
+    "\tsaturation: 3",
+    "\tusing converts to: 1 of bowl",
+    "\tcan always eat: true",
+    "\teffects:",
+    "\t\tapply potion effect of nausea without particles for 10 seconds",
+    "\t\tapply potion effect of poison without particles for 5 seconds with probability 50"})
+public class EffApplyPotion extends Effect {
+
+    static {
+        Skript.registerEffect(EffApplyPotion.class, "apply [potion[[ ]effect]] %potioneffect% [with probability %-number%]");
+    }
+
+    private Expression<PotionEffect> effect;
+    private Expression<Number> probability;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] expr, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!getParser().isCurrentEvent(FoodComponentApplyEvent.class)) {
+            Skript.error("Potion effect can only be applied in the 'effects' section of a food component section.");
+            return false;
+        }
+        this.effect = (Expression<PotionEffect>) expr[0];
+        this.probability = (Expression<Number>) expr[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        if (event instanceof FoodComponentApplyEvent applyEvent) {
+            PotionEffect effect = this.effect.getSingle(event);
+            if (effect == null) return;
+
+            Number probNum = this.probability != null ? this.probability.getSingle(event) : null;
+            float probability = probNum != null ? MathUtil.clamp((probNum.floatValue() / 100), 0.0F, 1.0F) : 1;
+
+            applyEvent.getComponent().addEffect(effect, probability);
+        }
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "apply " + this.effect.toString(e, d) + (this.probability != null ? (" with probability " + this.probability.toString(e, d)) : "");
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyPotion.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyPotion.java
@@ -15,7 +15,7 @@ import org.bukkit.event.Event;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 
-@Name("Component - Food Component Apply Potion Effect")
+@Name("ItemComponent - Food Component Apply Potion Effect")
 @Description({"Apply a potion effect to a food component. This works in the `effects` section of a food component section.",
     "Probability is an optional value between 0 and 100. This is the chance the player will get this effect when eaten."})
 @Examples({"apply food component to player's tool:",

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffClearComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffClearComponent.java
@@ -1,0 +1,65 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+
+@Name("ItemComponent - Clear Components")
+@Description({"Clear components of an item. Requires Minecraft 1.21+",
+    "**NOTE**: This will **NOT** clear vanilla components, it will only clear custom added components."})
+@Examples({"clear food component of player's tool",
+    "clear tool component of player's tool",
+    "clear attribute modifier components of player's tool"})
+@Since("INSERT VERSION")
+public class EffClearComponent extends Effect {
+
+    static {
+        Skript.registerEffect(EffClearComponent.class, "clear (:food|:tool|attribute modifier) component[s] of %itemtypes%");
+    }
+
+    private int type;
+    private Expression<ItemType> itemTypes;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.type = parseResult.hasTag("food") ? 0 : parseResult.hasTag("tool") ? 1 : 2;
+        this.itemTypes = (Expression<ItemType>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        for (ItemType itemType : this.itemTypes.getArray(event)) {
+            ItemMeta itemMeta = itemType.getItemMeta();
+            switch (this.type) {
+                case 0 -> itemMeta.setFood(null);
+                case 1 -> itemMeta.setTool(null);
+                default -> itemMeta.setAttributeModifiers(null);
+            }
+            itemType.setItemMeta(itemMeta);
+        }
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        String type = switch (this.type) {
+            case 0 -> "food";
+            case 1 -> "tool";
+            default -> "attribute modifiers";
+        };
+        return "clear " + type + " components of " + this.itemTypes.toString(e,d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecAttributeModifier.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecAttributeModifier.java
@@ -1,0 +1,141 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.util.slot.Slot;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.Util;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.attribute.AttributeModifier.Operation;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.EquipmentSlotGroup;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.entry.EntryValidator;
+import org.skriptlang.skript.lang.entry.util.ExpressionEntryData;
+
+import java.util.List;
+
+@SuppressWarnings("DataFlowIssue")
+@Name("ItemComponent - Attribute Modifier Apply")
+@Description({"Apply an attribute modifier to an item. Requires Minecraft 1.21+",
+    "See [**McWiki Component**](https://minecraft.wiki/w/Data_component_format#attribute_modifiers) and " +
+        "[**McWiki Modifiers**](https://minecraft.wiki/w/Attribute#Modifiers) for further details.",
+    "",
+    "**Entries/Sections**:",
+    "- `attribute` = The attribute this modifier is to act upon.",
+    "- `slot` = Equipment Slot Type the item must be in for the modifier to take effect.",
+    "- `id` = The NamespacedKey for this modifier.",
+    "- `amount` = Amount of change from the modifier.",
+    "- `operation` = The operation to decide how to modify."})
+@Examples({"set {_i} to a stick",
+    "apply attribute modifier to {_i}:",
+    "\tattribute: scale",
+    "\tid: \"minecraft:my_hand_scale\"",
+    "\tslot: mainhand_slot_group",
+    "\tamount: 2",
+    "\toperation: add_number",
+    "apply attribute modifier to {_i}:",
+    "\tattribute: scale",
+    "\tid: \"minecraft:my_hand_scale_off\"",
+    "\tslot: offhand_slot_group",
+    "\tamount: -0.9",
+    "\toperation: add_number",
+    "give player 1 of {_i}"})
+@Since("INSERT VERSION")
+public class SecAttributeModifier extends Section {
+
+    private static final boolean HAS_KEY = Skript.methodExists(AttributeModifier.class, "getKey");
+    private static final EntryValidator.EntryValidatorBuilder VALIDATIOR = EntryValidator.builder();
+
+    static {
+        if (HAS_KEY) {
+            VALIDATIOR.addEntryData(new ExpressionEntryData<>("attribute", null, false, Attribute.class));
+            VALIDATIOR.addEntryData(new ExpressionEntryData<>("slot", null, false, EquipmentSlotGroup.class));
+            VALIDATIOR.addEntryData(new ExpressionEntryData<>("id", null, false, String.class));
+            VALIDATIOR.addEntryData(new ExpressionEntryData<>("amount", null, false, Number.class));
+            VALIDATIOR.addEntryData(new ExpressionEntryData<>("operation", null, false, Operation.class));
+            Skript.registerSection(SecAttributeModifier.class, "apply attribute modifier to %itemtypes/itemstacks/slots%");
+        }
+    }
+
+    private Expression<?> items;
+    private Expression<Attribute> attribute;
+    private Expression<EquipmentSlotGroup> slotGroup;
+    private Expression<String> id;
+    private Expression<Number> amount;
+    private Expression<Operation> operation;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] expr, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        EntryContainer container = VALIDATIOR.build().validate(sectionNode);
+        if (container == null) return false;
+
+        this.items = expr[0];
+        this.attribute = (Expression<Attribute>) container.getOptional("attribute", false);
+        this.slotGroup = (Expression<EquipmentSlotGroup>) container.getOptional("slot", false);
+        this.id = (Expression<String>) container.getOptional("id", false);
+        this.amount = (Expression<Number>) container.getOptional("amount", false);
+        this.operation = (Expression<Operation>) container.getOptional("operation", false);
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems", "IfCanBeSwitch"})
+    @Override
+    protected @Nullable TriggerItem walk(Event event) {
+        Attribute attribute = this.attribute.getSingle(event);
+        EquipmentSlotGroup slotGroup = this.slotGroup.getSingle(event);
+        String id = this.id.getSingle(event);
+        Number amountNum = this.amount.getSingle(event);
+        Operation operation = this.operation.getSingle(event);
+
+        if (attribute == null || slotGroup == null || id == null || amount == null || operation == null)
+            return super.walk(event, false);
+
+        NamespacedKey namespacedKey = Util.getNamespacedKey(id, false);
+        if (namespacedKey == null) return super.walk(event, false);
+
+        for (Object object : this.items.getArray(event)) {
+            ItemMeta itemMeta;
+            if (object instanceof ItemStack itemStack) itemMeta = itemStack.getItemMeta();
+            else if (object instanceof ItemType itemType) itemMeta = itemType.getItemMeta();
+            else if (object instanceof Slot slot) itemMeta = slot.getItem().getItemMeta();
+            else continue;
+
+            AttributeModifier attributeModifier = new AttributeModifier(namespacedKey, amountNum.doubleValue(), operation, slotGroup);
+            itemMeta.addAttributeModifier(attribute, attributeModifier);
+
+            if (object instanceof ItemStack itemStack) itemStack.setItemMeta(itemMeta);
+            else if (object instanceof ItemType itemType) itemType.setItemMeta(itemMeta);
+            else {
+                Slot slot = (Slot) object;
+                ItemStack slotItem = slot.getItem();
+                slotItem.setItemMeta(itemMeta);
+                slot.setItem(slotItem);
+            }
+
+        }
+        return super.walk(event, false);
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "apply attribute modifier to " + this.items.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
@@ -1,0 +1,173 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.util.Timespan;
+import ch.njol.skript.util.slot.Slot;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.FoodComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.entry.EntryValidator;
+import org.skriptlang.skript.lang.entry.util.ExpressionEntryData;
+
+import java.util.List;
+
+@SuppressWarnings("DataFlowIssue")
+@Name("Component - Food Component Apply")
+@Description({"Apply a food component to any item making it an edible item. Requires Minecraft 1.20.5+",
+    "",
+    "**Entries/Sections**:",
+    "- `nutrition` = The number of food points restored by this item when eaten. Must be a non-negative integer.",
+    "- `saturation` = The amount of saturation restored by this item when eaten.",
+    "- `can always eat` = If true, this item can be eaten even if the player is not hungry. Defaults to false. [Optional]",
+    "- `eat time` = The number of seconds taken by this item to be eaten. Defaults to 1.6 seconds. [Optional]",
+    "- `using converts to` = The item to replace this item with when it is eaten. [Optional] (Requires Minecraft 1.21+)",
+    "- `effects:` = A section to apply potion effects to this food item. [Optional]"})
+@Examples({"# Directly apply a food component to the player's tool",
+    "apply food component to player's tool:",
+    "\tnutrition: 5",
+    "\tsaturation: 3",
+    "",
+    "# Create a new item and apply a food item to it",
+    "set {_i} to 1 of book",
+    "apply food component to {_i}:",
+    "\tnutrition: 5",
+    "\tsaturation: 3",
+    "\tusing converts to: 1 of bowl",
+    "\tcan always eat: true",
+    "\teffects:",
+    "\t\tapply potion effect of nausea without particles for 10 seconds",
+    "\t\tapply potion effect of poison without particles for 5 seconds ",
+    "give player 1 of {_i}"})
+@Since("INSERT VERSION")
+public class SecFoodComponent extends Section {
+
+    public static class FoodComponentApplyEvent extends Event {
+
+        private final FoodComponent component;
+
+        public FoodComponentApplyEvent(FoodComponent component) {
+            this.component = component;
+        }
+
+        public FoodComponent getComponent() {
+            return this.component;
+        }
+
+        @Override
+        public @NotNull HandlerList getHandlers() {
+            throw new IllegalStateException("FoodComponentApplyEvent should never be called");
+        }
+    }
+
+    private static final boolean HAS_CONVERT = Skript.methodExists(FoodComponent.class, "setUsingConvertsTo", ItemStack.class);
+    private static final EntryValidator.EntryValidatorBuilder VALIDATIOR = EntryValidator.builder();
+
+    static {
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("nutrition", null, false, Number.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("saturation", null, false, Number.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("can always eat", null, true, Boolean.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("eat time", null, true, Timespan.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("using converts to", null, true, ItemType.class));
+        VALIDATIOR.addSection("effects", true);
+        Skript.registerSection(SecFoodComponent.class, "apply food component to %itemtypes/itemstacks/slots%");
+    }
+
+    private Expression<?> items;
+    private Expression<Number> nutrition;
+    private Expression<Number> saturation;
+    private Expression<Boolean> canAlwaysEat;
+    private Expression<Timespan> eatTime;
+    private Expression<ItemType> usingConverts;
+    private Trigger potionEffectSection;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        EntryContainer container = VALIDATIOR.build().validate(sectionNode);
+        if (container == null) return false;
+
+        this.items = expressions[0];
+        this.nutrition = (Expression<Number>) container.getOptional("nutrition", false);
+        this.saturation = (Expression<Number>) container.getOptional("saturation", false);
+        this.canAlwaysEat = (Expression<Boolean>) container.getOptional("can always eat", false);
+        this.eatTime = (Expression<Timespan>) container.getOptional("eat time", false);
+        this.usingConverts = (Expression<ItemType>) container.getOptional("using converts to", false);
+        SectionNode potionEffects = container.getOptional("effects", SectionNode.class, false);
+        if (potionEffects != null) {
+            this.potionEffectSection = loadCode(potionEffects, "potion effects", FoodComponentApplyEvent.class);
+        }
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems", "IfCanBeSwitch"})
+    @Override
+    protected @Nullable TriggerItem walk(Event event) {
+        Number nutritionNum = this.nutrition.getSingle(event);
+        Number saturationNum = this.saturation.getSingle(event);
+        if (nutritionNum == null || saturationNum == null) return super.walk(event, false);
+
+        int nutrition = Math.max(nutritionNum.intValue(), 0);
+        float saturation = saturationNum.floatValue();
+
+        boolean canAlwaysEat = this.canAlwaysEat != null ? this.canAlwaysEat.getSingle(event) : false;
+        Timespan eatTime = this.eatTime != null ? this.eatTime.getSingle(event) : null;
+        ItemStack usingConvertsTo = this.usingConverts != null ? this.usingConverts.getSingle(event).getRandom() : null;
+
+        for (Object object : this.items.getArray(event)) {
+            ItemMeta itemMeta;
+            if (object instanceof ItemStack itemStack) itemMeta = itemStack.getItemMeta();
+            else if (object instanceof ItemType itemType) itemMeta = itemType.getItemMeta();
+            else if (object instanceof Slot slot) itemMeta = slot.getItem().getItemMeta();
+            else continue;
+
+            FoodComponent food = itemMeta.getFood();
+            food.setNutrition(nutrition);
+            food.setSaturation(saturation);
+            food.setCanAlwaysEat(canAlwaysEat);
+            if (eatTime != null) food.setEatSeconds((float) eatTime.getTicks() / 20);
+            if (HAS_CONVERT && usingConvertsTo != null) {
+                food.setUsingConvertsTo(usingConvertsTo);
+            }
+
+            if (this.potionEffectSection != null) {
+                TriggerItem.walk(this.potionEffectSection, new FoodComponentApplyEvent(food));
+            }
+
+            itemMeta.setFood(food);
+
+            if (object instanceof ItemStack itemStack) itemStack.setItemMeta(itemMeta);
+            else if (object instanceof ItemType itemType) itemType.setItemMeta(itemMeta);
+            else {
+                Slot slot = (Slot) object;
+                ItemStack slotItem = slot.getItem();
+                slotItem.setItemMeta(itemMeta);
+                slot.setItem(slotItem);
+            }
+
+        }
+        return super.walk(event, false);
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "apply food component to " + this.items.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
@@ -31,6 +31,7 @@ import java.util.List;
 @SuppressWarnings("DataFlowIssue")
 @Name("ItemComponent - Food Component Apply")
 @Description({"Apply a food component to any item making it an edible item. Requires Minecraft 1.20.5+",
+    "See [**McWiki Food Component**](https://minecraft.wiki/w/Data_component_format#food) for more details.",
     "",
     "**Entries/Sections**:",
     "- `nutrition` = The number of food points restored by this item when eaten. Must be a non-negative integer.",

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
@@ -29,7 +29,7 @@ import org.skriptlang.skript.lang.entry.util.ExpressionEntryData;
 import java.util.List;
 
 @SuppressWarnings("DataFlowIssue")
-@Name("Component - Food Component Apply")
+@Name("ItemComponent - Food Component Apply")
 @Description({"Apply a food component to any item making it an edible item. Requires Minecraft 1.20.5+",
     "",
     "**Entries/Sections**:",

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
@@ -14,6 +14,7 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.Timespan;
 import ch.njol.skript.util.slot.Slot;
+import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -119,6 +120,8 @@ public class SecFoodComponent extends Section {
     @SuppressWarnings({"NullableProblems", "IfCanBeSwitch"})
     @Override
     protected @Nullable TriggerItem walk(Event event) {
+        Object localVars = Variables.copyLocalVariables(event);
+
         Number nutritionNum = this.nutrition.getSingle(event);
         Number saturationNum = this.saturation.getSingle(event);
         if (nutritionNum == null || saturationNum == null) return super.walk(event, false);
@@ -147,7 +150,11 @@ public class SecFoodComponent extends Section {
             }
 
             if (this.potionEffectSection != null) {
-                TriggerItem.walk(this.potionEffectSection, new FoodComponentApplyEvent(food));
+                FoodComponentApplyEvent foodEvent = new FoodComponentApplyEvent(food);
+                Variables.setLocalVariables(foodEvent, localVars);
+                TriggerItem.walk(this.potionEffectSection, foodEvent);
+                Variables.setLocalVariables(event, Variables.copyLocalVariables(foodEvent));
+                Variables.removeLocals(foodEvent);
             }
 
             itemMeta.setFood(food);

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.slot.Slot;
+import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -104,6 +105,8 @@ public class SecToolComponent extends Section {
     @SuppressWarnings({"NullableProblems", "IfCanBeSwitch"})
     @Override
     protected @Nullable TriggerItem walk(Event event) {
+        Object localVars = Variables.copyLocalVariables(event);
+
         Number miningSpeedNum = this.defaultMiningSpeed.getSingle(event);
         Number damagePerNum = this.damagePerBlock.getSingle(event);
         if (damagePerNum == null) return super.walk(event, false);
@@ -124,7 +127,11 @@ public class SecToolComponent extends Section {
             tool.setDamagePerBlock(damagePerBlock);
 
             if (this.rulesSection != null) {
-                TriggerItem.walk(this.rulesSection, new ToolComponentApplyRulesEvent(tool));
+                ToolComponentApplyRulesEvent toolEvent = new ToolComponentApplyRulesEvent(tool);
+                Variables.setLocalVariables(toolEvent, localVars);
+                TriggerItem.walk(this.rulesSection, toolEvent);
+                Variables.setLocalVariables(event, Variables.copyLocalVariables(toolEvent));
+                Variables.removeLocals(toolEvent);
             }
 
             itemMeta.setTool(tool);

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
@@ -32,9 +32,9 @@ import java.util.List;
 @Description({"Apply a tool component to any item making it usable tool. Requires Minecraft 1.20.5+",
     "",
     "**Entries/Sections**:",
-    "`default mining speed` = The default mining speed of this tool, used if no rules override it. Defaults to 1.0. [Optional]",
-    "`damage per block` = The amount of durability to remove each time a block is broken with this tool. Must be a non-negative integer.",
-    "`rules:` =  A list of rules for the blocks that this tool has a special behavior with."})
+    "- `default mining speed` = The default mining speed of this tool, used if no rules override it. Defaults to 1.0. [Optional]",
+    "- `damage per block` = The amount of durability to remove each time a block is broken with this tool. Must be a non-negative integer.",
+    "- `rules:` =  A list of rules for the blocks that this tool has a special behavior with."})
 @Examples({"set {_i} to a stick",
     "apply tool component to {_i}:",
     "\tdefault mining speed: 2.3",

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
@@ -29,6 +29,7 @@ import java.util.List;
 @SuppressWarnings("DataFlowIssue")
 @Name("ItemComponent - Tool Component Apply")
 @Description({"Apply a tool component to any item making it usable tool. Requires Minecraft 1.20.5+",
+    "See [**McWiki Tool Component**](https://minecraft.wiki/w/Data_component_format#tool) for more details.",
     "",
     "**Entries/Sections**:",
     "- `default mining speed` = The default mining speed of this tool, used if no rules override it. Defaults to 1.0. [Optional]",

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
@@ -1,0 +1,150 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.util.slot.Slot;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.ToolComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.entry.EntryValidator;
+import org.skriptlang.skript.lang.entry.util.ExpressionEntryData;
+
+import java.util.List;
+
+@SuppressWarnings("DataFlowIssue")
+@Name("ItemComponent - Tool Component Apply")
+@Description({"Apply a tool component to any item making it usable tool. Requires Minecraft 1.20.5+",
+    "",
+    "**Entries/Sections**:",
+    "`default mining speed` = The default mining speed of this tool, used if no rules override it. Defaults to 1.0. [Optional]",
+    "`damage per block` = The amount of durability to remove each time a block is broken with this tool. Must be a non-negative integer.",
+    "`rules:` =  A list of rules for the blocks that this tool has a special behavior with."})
+@Examples({"set {_i} to a stick",
+    "apply tool component to {_i}:",
+    "\tdefault mining speed: 2.3",
+    "\tdamage per block: 2",
+    "\trules:",
+    "\t\tapply tool rule:",
+    "\t\t\tblock tag: minecraft block tag \"minecraft:dirt\"",
+    "\t\t\tspeed: 1.0",
+    "\t\t\tcorrect for drops: true",
+    "\t\tapply tool rule:",
+    "\t\t\tblock types: granite, stone and andesite",
+    "\t\t\tspeed: 0.5",
+    "\t\t\tcorrect for drops: false",
+    "give {_i} to player"})
+@Since("INSERT VERSION")
+public class SecToolComponent extends Section {
+
+    public static class ToolComponentApplyRulesEvent extends Event {
+
+        private final ToolComponent component;
+
+        public ToolComponentApplyRulesEvent(ToolComponent component) {
+            this.component = component;
+        }
+
+        public ToolComponent getComponent() {
+            return this.component;
+        }
+
+        @Override
+        public @NotNull HandlerList getHandlers() {
+            throw new IllegalStateException("ToolComponentApplyRulesEvent should never be called");
+        }
+    }
+
+    private static final EntryValidator.EntryValidatorBuilder VALIDATIOR = EntryValidator.builder();
+
+    static {
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("default mining speed", null, false, Number.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("damage per block", null, true, Number.class));
+        VALIDATIOR.addSection("rules", true);
+        Skript.registerSection(SecToolComponent.class, "apply tool component to %itemtypes/itemstacks/slots%");
+    }
+
+    private Expression<?> items;
+    private Expression<Number> defaultMiningSpeed;
+    private Expression<Number> damagePerBlock;
+    private Trigger rulesSection;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] expr, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        EntryContainer container = VALIDATIOR.build().validate(sectionNode);
+        if (container == null) return false;
+
+        this.items = expr[0];
+        this.defaultMiningSpeed = (Expression<Number>) container.getOptional("default mining speed", false);
+        this.damagePerBlock = (Expression<Number>) container.getOptional("damage per block", false);
+
+        SectionNode rulesNode = container.getOptional("rules", SectionNode.class, false);
+        if (rulesNode != null) {
+            this.rulesSection = loadCode(rulesNode, "rules section", ToolComponentApplyRulesEvent.class);
+        }
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems", "IfCanBeSwitch"})
+    @Override
+    protected @Nullable TriggerItem walk(Event event) {
+        Number miningSpeedNum = this.defaultMiningSpeed.getSingle(event);
+        Number damagePerNum = this.damagePerBlock.getSingle(event);
+        if (damagePerNum == null) return super.walk(event, false);
+
+        int damagePerBlock = damagePerNum.intValue();
+
+        for (Object object : this.items.getArray(event)) {
+            ItemMeta itemMeta;
+            if (object instanceof ItemStack itemStack) itemMeta = itemStack.getItemMeta();
+            else if (object instanceof ItemType itemType) itemMeta = itemType.getItemMeta();
+            else if (object instanceof Slot slot) itemMeta = slot.getItem().getItemMeta();
+            else continue;
+
+            ToolComponent tool = itemMeta.getTool();
+            if (miningSpeedNum != null) {
+                tool.setDefaultMiningSpeed(miningSpeedNum.floatValue());
+            }
+            tool.setDamagePerBlock(damagePerBlock);
+
+            if (this.rulesSection != null) {
+                TriggerItem.walk(this.rulesSection, new ToolComponentApplyRulesEvent(tool));
+            }
+
+            itemMeta.setTool(tool);
+
+            if (object instanceof ItemStack itemStack) itemStack.setItemMeta(itemMeta);
+            else if (object instanceof ItemType itemType) itemType.setItemMeta(itemMeta);
+            else {
+                Slot slot = (Slot) object;
+                ItemStack slotItem = slot.getItem();
+                slotItem.setItemMeta(itemMeta);
+                slot.setItem(slotItem);
+            }
+        }
+
+        return super.walk(event, false);
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "apply tool component to " + this.items.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
@@ -1,0 +1,125 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecToolComponent.ToolComponentApplyRulesEvent;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.meta.components.ToolComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.entry.EntryValidator;
+import org.skriptlang.skript.lang.entry.util.ExpressionEntryData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("DataFlowIssue")
+@Name("ItemComponent - Tool Rule Apply")
+@Description({"Apply rules to a tool component. You can add as many as you'd like.",
+    "",
+    "**Entries/Sections**:",
+    "NOTE: One of either `block types` or `block tag` MUST be used.",
+    "`block types` = The blocks to match for this rule to apply.",
+    "`block tag` = A Minecraft Tag to match for this rule to apply.",
+    "`speed` = If the blocks match, overrides the default mining speed. [Optional]",
+    "`correct for drops` = If the blocks match, overrides whether or not this tool is " +
+        "considered correct to mine at its most efficient speed, and to drop items if the block's loot table requires it. [Optional]"})
+@Examples({"set {_i} to a stick",
+    "apply tool component to {_i}:",
+    "\tdefault mining speed: 2.3",
+    "\tdamage per block: 2",
+    "\trules:",
+    "\t\tapply tool rule:",
+    "\t\t\tblock tag: minecraft block tag \"minecraft:dirt\"",
+    "\t\t\tspeed: 1.0",
+    "\t\t\tcorrect for drops: true",
+    "\t\tapply tool rule:",
+    "\t\t\tblock types: granite, stone and andesite",
+    "\t\t\tspeed: 0.5",
+    "\t\t\tcorrect for drops: false",
+    "give {_i} to player"})
+@Since("INSERT VERSION")
+public class SecToolRule extends Section {
+
+    private static final EntryValidator.EntryValidatorBuilder VALIDATIOR = EntryValidator.builder();
+
+    static {
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("block types", null, true, ItemType.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("block tag", null, true, Tag.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("speed", null, true, Number.class));
+        VALIDATIOR.addEntryData(new ExpressionEntryData<>("correct for drops", null, true, Boolean.class));
+        Skript.registerSection(SecToolRule.class, "apply tool rule");
+    }
+
+    private Expression<ItemType> blockTypes;
+    private Expression<Tag<Material>> blockKey;
+    private Expression<Number> speed;
+    private Expression<Boolean> correctForDrops;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] expr, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().isCurrentEvent(ToolComponentApplyRulesEvent.class)) {
+            Skript.error("Tool rules can only be applied in a 'rules' section of a tool component section.");
+            return false;
+        }
+
+        EntryContainer container = VALIDATIOR.build().validate(sectionNode);
+        if (container == null) return false;
+
+        this.blockTypes = (Expression<ItemType>) container.getOptional("block types", false);
+        this.blockKey = (Expression<Tag<Material>>) container.getOptional("block tag", false);
+        if (this.blockTypes == null && this.blockKey == null) {
+            Skript.error("Either a 'block types' or 'block tag' entry needs to be used.");
+            return false;
+        }
+        this.speed = (Expression<Number>) container.getOptional("speed", false);
+        this.correctForDrops = (Expression<Boolean>) container.getOptional("correct for drops", false);
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected @Nullable TriggerItem walk(Event event) {
+        if (event instanceof ToolComponentApplyRulesEvent rulesEvent) {
+            ToolComponent component = rulesEvent.getComponent();
+
+            Number speedNum = this.speed != null ? this.speed.getSingle(event) : null;
+            Float speed = speedNum != null ? speedNum.floatValue() : null;
+            Boolean correctForDrops = this.correctForDrops != null ? this.correctForDrops.getSingle(event) : null;
+
+            if (this.blockTypes != null) {
+                List<Material> blockMaterials = new ArrayList<>();
+                for (ItemType itemType : this.blockTypes.getArray(event)) {
+                    Material material = itemType.getMaterial();
+                    if (material.isBlock()) blockMaterials.add(material);
+                }
+                component.addRule(blockMaterials, speed, correctForDrops);
+            } else if (this.blockKey != null) {
+                Tag<Material> tag = this.blockKey.getSingle(event);
+                if (tag != null) {
+                    component.addRule(tag, speed, correctForDrops);
+                }
+            }
+        }
+        return super.walk(event, false);
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "apply tool rule";
+    }
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
@@ -71,7 +71,7 @@ public class SecToolRule extends Section {
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
-    public boolean init(Expression<?>[] expr, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
         if (!getParser().isCurrentEvent(ToolComponentApplyRulesEvent.class)) {
             Skript.error("Tool rules can only be applied in a 'rules' section of a tool component section.");
             return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
@@ -29,6 +29,7 @@ import java.util.List;
 @SuppressWarnings("DataFlowIssue")
 @Name("ItemComponent - Tool Rule Apply")
 @Description({"Apply rules to a tool component. You can add as many as you'd like.",
+    "See [**McWiki Tool Component**](https://minecraft.wiki/w/Data_component_format#tool) for more details.",
     "",
     "**Entries/Sections**:",
     "NOTE: One of either `block types` or `block tag` MUST be used.",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -129,12 +129,14 @@ public class OtherEvents extends SimpleEvent {
             }
         }, 0);
 
-        EventValues.registerEventValue(PrepareAnvilEvent.class, Player.class, new Getter<>() {
-            @Override
-            public Player get(PrepareAnvilEvent event) {
-                return (Player) event.getView().getPlayer();
-            }
-        }, 0);
+        if (Skript.isRunningMinecraft(1,21)) {
+            EventValues.registerEventValue(PrepareAnvilEvent.class, Player.class, new Getter<>() {
+                @Override
+                public Player get(PrepareAnvilEvent event) {
+                    return (Player) event.getView().getPlayer();
+                }
+            }, 0);
+        }
 
         // Player shear entity event
         Skript.registerEvent("Shear Entity", OtherEvents.class, PlayerShearEntityEvent.class, "[player] shear entity")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -129,7 +129,7 @@ public class OtherEvents extends SimpleEvent {
             }
         }, 0);
 
-        if (Skript.isRunningMinecraft(1,21)) {
+        if (Util.IS_RUNNING_MC_1_21) {
             EventValues.registerEventValue(PrepareAnvilEvent.class, Player.class, new Getter<>() {
                 @Override
                 public Player get(PrepareAnvilEvent event) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -11,8 +11,10 @@ import ch.njol.skript.lang.function.SimpleJavaFunction;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.registrations.DefaultClasses;
+import ch.njol.util.StringUtils;
 import ch.njol.yggdrasil.Fields;
 import com.shanebeestudios.skbee.api.util.MathUtil;
+import com.shanebeestudios.skbee.api.util.SkriptUtils;
 import com.shanebeestudios.skbee.api.util.Util;
 import com.shanebeestudios.skbee.api.wrapper.EnumWrapper;
 import com.shanebeestudios.skbee.api.wrapper.RegistryClassInfo;
@@ -22,6 +24,7 @@ import org.bukkit.EntityEffect;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.TreeType;
+import org.bukkit.attribute.AttributeModifier.Operation;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.EntityType;
@@ -35,6 +38,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerRespawnEvent.RespawnReason;
 import org.bukkit.event.player.PlayerSpawnChangeEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.EquipmentSlotGroup;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.meta.trim.ArmorTrim;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
@@ -44,6 +48,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.StreamCorruptedException;
+import java.util.Map;
 
 @SuppressWarnings({"removal", "deprecation"})
 public class Types {
@@ -385,6 +390,40 @@ public class Types {
             .description("Represents the pose of an entity.",
                 "NOTE: These are auto-generated and may differ between server versions.")
             .since("3.5.4"));
+
+        if (Skript.classExists("org.bukkit.inventory.EquipmentSlotGroup")) {
+            // This class is not an enum, and does not have a registry
+            Map<String, EquipmentSlotGroup> equipmentSlotGroups = SkriptUtils.getEquipmentSlotGroups();
+            Classes.registerClass(new ClassInfo<>(EquipmentSlotGroup.class, "equipmentslotgroup")
+                .user("equipment ?slot ?groups?")
+                .name("Equipment Slot Group")
+                .description("Represents different groups of equipment slots.")
+                .usage(StringUtils.join(equipmentSlotGroups.keySet().stream().sorted().toList(), ", "))
+                .parser(new Parser<>() {
+
+                    @SuppressWarnings("NullableProblems")
+                    @Override
+                    public @Nullable EquipmentSlotGroup parse(String string, ParseContext context) {
+                        string = string.replace(" ", "_");
+                        return equipmentSlotGroups.get(string);
+                    }
+
+                    @Override
+                    public @NotNull String toString(EquipmentSlotGroup slot, int flags) {
+                        return slot.toString();
+                    }
+
+                    @Override
+                    public @NotNull String toVariableNameString(EquipmentSlotGroup slot) {
+                        return slot.toString();
+                    }
+                }));
+        }
+
+        Classes.registerClass(new EnumWrapper<>(Operation.class).getClassInfo("attributeoperation")
+            .user("attribute ?operations?")
+            .name("Attribute Modifier Operation")
+            .description("Represents the different operations of an attribute modifer."));
     }
 
     // FUNCTIONS

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprPlayerListName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprPlayerListName.java
@@ -6,6 +6,9 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import net.kyori.adventure.text.Component;
@@ -14,22 +17,37 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@Name("TextComponent - Player List Name")
-@Description("Represents the player list name of a player.")
+@Name("TextComponent - Player List Name/Header/Footer")
+@Description("Represents the player list name/header/footer of a player.")
 @Examples({"set component player list name of player to mini message from \"<rainbow>%player%\"",
     "reset component player list name of player",
-    "set {_comp} to component player list name of player"})
+    "set {_comp} to component player list name of player",
+    "set component player list header of all players to mini message from \"<rainbow>MY SERVER!!!\""})
 @Since("INSERT VERSION")
 public class ExprPlayerListName extends SimplePropertyExpression<Player, ComponentWrapper> {
 
     static {
         register(ExprPlayerListName.class, ComponentWrapper.class,
-            "component (player|tab)[ ]list name", "players");
+            "component (player|tab)[ ]list (name|:header|:footer)", "players");
+    }
+
+    private int type;
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.type = parseResult.hasTag("header") ? 1 : parseResult.hasTag("footer") ? 2 : 0;
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override
     public @Nullable ComponentWrapper convert(Player player) {
-        return ComponentWrapper.fromComponent(player.playerListName());
+        Component component = switch (this.type) {
+            case 1 -> player.playerListHeader();
+            case 2 -> player.playerListFooter();
+            default -> player.playerListName();
+        };
+        return ComponentWrapper.fromComponent(component);
     }
 
     @SuppressWarnings("NullableProblems")
@@ -39,19 +57,25 @@ public class ExprPlayerListName extends SimplePropertyExpression<Player, Compone
         return null;
     }
 
-    @SuppressWarnings({"NullableProblems", "ConstantValue"})
+    @SuppressWarnings({"NullableProblems", "ConstantValue", "DataFlowIssue"})
     @Override
     public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
         Component component = delta != null && delta[0] instanceof ComponentWrapper componentWrapper ? componentWrapper.getComponent() : null;
+        if (component == null && this.type != 0) component = Component.empty();
 
         for (Player player : getExpr().getArray(event)) {
-            player.playerListName(component);
+            switch (this.type) {
+                case 1 -> player.sendPlayerListHeader(component);
+                case 2 -> player.sendPlayerListFooter(component);
+                default -> player.playerListName(component);
+            }
         }
     }
 
     @Override
     protected @NotNull String getPropertyName() {
-        return "component player list name";
+        String type = this.type == 1 ? "header" : this.type == 2 ? "footer" : "name";
+        return "component player list " + type;
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprPlayerListName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprPlayerListName.java
@@ -1,0 +1,62 @@
+package com.shanebeestudios.skbee.elements.text.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("TextComponent - Player List Name")
+@Description("Represents the player list name of a player.")
+@Examples({"set component player list name of player to mini message from \"<rainbow>%player%\"",
+    "reset component player list name of player",
+    "set {_comp} to component player list name of player"})
+@Since("INSERT VERSION")
+public class ExprPlayerListName extends SimplePropertyExpression<Player, ComponentWrapper> {
+
+    static {
+        register(ExprPlayerListName.class, ComponentWrapper.class,
+            "component (player|tab)[ ]list name", "players");
+    }
+
+    @Override
+    public @Nullable ComponentWrapper convert(Player player) {
+        return ComponentWrapper.fromComponent(player.playerListName());
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET || mode == ChangeMode.RESET) return CollectionUtils.array(ComponentWrapper.class);
+        return null;
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantValue"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        Component component = delta != null && delta[0] instanceof ComponentWrapper componentWrapper ? componentWrapper.getComponent() : null;
+
+        for (Player player : getExpr().getArray(event)) {
+            player.playerListName(component);
+        }
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "component player list name";
+    }
+
+    @Override
+    public @NotNull Class<? extends ComponentWrapper> getReturnType() {
+        return ComponentWrapper.class;
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,26 +1,70 @@
 # Welcome to SkBee
 
 settings:
-  # Enable this if you would like to see more verbose debug messages
-  debug: false
+    # Enable this if you would like to see more verbose debug messages
+    debug: false
 
-  # Enable this to automatically check for SkBee updates
-  # Disable this if you do not want to check for updates, or it takes too long/has issues checking
-  update-checker:
-    # Whether or not to check for updates
-    enabled: true
-    # Whether or not the update check should be done on another thread
-    async: false
+    # Enable this to automatically check for SkBee updates
+    # Disable this if you do not want to check for updates, or it takes too long/has issues checking
+    update-checker:
+        # Whether or not to check for updates
+        enabled: true
+        # Whether or not the update check should be done on another thread
+        async: false
 
-  # Whether scoreboard lines should be in normal order or reversed
-  # False = Line 1 at the top, line 15 at the bottom (default)
-  # True = Line 15 at the top, line 1 at the bottom
-  scoreboard-reverse-lines: false
+    # Whether scoreboard lines should be in normal order or reversed
+    # False = Line 1 at the top, line 15 at the bottom (default)
+    # True = Line 15 at the top, line 1 at the bottom
+    scoreboard-reverse-lines: false
 
 # Disable elements you do not plan to use.
 elements:
+    # Enable advancement elements
+    advancement: true
+
+    # Enable boss bar elements
+    boss-bar: true
+
+    # Enable bound elements
+    # Bounds are like custom world guard regions
+    bound: true
+
+    # Enable Chunk Generator elements
+    # Due to the complexity of this, it is disabled by default
+    chunk-generator: false
+
+    # Enable Damage Source elements
+    # This is specifically for Minecraft 1.20.4+
+    damage-source: true
+
+    # Enable display entity elements
+    # This is specifically for Minecraft 1.19.4+
+    display-entity: true
+
+    # Enable fishing elements
+    fishing: true
+
+    # Enable Minecraft GameEvent elements
+    game-event: true
+
+    # Enable different Item Component elements
+    # This is specifically for Minecraft 1.20.5+
+    item-component: true
+
+    # Enable MinecraftTag Elements
+    minecraft-tag: true
+
     # Enable NBT elements
     nbt: true
+
+    # Enable particle elements
+    particle: true
+
+    # Enable RayTrace elements
+    raytrace: true
+
+    # Enable custom recipe elements
+    recipe: true
 
     # Enable Scoreboard elements
     scoreboard: true
@@ -28,82 +72,38 @@ elements:
     # Enable Scoreboard Objective elements
     scoreboard-objective: true
 
-    # Enable Team elements
-    team: true
-
-    # Enable custom recipe elements
-    recipe: true
-
-    # Enable bound elements
-    # Bounds are like custom world guard regions
-    bound: true
+    # Enable statistic elements
+    statistic: true
 
     # Enable structure elements
     structure: true
 
-    # Enable VirtualFurnace elements
-    # This feature is semi-experimental, please use with caution
-    virtual-furnace: false
+    # Enable Team elements
+    team: true
 
     # Enable Text Component elements
     text-component: true
-
-    # Enable world creator elements
-    world-creator: true
-    # Whether or not custom worlds should automatically load on server start
-    # If disabled, you will need to load worlds with the load world effect
-    auto-load-custom-worlds: true
-
-    # Enable Chunk Generator elements
-    # Due to the complexity of this, it is disabled by default
-    chunk-generator: false
-
-    # Enable Minecraft GameEvent elements
-    game-event: true
-
-    # Enable boss bar elements
-    boss-bar: true
-
-    # Enable statistic elements
-    statistic: true
-
-    # Enable villager/merchant elements
-    villager: true
-
-    # Enable advancement elements
-    advancement: true
-
-    # Enable world border elements
-    world-border: true
-
-    # Enable particle elements
-    particle: true
-
-    # Enable MinecraftTag Elements
-    minecraft-tag: true
-
-    # Enable RayTrace elements
-    raytrace: true
-
-    # Enable fishing elements
-    fishing: true
-
-    # Enable display entity elements
-    # This is specifically for Minecraft 1.19.4+
-    display-entity: true
 
     # Enable Server Tick Manager elements
     # These elements are based around Minecraft's tick command
     # This is specifically for Minecraft 1.20.4+
     tick-manager: true
 
-    # Enable Damage Source elements
-    # This is specifically for Minecraft 1.20.4+
-    damage-source: true
+    # Enable villager/merchant elements
+    villager: true
 
-    # Enable different Item Component elements
-    # This is specifically for Minecraft 1.20.5+
-    item-component: true
+    # Enable VirtualFurnace elements
+    # This feature is semi-experimental, please use with caution
+    virtual-furnace: false
+
+    # Enable world border elements
+    world-border: true
+
+    # Enable world creator elements
+    world-creator: true
+    # Whether or not custom worlds should automatically load on server start
+    # If disabled, you will need to load worlds with the load world effect
+    auto-load-custom-worlds: true
 
 # Enable different event listeners for NBT
 nbt-events:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -101,6 +101,10 @@ elements:
     # This is specifically for Minecraft 1.20.4+
     damage-source: true
 
+    # Enable different Item Component elements
+    # This is specifically for Minecraft 1.20.5+
+    item-component: true
+
 # Enable different event listeners for NBT
 nbt-events:
     # Whether breaking a block should remove NBT

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,8 +30,7 @@ elements:
     bound: true
 
     # Enable Chunk Generator elements
-    # Due to the complexity of this, it is disabled by default
-    chunk-generator: false
+    chunk-generator: true
 
     # Enable Damage Source elements
     # This is specifically for Minecraft 1.20.4+


### PR DESCRIPTION
temp changelog

## ADDED:
- Added a section to create food components on items (along with an effect to apply potion effects to said component)
- Added sections to create tool components and apply tool rules.
- Added a section to apply attribute modifiers to items (along with types for attribute operations and equipment slot groups)
- Added an effect to clear food/tool/attribute modifier components from an item (this will not clear vanilla components)
- Added an expression to get/set the player list name/header/footer as text component

## FIXED:
- Fixed an issue where custom worlds with custom chunk generators would auto-load before the generator loads, thus failing to use the chunk generator
- Fixed an error with anvil prepare event when getting player on pre 1.21 MC versions.
- Fixed an issue with `force` not working on particles when using `to player`

## CHANGED:
- chunk generator is now enabled by default in config