### PR TITLE
Bound & ExprBoundBlocks - Support Getting Specific Blocks

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.shanebeestudios.skbee.api.util.WorldUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -153,9 +154,18 @@ public class Bound implements ConfigurationSerializable {
      * @return List of blocks within bound
      */
     public List<Block> getBlocks() {
-        World w = getWorld();
-        if (w == null) return null;
+        return getBlocks(null);
+    }
+
+    /**
+     * Get a list of blocks with the specified material within a bound
+     *
+     * @return List of blocks with the specified material within bound
+     */
+    public List<Block> getBlocks(Material material) {
         List<Block> array = new ArrayList<>();
+        World w = getWorld();
+        if (w == null) return array;
         int minX = (int) boundingBox.getMinX();
         int minY = (int) boundingBox.getMinY();
         int minZ = (int) boundingBox.getMinZ();
@@ -166,6 +176,8 @@ public class Bound implements ConfigurationSerializable {
             for (int y = minY; y < maxY; y++) {
                 for (int z = minZ; z < maxZ; z++) {
                     Block b = w.getBlockAt(x, y, z);
+                    if (material != null && !b.getType().equals(material))
+                        continue;
                     array.add(b);
                 }
             }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundBlocks.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundBlocks.java
@@ -1,6 +1,7 @@
 package com.shanebeestudios.skbee.elements.bound.expressions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -10,6 +11,8 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.Event;
 import com.shanebeestudios.skbee.api.bound.Bound;
@@ -19,27 +22,31 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Name("Bound - Blocks")
-@Description("All the blocks within a bound")
+@Description("All the blocks or specific type of blocks within a bound")
 @Examples({"set {_blocks::*} to all blocks within bound {bound}",
         "set {_blocks::*} to all blocks within bound bound with id \"le-bound\"",
+        "set {_stone blocks::*} to all blocks of type stone block with bound {_bound}",
         "set all blocks within bound {bound} to stone",
         "loop all blocks within bound {bound}:",
         "\tif loop-block is stone:",
         "\t\tset loop-block to grass"})
-@Since("1.0.0")
+@Since("1.0.0, INSERT VERSION (specific blocks)")
 public class ExprBoundBlocks extends SimpleExpression<Block> {
 
     static {
         Skript.registerExpression(ExprBoundBlocks.class, Block.class, ExpressionType.SIMPLE,
-                "[(all [[of] the]|the)] blocks within bound %bound%");
+                "[(all [[of] the]|the)] blocks [of type %-itemtypes%] within bound %bound%");
     }
 
     private Expression<Bound> bound;
+    private Expression<ItemType> types;
 
     @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-        bound = (Expression<Bound>) exprs[0];
+        bound = (Expression<Bound>) exprs[1];
+        if (exprs[0] != null)
+            types = ((Expression<ItemType>) exprs[0]);
         return true;
     }
 
@@ -50,8 +57,19 @@ public class ExprBoundBlocks extends SimpleExpression<Block> {
         if (single == null) {
             return null;
         }
-        List<Block> list = new ArrayList<>(single.getBlocks());
-        return list.toArray(new Block[0]);
+        List<Block> blocks;
+        if (types != null) {
+            blocks = new ArrayList<>();
+            for (ItemType itemType : types.getArray(event)) {
+                Material material = itemType.getMaterial();
+                if (!material.isBlock()) continue;
+                blocks.addAll(new ArrayList<>(single.getBlocks(material)));
+            }
+        }
+        else {
+            blocks = new ArrayList<>(single.getBlocks());
+        }
+        return blocks.toArray(new Block[0]);
     }
 
     @Override
@@ -65,8 +83,11 @@ public class ExprBoundBlocks extends SimpleExpression<Block> {
     }
 
     @Override
-    public @NotNull String toString(Event e, boolean d) {
-        return "the blocks within bound " + bound.toString(e, d);
+    public @NotNull String toString(Event event, boolean debug) {
+        String types = "";
+        if (this.types != null)
+            types = " of type " + this.types.toString(event, debug);
+        return "the blocks" + types + " within bound " + bound.toString(event, debug);
     }
 
 }


### PR DESCRIPTION
This PR enhances the Bound class to:
- support getting specific type of blocks (also carried along to ExprBoundBlocks.class)
- minor API change to Bound#getBlocks() where it returns an empty List instead of null in case if the associated world is not loaded