### PR TITLE
Dev/Patch - future update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     // Paper
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
 
     // Skript
     compileOnly(group: 'com.github.SkriptLang', name: 'Skript', version: '2.8.7') {

--- a/src/main/java/com/shanebeestudios/skbee/AddonLoader.java
+++ b/src/main/java/com/shanebeestudios/skbee/AddonLoader.java
@@ -285,7 +285,7 @@ public class AddonLoader {
             Util.logLoading("&5Text Component Elements &cdisabled via config");
             return;
         }
-        if (!Skript.classExists("net.kyori.adventure.text.Component")) {
+        if (!Skript.classExists("io.papermc.paper.event.player.AsyncChatEvent")) {
             Util.logLoading("&5Text Component Elements &cdisabled");
             Util.logLoading("&7- Text components require a PaperMC server.");
             return;

--- a/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
@@ -295,7 +295,7 @@ public class Bound implements ConfigurationSerializable {
         Location greaterCorner = bound.getGreaterCorner().clone();
         Bound newBound = new Bound(lesserCorner, greaterCorner, id, bound.isTemporary());
         newBound.setOwners(bound.getOwners());
-        newBound.setMembers(bound.getOwners());
+        newBound.setMembers(bound.getMembers());
         newBound.setBoundingBox(bound.getBoundingBox().clone());
         newBound.values = bound.values;
         return newBound;
@@ -377,7 +377,7 @@ public class Bound implements ConfigurationSerializable {
      * @param owners Owners to set
      */
     public void setOwners(List<UUID> owners) {
-        this.owners = owners;
+        this.owners = new ArrayList<>(owners);
     }
 
     /**
@@ -422,7 +422,7 @@ public class Bound implements ConfigurationSerializable {
      * @param members Members to set
      */
     public void setMembers(List<UUID> members) {
-        this.members = members;
+        this.members = new ArrayList<>(members);
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTApi.java
@@ -617,7 +617,11 @@ public class NBTApi {
                             byteArray = ArrayUtils.remove(byteArray, index);
                         }
                     }
-                    compound.setByteArray(tag, byteArray);
+                    if (byteArray.length > 0) {
+                        compound.setByteArray(tag, byteArray);
+                    } else {
+                        compound.removeKey(tag);
+                    }
                 }
             }
             case NBTTagIntArray -> {
@@ -631,7 +635,11 @@ public class NBTApi {
                             intArray = ArrayUtils.remove(intArray, index);
                         }
                     }
-                    compound.setIntArray(tag, intArray);
+                    if (intArray.length > 0) {
+                        compound.setIntArray(tag, intArray);
+                    } else {
+                        compound.removeKey(tag);
+                    }
                 }
             }
             case NBTTagIntList -> {
@@ -640,6 +648,7 @@ public class NBTApi {
                     for (Object o : object)
                         if (o instanceof Number number)
                             intList.remove((Object) number.intValue());
+                    if (intList.isEmpty()) compound.removeKey(tag);
                 }
             }
             case NBTTagLongList -> {
@@ -648,6 +657,7 @@ public class NBTApi {
                     for (Object o : object)
                         if (o instanceof Number number)
                             longList.remove(number.longValue());
+                    if (longList.isEmpty()) compound.removeKey(tag);
                 }
             }
             case NBTTagFloatList -> {
@@ -656,6 +666,7 @@ public class NBTApi {
                     for (Object o : object)
                         if (o instanceof Number number)
                             floatList.remove(number.floatValue());
+                    if (floatList.isEmpty()) compound.removeKey(tag);
                 }
             }
             case NBTTagDoubleList -> {
@@ -664,6 +675,7 @@ public class NBTApi {
                     for (Object o : object)
                         if (o instanceof Number number)
                             doubleList.remove(number.doubleValue());
+                    if (doubleList.isEmpty()) compound.removeKey(tag);
                 }
             }
             case NBTTagStringList -> {
@@ -672,6 +684,7 @@ public class NBTApi {
                     for (Object o : object)
                         if (o instanceof String string)
                             stringList.remove(string);
+                    if (stringList.isEmpty()) compound.removeKey(tag);
                 }
             }
             case NBTTagCompoundList -> {

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomItemStack.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomItemStack.java
@@ -15,11 +15,13 @@ public class NBTCustomItemStack extends NBTContainer {
 
     private final ItemStack originalItemStack;
     private final boolean isCustomData;
+    private final boolean isFull;
 
     public NBTCustomItemStack(ItemStack itemStack, boolean isCustomData, boolean isVanilla, boolean isFull) {
         super(getInitialContainer(itemStack, isCustomData, isVanilla, isFull).toString());
         this.originalItemStack = itemStack;
         this.isCustomData = isCustomData;
+        this.isFull = isFull;
     }
 
     private static NBTCompound getInitialContainer(ItemStack itemStack, boolean isCustomData, boolean isVanilla, boolean isFull) {
@@ -46,6 +48,7 @@ public class NBTCustomItemStack extends NBTContainer {
     @Override
     protected void saveCompound() {
         super.saveCompound();
+        if (this.isFull) return;
         NBTContainer originalItemContainer = NBTItem.convertItemtoNBT(this.originalItemStack.clone());
         NBTCompound components = getContainer(originalItemContainer, this.isCustomData, false);
         components.clearNBT();

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/ComponentWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/ComponentWrapper.java
@@ -7,6 +7,7 @@ import ch.njol.skript.util.Color;
 import ch.njol.skript.util.ColorRGB;
 import ch.njol.skript.util.SkriptColor;
 import ch.njol.skript.util.slot.Slot;
+import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.ChatUtil;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
@@ -47,15 +48,17 @@ import org.jetbrains.annotations.Nullable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Wrapper for {@link Component Adventure API Components}
  */
-@SuppressWarnings({"PatternValidation"})
+@SuppressWarnings({"PatternValidation", "CallToPrintStackTrace"})
 public class ComponentWrapper {
 
     // STATIC
     private static final boolean HAS_SIDES = Skript.classExists("org.bukkit.block.sign.SignSide");
+    private static final boolean DEBUG = SkBee.getPlugin().getPluginConfig().SETTINGS_DEBUG;
     /**
      * Check if ItemMeta supports 'itemName' ('item_name' component
      */
@@ -424,18 +427,26 @@ public class ComponentWrapper {
      */
     @SuppressWarnings("LanguageMismatch")
     public void replace(String text, ComponentWrapper replacement) {
-        this.component = this.component.replaceText(c -> c.match(text).replacement(replacement.component));
+        try {
+            this.component = this.component.replaceText(c -> c.match(text).replacement(replacement.component));
+        } catch (PatternSyntaxException ex) {
+            if (DEBUG) ex.printStackTrace();
+        }
     }
 
     /**
-     * Rpelace a string with a string
+     * Replace a string with a string
      *
      * @param text        String to replace
      * @param replacement To replace with
      */
     @SuppressWarnings("LanguageMismatch")
     public void replace(String text, String replacement) {
-        this.component = this.component.replaceText(c -> c.match(text).replacement(replacement));
+        try {
+            this.component = this.component.replaceText(c -> c.match(text).replacement(replacement));
+        } catch (PatternSyntaxException ex) {
+            if (DEBUG) ex.printStackTrace();
+        }
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffBreakBlocksWithEffects.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffBreakBlocksWithEffects.java
@@ -1,0 +1,75 @@
+package com.shanebeestudios.skbee.elements.other.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Break Blocks with Effects")
+@Description({"Breaks blocks as if a player had broken them. Will drop items, play particles and sounds. Requires PaperMC.",
+    "Optionally you can trigger it to drop experience as well.",
+    "Optionally you can include an item which is used to determine which drops the block will drop."})
+@Examples({"break blocks in radius 2 around target block with effects",
+    "break {_blocks::*} with effects and with xp",
+    "break {_blocks::*} with effects and with xp using player's tool"})
+@Since("INSERT VERSION")
+public class EffBreakBlocksWithEffects extends Effect {
+
+    private static final boolean HAS_EFFECTS = Skript.methodExists(Block.class, "breakNaturally", boolean.class, boolean.class);
+
+    static {
+        Skript.registerEffect(EffBreakBlocksWithEffects.class,
+            "break %blocks% [naturally] with effects [exp:[and] with (experience|exp|xp)] [using %-itemtype%]");
+    }
+
+    private boolean exp;
+    private Expression<Block> blocks;
+    private Expression<ItemType> itemType;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!HAS_EFFECTS) {
+            Skript.error("'break %blocks% with effects' requires PaperMC. Use Skript's 'break %blocks%' effect instead.");
+            return false;
+        }
+        this.exp = parseResult.hasTag("exp");
+        this.blocks = (Expression<Block>) exprs[0];
+        this.itemType = (Expression<ItemType>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void execute(Event event) {
+        ItemStack itemStack = null;
+        if (this.itemType != null) {
+            ItemType it = this.itemType.getSingle(event);
+            if (it != null) itemStack = it.getRandom();
+        }
+
+        for (Block block : this.blocks.getArray(event)) {
+            if (itemStack != null) block.breakNaturally(itemStack, true, this.exp);
+            else block.breakNaturally(true, this.exp);
+        }
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        String blocks = this.blocks.toString(e, d);
+        String xp = this.exp ? " and with experience" : "";
+        String it = this.itemType != null ? (" using " + this.itemType.toString(e, d)) : "";
+        return "break " + blocks + " naturally with effects" + xp + it;
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -29,7 +29,6 @@ import org.bukkit.event.block.BlockDamageAbortEvent;
 import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.block.CrafterCraftEvent;
 import org.bukkit.event.block.MoistureChangeEvent;
 import org.bukkit.event.entity.EntityAirChangeEvent;
 import org.bukkit.event.entity.EntityBreedEvent;
@@ -627,31 +626,6 @@ public class OtherEvents extends SimpleEvent {
                     return event.getNewSpawn();
                 }
             }, EventValues.TIME_FUTURE);
-        }
-
-        if (Skript.classExists("org.bukkit.event.block.CrafterCraftEvent")) {
-            Skript.registerEvent("Crafter Craft Event", OtherEvents.class, CrafterCraftEvent.class, "crafter craft")
-                .description("Called when a Crafter is about to craft an item. Requires Minecraft 1.21.1+",
-                    "`event-string` = The key for the recipe used in this event.",
-                    "`recipe result` = An expression that reprsents the result slot (can be changed).")
-                .examples("on crafter craft:",
-                    "\tif event-string = \"minecraft:diamond_sword\":",
-                    "\t\tset name of recipe result to \"Señor Sword\"",
-                    "\telse:",
-                    "\t\tset recipe result to a stick named \"&cNice Try\"",
-                    "",
-                    "on preparing craft:",
-                    "\tset {_e} to event-string",
-                    "\tif {_e} = \"minecraft:diamond_shovel\":",
-                    "\t\tset name of recipe result to \"&cMr Shovel\"")
-                .since("INSERT VERSION");
-
-            EventValues.registerEventValue(CrafterCraftEvent.class, String.class, new Getter<>() {
-                @Override
-                public @NotNull String get(CrafterCraftEvent event) {
-                    return event.getRecipe().getKey().toString();
-                }
-            }, EventValues.TIME_NOW);
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/OtherEvents.java
@@ -29,6 +29,7 @@ import org.bukkit.event.block.BlockDamageAbortEvent;
 import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.CrafterCraftEvent;
 import org.bukkit.event.block.MoistureChangeEvent;
 import org.bukkit.event.entity.EntityAirChangeEvent;
 import org.bukkit.event.entity.EntityBreedEvent;
@@ -626,6 +627,31 @@ public class OtherEvents extends SimpleEvent {
                     return event.getNewSpawn();
                 }
             }, EventValues.TIME_FUTURE);
+        }
+
+        if (Skript.classExists("org.bukkit.event.block.CrafterCraftEvent")) {
+            Skript.registerEvent("Crafter Craft Event", OtherEvents.class, CrafterCraftEvent.class, "crafter craft")
+                .description("Called when a Crafter is about to craft an item. Requires Minecraft 1.21.1+",
+                    "`event-string` = The key for the recipe used in this event.",
+                    "`recipe result` = An expression that reprsents the result slot (can be changed).")
+                .examples("on crafter craft:",
+                    "\tif event-string = \"minecraft:diamond_sword\":",
+                    "\t\tset name of recipe result to \"Señor Sword\"",
+                    "\telse:",
+                    "\t\tset recipe result to a stick named \"&cNice Try\"",
+                    "",
+                    "on preparing craft:",
+                    "\tset {_e} to event-string",
+                    "\tif {_e} = \"minecraft:diamond_shovel\":",
+                    "\t\tset name of recipe result to \"&cMr Shovel\"")
+                .since("INSERT VERSION");
+
+            EventValues.registerEventValue(CrafterCraftEvent.class, String.class, new Getter<>() {
+                @Override
+                public @NotNull String get(CrafterCraftEvent event) {
+                    return event.getRecipe().getKey().toString();
+                }
+            }, EventValues.TIME_NOW);
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprChunksWithinCuboid.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprChunksWithinCuboid.java
@@ -1,0 +1,88 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Name("Chunks Within Locations")
+@Description("Get a list of all chunks within 2 locations.")
+@Examples({"loop all chunks within {_l1} and {_l2}:",
+    "refresh all chunks within {_l1} and {_l2}"})
+@Since("INSERT VERSION")
+public class ExprChunksWithinCuboid extends SimpleExpression<Chunk> {
+
+    static {
+        Skript.registerExpression(ExprChunksWithinCuboid.class, Chunk.class, ExpressionType.COMBINED,
+            "all chunks within %location% and %location%");
+    }
+
+    private Expression<Location> loc1, loc2;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.loc1 = (Expression<Location>) exprs[0];
+        this.loc2 = (Expression<Location>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected Chunk @Nullable [] get(Event event) {
+        Location loc1 = this.loc1.getSingle(event);
+        Location loc2 = this.loc2.getSingle(event);
+        if (loc1 == null || loc2 == null) return null;
+
+        World world = loc1.getWorld();
+        if (world != loc2.getWorld()) return null;
+
+        List<Chunk> chunks = new ArrayList<>();
+        int minX = Math.min(loc1.getBlockX(), loc2.getBlockX()) >> 4;
+        int minZ = Math.min(loc1.getBlockZ(), loc2.getBlockZ()) >> 4;
+        int maxX = (Math.max(loc1.getBlockX(), loc2.getBlockX()) + 1) >> 4;
+        int maxZ = (Math.max(loc1.getBlockZ(), loc2.getBlockZ()) + 1) >> 4;
+        for (int x = minX; x <= maxX; x++) {
+            for (int z = minZ; z <= maxZ; z++) {
+                chunks.add(world.getChunkAt(x, z, false));
+            }
+        }
+
+        Iterator<Entity> e;
+
+        return chunks.toArray(new Chunk[0]);
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<? extends Chunk> getReturnType() {
+        return Chunk.class;
+    }
+
+    @Override
+    public @NotNull String toString(Event e, boolean d) {
+        return "all chunks within " + this.loc1.toString(e, d) + " and " + this.loc2.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLootTableObject.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprLootTableObject.java
@@ -23,17 +23,17 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Name("LootTable - Lootables")
+@Name("LootTable - LootTable of Lootable")
 @Description({"Get/set/delete the LootTable of a lootable object such as a block or entity.",
-        "`with seed` = Provide an optional seed for loot generation otherwise will randomly generate."})
+    "`with seed` = Provide an optional seed for loot generation otherwise will randomly generate."})
 @Examples({"set {_lootTable} to loottable of target block",
-        "set loottable of target block to loottable from key \"minecraft:chests/ancient_city\""})
+    "set loottable of target block to loottable from key \"minecraft:chests/ancient_city\""})
 @Since("3.4.0")
 public class ExprLootTableObject extends SimpleExpression<LootTable> {
 
     static {
         Skript.registerExpression(ExprLootTableObject.class, LootTable.class, ExpressionType.COMBINED,
-                "loot[ ]table of %blocks/entities% [with seed %-number%]");
+            "loot[ ]table of %blocks/entities% [with seed %-number%]");
     }
 
     private Expression<?> objects;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/sections/SecAttributeModifier.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/sections/SecAttributeModifier.java
@@ -191,6 +191,7 @@ public class SecAttributeModifier extends Section {
                 itemType.setItemMeta(itemMeta);
             } else if (object instanceof LivingEntity entity) {
                 AttributeInstance attributeInstance = entity.getAttribute(attribute);
+                if (attributeInstance == null) continue;
                 if (!EntityUtils.hasAttributeModifier(entity, attribute, attributeModifier)) {
                     if (this.trans) {
                         attributeInstance.addTransientModifier(attributeModifier);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -311,7 +311,7 @@ public class Types {
 
                     @Override
                     public @NotNull String toString(LootTable lootTable, int flags) {
-                        return "LootTable{" + lootTable.getKey() + "}";
+                        return lootTable.getKey().toString();
                     }
 
                     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/events/EvtRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/events/EvtRecipe.java
@@ -4,7 +4,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Getter;
+import com.shanebeestudios.skbee.elements.other.events.OtherEvents;
+import org.bukkit.event.block.CrafterCraftEvent;
 import org.bukkit.event.player.PlayerRecipeDiscoverEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class EvtRecipe extends SimpleEvent {
 
@@ -25,6 +28,31 @@ public class EvtRecipe extends SimpleEvent {
                 return event.getRecipe().toString();
             }
         }, 0);
+
+        if (Skript.classExists("org.bukkit.event.block.CrafterCraftEvent")) {
+            Skript.registerEvent("Recipe - Crafter Craft Event", EvtRecipe.class, CrafterCraftEvent.class, "crafter craft")
+                .description("Called when a Crafter is about to craft an item. Requires Minecraft 1.21.1+",
+                    "`event-string` = The key for the recipe used in this event.",
+                    "`recipe result` = An expression that reprsents the result slot (can be changed).")
+                .examples("on crafter craft:",
+                    "\tif event-string = \"minecraft:diamond_sword\":",
+                    "\t\tset name of recipe result to \"Señor Sword\"",
+                    "\telse:",
+                    "\t\tset recipe result to a stick named \"&cNice Try\"",
+                    "",
+                    "on preparing craft:",
+                    "\tset {_e} to event-string",
+                    "\tif {_e} = \"minecraft:diamond_shovel\":",
+                    "\t\tset name of recipe result to \"&cMr Shovel\"")
+                .since("INSERT VERSION");
+
+            EventValues.registerEventValue(CrafterCraftEvent.class, String.class, new Getter<>() {
+                @Override
+                public @NotNull String get(CrafterCraftEvent event) {
+                    return event.getRecipe().getKey().toString();
+                }
+            }, EventValues.TIME_NOW);
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprRecipeResultSlot.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprRecipeResultSlot.java
@@ -1,0 +1,160 @@
+package com.shanebeestudios.skbee.elements.recipe.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.slot.Slot;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.CrafterCraftEvent;
+import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Recipe - Result Slot")
+@Description({"Represents the result slot of a crafting event.",
+    "This can be changed."})
+@Examples({"on crafter craft:",
+    "\tif event-string = \"minecraft:diamond_sword\":",
+    "\t\tset name of recipe result to \"Señor Sword\"",
+    "\telse:",
+    "\t\tset recipe result to a stick named \"&cNice Try\"",
+    "",
+    "on preparing craft:",
+    "\tset {_e} to event-string",
+    "\tif {_e} = \"minecraft:diamond_shovel\":",
+    "\t\tset name of recipe result to \"&cMr Shovel\""})
+@Since("INSERT VERSION")
+public class ExprRecipeResultSlot extends SimpleExpression<Slot> {
+
+    public static final boolean HAS_CRAFTER_RECIPE = Skript.classExists("org.bukkit.event.block.CrafterCraftEvent");
+
+    static {
+        Skript.registerExpression(ExprRecipeResultSlot.class, Slot.class, ExpressionType.SIMPLE,
+            "recipe result [slot]");
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        ParserInstance parser = getParser();
+        if (HAS_CRAFTER_RECIPE && parser.isCurrentEvent(CrafterCraftEvent.class)) {
+            return true;
+        } else if (parser.isCurrentEvent(CraftItemEvent.class, PrepareItemCraftEvent.class)) {
+            return true;
+        }
+        Skript.error("'" + parser.getCurrentEventName() + "' does not have a recipe result.");
+        return false;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected Slot @Nullable [] get(Event event) {
+        Slot slot = null;
+        if (HAS_CRAFTER_RECIPE && event instanceof CrafterCraftEvent craftEvent) {
+            slot = new Slot() {
+                @Override
+                public @NotNull ItemStack getItem() {
+                    return craftEvent.getResult();
+                }
+
+                @Override
+                public void setItem(@Nullable ItemStack item) {
+                    if (item == null) return;
+                    craftEvent.setResult(item);
+                }
+
+                @Override
+                public int getAmount() {
+                    return getItem().getAmount();
+                }
+
+                @Override
+                public void setAmount(int amount) {
+                    ItemStack clone = getItem().clone();
+                    clone.setAmount(amount);
+                    setItem(clone);
+                }
+
+                @Override
+                public boolean isSameSlot(Slot other) {
+                    return other.getItem() == getItem();
+                }
+
+                @Override
+                public String toString(Event event, boolean debug) {
+                    return "crafter craft event result slot";
+                }
+            };
+            //} else if (event instanceof CraftItemEvent craftItemEvent) {
+        } else if (event instanceof InventoryEvent invEvent && invEvent.getInventory() instanceof CraftingInventory craftingInventory) {
+            slot = new Slot() {
+                @Override
+                public @Nullable ItemStack getItem() {
+                    return craftingInventory.getResult();
+                }
+
+                @Override
+                public void setItem(@Nullable ItemStack item) {
+                    craftingInventory.setResult(item);
+                }
+
+                @Override
+                public int getAmount() {
+                    ItemStack item = getItem();
+                    if (item == null) return 0;
+                    return item.getAmount();
+                }
+
+                @Override
+                public void setAmount(int amount) {
+                    ItemStack item = getItem();
+                    if (item != null) {
+                        ItemStack clone = item.clone();
+                        clone.setAmount(amount);
+                        setItem(clone);
+                    }
+                }
+
+                @Override
+                public boolean isSameSlot(Slot other) {
+                    return other.getItem() == getItem();
+                }
+
+                @Override
+                public String toString(Event event, boolean debug) {
+                    return "crafting inventory result slot";
+                }
+            };
+        }
+        if (slot != null) return new Slot[]{slot};
+        return null;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends Slot> getReturnType() {
+        return Slot.class;
+    }
+
+    @Override
+    public @NotNull String toString(Event event, boolean b) {
+        return "recipe result slot";
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
@@ -12,18 +12,20 @@ import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @Name("TextComponent - Replace Text")
-@Description({"Replace a string with another string or text component in a text component. Supports regex patterns."})
+@Description({"Replace a string with another string or text component in a text component. Supports regex patterns.",
+    "NOTE: If you notice sometimes your symbols aren't replace, this could be a regex pattern issue and you may need to escape characters.",
+    "ex: `:(` -> `:\\(` and `[` -> `\\[`"})
 @Examples({"component replace \"puppy\" with \"***\" in {_comp}",
-        "component replace \"\\d+\" with \"0\" in {_comp}"})
+    "component replace \"\\d+\" with \"0\" in {_comp}",
+    "component replace \":\\(\" with \"sad\" in {_comp}"})
 @Since("2.18.0")
 public class EffComponentReplace extends Effect {
 
     static {
         Skript.registerEffect(EffComponentReplace.class,
-                "component replace %strings% with %string/textcomponent% in %textcomponents%");
+            "component replace %strings% with %string/textcomponent% in %textcomponents%");
     }
 
     private Expression<String> toReplace;
@@ -54,7 +56,7 @@ public class EffComponentReplace extends Effect {
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(Event e, boolean d) {
         String toReplace = this.toReplace.toString(e, d);
         String replace = this.replacement.toString(e, d);
         String comp = this.components.toString(e, d);

--- a/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffVillagerEffects.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/villager/effects/EffVillagerEffects.java
@@ -13,27 +13,27 @@ import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Villager - Effects")
 @Description("A few effects to make villagers do things.")
 @Examples({"zombify last spawned villager",
-        "wake up all villagers",
-        "make target entity shake his head",
-        "make target entity sleep at location(100, 64, 100, world \"world\")"})
+    "wake up all villagers",
+    "make target entity shake his head",
+    "make target entity sleep at location(100, 64, 100, world \"world\")"})
 @Since("1.17.0")
 public class EffVillagerEffects extends Effect {
 
-    private static boolean CAN_ZOMBIFY = Skript.methodExists(Villager.class, "zombify");
-    private static boolean CAN_WAKEUP = Skript.methodExists(Villager.class, "wakeup");
+    private static final boolean CAN_ZOMBIFY = Skript.methodExists(Villager.class, "zombify");
+    private static final boolean CAN_WAKEUP = Skript.methodExists(Villager.class, "wakeup");
 
     static {
         Skript.registerEffect(EffVillagerEffects.class,
-                "zombify %livingentities%",
-                "wake[ ]up %livingentities%",
-                "make %livingentities% shake [(his|their)] head[s]",
-                "make %livingentities% sleep at %location%");
+            "zombify %livingentities%",
+            "wake[ ]up %livingentities%",
+            "make %livingentities% shake [(his|their)] head[s]",
+            "make %livingentities% sleep at %location%");
     }
 
     private Expression<LivingEntity> entities;
@@ -63,9 +63,11 @@ public class EffVillagerEffects extends Effect {
         Location location = this.location != null ? this.location.getSingle(event) : null;
         for (LivingEntity entity : this.entities.getArray(event)) {
             if (entity instanceof Villager villager) {
-                switch (pattern) {
+                switch (this.pattern) {
                     case 0 -> villager.zombify();
-                    case 1 -> villager.wakeup();
+                    case 1 -> {
+                        if (villager.isSleeping()) villager.wakeup();
+                    }
                     case 2 -> villager.shakeHead();
                     case 3 -> sleepVillager(villager, location);
                 }
@@ -86,7 +88,7 @@ public class EffVillagerEffects extends Effect {
     @Override
     public @NotNull String toString(@Nullable Event e, boolean d) {
         String entity = this.entities.toString(e, d);
-        return switch (pattern) {
+        return switch (this.pattern) {
             case 0 -> "zombify " + entity;
             case 1 -> "wakeup " + entity;
             case 2 -> "shake head of " + entity;


### PR DESCRIPTION
## FIXED:
- Fixed an error when attempting to wake up a villager that isn't sleeping
- Fixed an issue with modifying `full nbt of %item%` throwing Minecraft component errors to console
- Fixed an error when applying an attribute modifier to an entity which doesn't have that attribute.
- Fixed an issue where an empty list/array is left in an NBT compound after removing from it (and often returning an incorrect tag type)
- Fixed an error when running a Spigot server and another plugin has added AdventureAPI
- Fixed an error with component replace when a regex pattern is broken
- Fixed an issue when copying bounds, and the owner was copied into members
- Fixed an issue where the bound owners/members list was not cloned but referenced when copying a bound (therefor linking the two)

## ADDED:
- Added crafter craft event (along with `event-string` event value which represents the recipe)
- Added an expression that represents the result slot of crafting events.
- Added an expression to get all chunks within 2 locations (a cuboid)
- Added an effect to break blocks naturally but also play particles/sounds