### PR TITLE
dev/patch - stuff im working on

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
@@ -80,7 +80,7 @@ public class Bound implements ConfigurationSerializable {
     public boolean isInRegion(@NotNull Location loc) {
         World w = loc.getWorld();
         if (w != null && w.getName().equals(world)) {
-            return this.boundingBox.contains(loc.toVector());
+            return getCachedBoundingBox().contains(loc.toVector());
         }
         return false;
     }
@@ -93,7 +93,7 @@ public class Bound implements ConfigurationSerializable {
      */
     public boolean overlaps(Bound bound) {
         if (bound.world.equals(world)) {
-            return boundingBox.overlaps(bound.boundingBox);
+            return getCachedBoundingBox().overlaps(bound.getCachedBoundingBox());
         }
         return false;
     }
@@ -107,7 +107,7 @@ public class Bound implements ConfigurationSerializable {
      */
     public boolean overlaps(Location l1, Location l2) {
         if (l1.getWorld() != null && l1.getWorld() == l2.getWorld()) {
-            return boundingBox.overlaps(l1.toVector(), l2.toVector());
+            return getCachedBoundingBox().overlaps(l1.toVector(), l2.toVector());
         }
         return false;
     }
@@ -398,12 +398,9 @@ public class Bound implements ConfigurationSerializable {
             int minY = world != null ? world.getMinHeight() : 0;
             int maxY = world != null ? world.getMaxHeight() - 1 : 255;
             this.fullBoundBoxCache = box.resize(box.getMinX(), minY, box.getMinZ(), box.getMaxX(), maxY, box.getMaxZ());
+            return this.fullBoundBoxCache;
         }
         return this.boundingBox;
-    }
-
-    public void setBoundingBox(BoundingBox box) {
-        this.boundingBox = box;
     }
 
     /**
@@ -415,10 +412,20 @@ public class Bound implements ConfigurationSerializable {
         return temporary;
     }
 
+    /**
+     * Check if this bound is full
+     *
+     * @return Whether bound is full
+     */
     public boolean isFull() {
         return this.full;
     }
 
+    /**
+     * Set if this bound is full
+     *
+     * @param full Whether the bound is full
+     */
     public void setFull(boolean full) {
         this.full = full;
     }

--- a/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -157,10 +156,11 @@ public class Bound implements ConfigurationSerializable {
      *
      * @return List of blocks within bound
      */
-    public @Nullable List<Block> getBlocks() {
+    public @NotNull List<Block> getBlocks() {
+        List<Block> blocks = new ArrayList<>();
         World w = getWorld();
-        if (w == null) return null;
-        List<Block> array = new ArrayList<>();
+        if (w == null) return blocks;
+
         int minX = (int) boundingBox.getMinX();
         int minY = (int) boundingBox.getMinY();
         int minZ = (int) boundingBox.getMinZ();
@@ -170,12 +170,11 @@ public class Bound implements ConfigurationSerializable {
         for (int x = minX; x < maxX; x++) {
             for (int y = minY; y < maxY; y++) {
                 for (int z = minZ; z < maxZ; z++) {
-                    Block b = w.getBlockAt(x, y, z);
-                    array.add(b);
+                    blocks.add(w.getBlockAt(x, y, z));
                 }
             }
         }
-        return array;
+        return blocks;
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
@@ -141,12 +141,15 @@ public class Bound implements ConfigurationSerializable {
      * @param type Type of entity to get
      * @return List of loaded entities in bound
      */
-    public @Nullable List<Entity> getEntities(Class<? extends Entity> type) {
+    public List<Entity> getEntities(Class<? extends Entity> type) {
+        List<Entity> entities = new ArrayList<>();
         World world = getWorld();
-        if (world == null) return null;
-        Collection<Entity> nearbyEntities = world.getNearbyEntities(this.boundingBox, entity ->
-            type.isAssignableFrom(entity.getClass()));
-        return new ArrayList<>(nearbyEntities);
+        if (world != null) {
+            Collection<Entity> nearbyEntities = world.getNearbyEntities(this.boundingBox, entity ->
+                type.isAssignableFrom(entity.getClass()));
+            entities.addAll(nearbyEntities);
+        }
+        return entities;
     }
 
     /**
@@ -218,70 +221,6 @@ public class Bound implements ConfigurationSerializable {
         return new Location(getWorld(), center.getX(), center.getY(), center.getZ());
     }
 
-    public int getLesserX() {
-        return ((int) boundingBox.getMinX());
-    }
-
-    public void setLesserX(int x) {
-        Vector min = this.boundingBox.getMin();
-        min.setX(x);
-        resize(min, this.boundingBox.getMax());
-    }
-
-    public int getLesserY() {
-        return ((int) boundingBox.getMinY());
-    }
-
-    public void setLesserY(int y) {
-        Vector min = this.boundingBox.getMin();
-        min.setY(y);
-        resize(min, this.boundingBox.getMax());
-    }
-
-    public int getLesserZ() {
-        return ((int) boundingBox.getMinZ());
-    }
-
-    public void setLesserZ(int z) {
-        Vector min = this.boundingBox.getMin();
-        min.setZ(z);
-        resize(min, this.boundingBox.getMax());
-    }
-
-    public int getGreaterX() {
-        return ((int) boundingBox.getMaxX());
-    }
-
-    public void setGreaterX(int x2) {
-        Vector max = this.boundingBox.getMax();
-        max.setX(x2);
-        resize(this.boundingBox.getMin(), max);
-    }
-
-    public int getGreaterY() {
-        return ((int) boundingBox.getMaxY());
-    }
-
-    public void setGreaterY(int y2) {
-        Vector max = this.boundingBox.getMax();
-        max.setY(y2);
-        resize(this.boundingBox.getMin(), max);
-    }
-
-    public int getGreaterZ() {
-        return ((int) boundingBox.getMaxZ());
-    }
-
-    public void setGreaterZ(int z2) {
-        Vector max = this.boundingBox.getMax();
-        max.setZ(z2);
-        resize(this.boundingBox.getMin(), max);
-    }
-
-    public void resize(Vector v1, Vector v2) {
-        this.boundingBox = this.boundingBox.resize(v1.getX(), v1.getY(), v1.getZ(), v2.getX(), v2.getY(), v2.getZ());
-    }
-
     public void resize(Location loc1, Location loc2) {
         Preconditions.checkArgument(loc1.getWorld() == loc2.getWorld(), "Worlds have to match");
         Preconditions.checkArgument(loc1.getWorld().getName().equalsIgnoreCase(this.world), "World cannot be changed!");
@@ -290,14 +229,20 @@ public class Bound implements ConfigurationSerializable {
         this.boundingBox = BoundingBox.of(block1, block2);
     }
 
-    public Bound copy(Bound bound, String id) {
-        Location lesserCorner = bound.getLesserCorner().clone();
-        Location greaterCorner = bound.getGreaterCorner().clone();
-        Bound newBound = new Bound(lesserCorner, greaterCorner, id, bound.isTemporary());
-        newBound.setOwners(bound.getOwners());
-        newBound.setMembers(bound.getMembers());
-        newBound.setBoundingBox(bound.getBoundingBox().clone());
-        newBound.values = bound.values;
+    /**
+     * Create a copy of a bound
+     *
+     * @param newId ID of new bound
+     * @return New cloned bound
+     */
+    public Bound copy(String newId) {
+        Location lesserCorner = this.getLesserCorner().clone();
+        Location greaterCorner = this.getGreaterCorner().clone();
+        Bound newBound = new Bound(lesserCorner, greaterCorner, newId, this.isTemporary());
+        newBound.setOwners(this.getOwners());
+        newBound.setMembers(this.getMembers());
+        newBound.setBoundingBox(this.getBoundingBox().clone());
+        newBound.values = this.values;
         return newBound;
     }
 
@@ -312,36 +257,6 @@ public class Bound implements ConfigurationSerializable {
         min.setY(WorldUtils.getMinHeight(world));
         max.setY(WorldUtils.getMaxHeight(world));
         this.boundingBox = BoundingBox.of(min, max);
-    }
-
-    public void change(Axis axis, Corner corner, int amount) {
-        if (axis == Axis.X) {
-            if (corner == Corner.GREATER) {
-                setGreaterX(getGreaterX() + amount);
-            } else {
-                setLesserX(getLesserX() + amount);
-            }
-        } else if (axis == Axis.Y) {
-            if (corner == Corner.GREATER) {
-                setGreaterY(getGreaterY() + amount);
-            } else {
-                setLesserY(getLesserY() + amount);
-            }
-        } else {
-            if (corner == Corner.GREATER) {
-                setGreaterZ(getGreaterZ() + amount);
-            } else {
-                setLesserZ(getLesserZ() + amount);
-            }
-        }
-    }
-
-    public enum Axis {
-        X, Y, Z
-    }
-
-    public enum Corner {
-        GREATER, LESSER
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/api/bound/BoundRegion.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/BoundRegion.java
@@ -1,0 +1,69 @@
+package com.shanebeestudios.skbee.api.bound;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a region that holds {@link Bound bounds}.
+ * <br>A bound region is 16x16 chunks in size.
+ */
+public class BoundRegion {
+
+    private final List<Bound> bounds = new ArrayList<>();
+    private final long id;
+
+    public BoundRegion(long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get a list of all bounds in this region
+     *
+     * @return List of bounds in region
+     */
+    public List<Bound> getBounds() {
+        return this.bounds;
+    }
+
+    /**
+     * Add a bound to this region
+     *
+     * @param bound Bound to add
+     */
+    public void addBound(Bound bound) {
+        if (this.bounds.contains(bound)) return;
+        this.bounds.add(bound);
+    }
+
+    /**
+     * Remove a bound from this region
+     *
+     * @param bound Bound to remove
+     */
+    public void removeBound(Bound bound) {
+        this.bounds.remove(bound);
+    }
+
+    /**
+     * Get the size of all bounds in this region
+     *
+     * @return Size of bounds in this region
+     */
+    public int size() {
+        return this.bounds.size();
+    }
+
+    /**
+     * Get the ID of this region
+     *
+     * @return ID of region
+     */
+    public long getId() {
+        return this.id;
+    }
+
+    @Override
+    public String toString() {
+        return "BoundRegion{id=" + id + ", size=" + bounds.size() + '}';
+    }
+}

--- a/src/main/java/com/shanebeestudios/skbee/api/bound/BoundWorld.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/BoundWorld.java
@@ -1,0 +1,120 @@
+package com.shanebeestudios.skbee.api.bound;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a holder of {@link BoundRegion BoundRegions} for Worlds
+ */
+public class BoundWorld {
+
+    private static final long SHIFT_VALUE = 8;
+
+    private final World world;
+    private final Map<Long, BoundRegion> regions = new HashMap<>();
+
+    public BoundWorld(World world) {
+        this.world = world;
+    }
+
+    /**
+     * Get a {@link BoundRegion region} at a location
+     *
+     * @param location Location to check for region
+     * @return BoundRegion if available, else null
+     */
+    public @Nullable BoundRegion getRegionAtLocation(Location location) {
+        long id = getIdFromLocation(location);
+        return this.regions.get(id);
+    }
+
+    /**
+     * Get a {@link BoundRegion region} at a location
+     * <br>Will create a region if one does not yet exist
+     *
+     * @param location Location to check for region
+     * @return BoundRegion if available or a new one
+     */
+    public @NotNull BoundRegion getOrCreateRegionAtLocation(Location location) {
+        long id = getIdFromLocation(location);
+        BoundRegion boundRegion = this.regions.get(id);
+        if (boundRegion == null) {
+            boundRegion = new BoundRegion(id);
+            this.regions.put(id, boundRegion);
+        }
+        return boundRegion;
+    }
+
+    private long getIdFromLocation(Location location) {
+        long x = location.getBlockX() >> SHIFT_VALUE;
+        long z = location.getBlockZ() >> SHIFT_VALUE;
+        return x & 4294967295L | (z & 4294967295L) << 32;
+    }
+
+    /**
+     * Add a bound to a region
+     *
+     * @param bound Bound to add to region
+     */
+    public void addBoundToRegion(Bound bound) {
+        for (Location loc : getLocationList(bound)) {
+            BoundRegion region = getOrCreateRegionAtLocation(loc);
+            region.addBound(bound);
+        }
+    }
+
+    /**
+     * Remove a bound from a region
+     * <br>If the region is empty after removal,
+     * the region will be deleted
+     *
+     * @param bound Bound to remove
+     */
+    public void removeBoundFromRegion(Bound bound) {
+        for (Location loc : getLocationList(bound)) {
+            BoundRegion region = getRegionAtLocation(loc);
+            if (region == null) continue;
+            region.removeBound(bound);
+            if (region.size() == 0) {
+                this.regions.remove(region.getId());
+            }
+        }
+    }
+
+    /**
+     * Get the points of a bound to regionalize
+     * <br>This will be the 4 corners in most cases
+     *
+     * @param bound Bound to get corners from
+     * @return List of locations representing the points of a bound to regionalize
+     */
+    private List<Location> getLocationList(Bound bound) {
+        List<Location> locations = new ArrayList<>();
+
+        BoundingBox box = bound.getBoundingBox();
+        Vector min = box.getMin();
+        Vector max = box.getMax();
+        for (int x = min.getBlockX(); x < max.getBlockX(); x += (1 << SHIFT_VALUE)) {
+            for (int z = min.getBlockZ(); z < max.getBlockZ(); z += (1 << SHIFT_VALUE)) {
+                locations.add(new Location(this.world, x, 0, z));
+            }
+        }
+
+        return locations;
+    }
+
+    public List<Bound> getBoundsAtLocation(Location location) {
+        BoundRegion region = getOrCreateRegionAtLocation(location);
+        return region.getBounds();
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/api/listener/BoundBorderListener.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/listener/BoundBorderListener.java
@@ -233,8 +233,8 @@ public class BoundBorderListener implements Listener {
         // Skip same location and different worlds
         if (to.equals(from)) return false;
         if (ignoreWorldChange && !to.getWorld().equals(from.getWorld())) return false;
-        Collection<Bound> bounds = ignoreWorldChange ? boundConfig.getBoundsIn(from.getWorld()) : boundConfig.getBounds();
-        for (Bound bound : bounds) {
+        //Collection<Bound> bounds = ignoreWorldChange ? boundConfig.getBoundsInRegion(from) : boundConfig.getBounds();
+        for (Bound bound : boundConfig.getBoundsInRegion(from)) {
             // Exit called first, as we'd probably leave one before entering another
             if (!bound.isInRegion(to) && bound.isInRegion(from)) {
                 BoundExitEvent exitEvent = new BoundExitEvent(bound, player);
@@ -243,6 +243,9 @@ public class BoundBorderListener implements Listener {
                     return true;
                 }
             }
+
+        }
+        for (Bound bound : boundConfig.getBoundsInRegion(to)) {
             if (bound.isInRegion(to) && !bound.isInRegion(from)) {
                 BoundEnterEvent enterEvent = new BoundEnterEvent(bound, player);
                 Bukkit.getPluginManager().callEvent(enterEvent);

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
@@ -98,7 +98,7 @@ public enum NBTCustomType {
                     case NBTTagLong -> NBTTagLongList;
                     case NBTTagFloat -> NBTTagFloatList;
                     case NBTTagDouble -> NBTTagDoubleList;
-                    case NBTTagString -> NBTTagString;
+                    case NBTTagString -> NBTTagStringList;
                     case NBTTagCompound -> NBTTagCompoundList;
                     default -> null;
                 };

--- a/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/nbt/NBTCustomType.java
@@ -86,24 +86,22 @@ public enum NBTCustomType {
         return null;
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Nullable
     public static NBTCustomType getByTag(NBTCompound compound, String key) {
         if (compound == null) return null;
         NBTType nbtType = compound.getType(key);
         if (BY_TYPE.containsKey(nbtType)) {
             if (nbtType == NBTType.NBTTagList) {
-                if (!compound.getIntegerList(key).isEmpty())
-                    return NBTTagIntList;
-                else if (!compound.getLongList(key).isEmpty())
-                    return NBTTagLongList;
-                else if (!compound.getFloatList(key).isEmpty())
-                    return NBTTagFloatList;
-                else if (!compound.getDoubleList(key).isEmpty())
-                    return NBTTagDoubleList;
-                else if (!compound.getCompoundList(key).isEmpty())
-                    return NBTTagCompoundList;
-                else if (!compound.getStringList(key).isEmpty())
-                    return NBTTagStringList;
+                return switch (compound.getListType(key)) {
+                    case NBTTagInt -> NBTTagIntList;
+                    case NBTTagLong -> NBTTagLongList;
+                    case NBTTagFloat -> NBTTagFloatList;
+                    case NBTTagDouble -> NBTTagDoubleList;
+                    case NBTTagString -> NBTTagString;
+                    case NBTTagCompound -> NBTTagCompoundList;
+                    default -> null;
+                };
             }
             return BY_TYPE.get(nbtType);
         }

--- a/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/particle/ParticleUtil.java
@@ -39,6 +39,8 @@ public class ParticleUtil {
 
     private static final Map<String, Particle> PARTICLES = new HashMap<>();
     private static final Map<Particle, String> PARTICLE_NAMES = new HashMap<>();
+    private static final boolean HAS_FORCE = Skript.methodExists(Player.class, "spawnParticle",
+        Particle.class, Location.class, int.class, double.class, double.class, double.class, double.class, Object.class, boolean.class);
 
     static {
         // Added in Spigot 1.20.2 (oct 20/2023)
@@ -165,7 +167,11 @@ public class ParticleUtil {
         } else {
             for (Player player : players) {
                 assert player != null;
-                player.spawnParticle(particle, location, count, x, y, z, extra, particleData, force);
+                if (HAS_FORCE) {
+                    player.spawnParticle(particle, location, count, x, y, z, extra, particleData, force);
+                } else {
+                    player.spawnParticle(particle, location, count, x, y, z, extra, particleData);
+                }
             }
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/api/util/BlockDataUtils.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/BlockDataUtils.java
@@ -1,8 +1,11 @@
 package com.shanebeestudios.skbee.api.util;
 
+import ch.njol.skript.Skript;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemType;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -10,6 +13,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class BlockDataUtils {
+
+    private static final boolean HAS_ITEMTYPE = Skript.classExists("org.bukkit.inventory.ItemType");
 
     /**
      * Get an array of BlockData keys/values
@@ -49,10 +54,16 @@ public class BlockDataUtils {
      * <p>Some Items (such as POTATO) have a different block form (POTATOES)</p>
      *
      * @param material Material to convert to Block form
-     * @return Block form of Material
+     * @return Block form of Material, null if not available
      */
-    public static Material getBlockForm(Material material) {
+    @SuppressWarnings("deprecation")
+    public static @Nullable Material getBlockForm(Material material) {
         if (material.isBlock()) return material;
+        if (HAS_ITEMTYPE) {
+            ItemType itemType = Registry.ITEM.get(material.getKey());
+            if (itemType != null && itemType.hasBlockType()) return itemType.getBlockType().asMaterial();
+            return null;
+        }
         return switch (material) {
             case WHEAT_SEEDS -> Material.WHEAT;
             case POTATO -> Material.POTATOES;

--- a/src/main/java/com/shanebeestudios/skbee/api/util/ItemUtils.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/ItemUtils.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class ItemUtils {
 
@@ -111,6 +112,18 @@ public class ItemUtils {
             if (itemStack != null && !itemStack.isEmpty()) newItems.add(itemStack);
         }
         return newItems;
+    }
+
+    public static void modifyItemMeta(ItemType itemType, Consumer<ItemMeta> meta) {
+        ItemMeta itemMeta = itemType.getItemMeta();
+        meta.accept(itemMeta);
+        itemType.setItemMeta(itemMeta);
+    }
+
+    public static void modifyItemMeta(ItemStack itemStack, Consumer<ItemMeta> meta) {
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        meta.accept(itemMeta);
+        itemStack.setItemMeta(itemMeta);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/api/wrapper/ComponentWrapper.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/wrapper/ComponentWrapper.java
@@ -542,6 +542,7 @@ public class ComponentWrapper {
      *
      * @param inventory Inventory to change name
      */
+    @SuppressWarnings("deprecation")
     public void setInventoryName(Inventory inventory) {
         List<HumanEntity> viewers = inventory.getViewers();
         if (viewers.isEmpty()) return;

--- a/src/main/java/com/shanebeestudios/skbee/config/BoundConfig.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/BoundConfig.java
@@ -43,11 +43,6 @@ public class BoundConfig {
         }
         boundConfig = YamlConfiguration.loadConfiguration(boundFile);
         loadBounds();
-
-        // Update heights for 1.18 worlds
-        if (Skript.isRunningMinecraft(1, 18) && !boundConfig.getBoolean(UPDATED_18_HEIGHTS)) {
-            update18Heights();
-        }
     }
 
     private void loadBounds() {

--- a/src/main/java/com/shanebeestudios/skbee/config/BoundConfig.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/BoundConfig.java
@@ -1,15 +1,13 @@
 package com.shanebeestudios.skbee.config;
 
-import ch.njol.skript.Skript;
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.bound.Bound;
-import com.shanebeestudios.skbee.api.util.Util;
-import com.shanebeestudios.skbee.api.util.WorldUtils;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,8 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BoundConfig {
-
-    private static final String UPDATED_18_HEIGHTS = "updated_18_heights";
 
     private final SkBee plugin;
     private File boundFile;
@@ -56,26 +52,6 @@ public class BoundConfig {
         }
     }
 
-    private void update18Heights() {
-        Util.log("Updating bounds:");
-        for (Bound bound : boundsMap.values()) {
-            int lesserY = bound.getLesserY();
-            int greaterY = bound.getGreaterY();
-            World world = bound.getWorld();
-            if (lesserY == 0 && world != null) {
-                int minHeight = WorldUtils.getMinHeight(world);
-                int maxHeight = WorldUtils.getMaxHeight(world);
-                if (greaterY == 255 || greaterY == maxHeight) {
-                    bound.setGreaterY(maxHeight);
-                    bound.setLesserY(minHeight);
-                    Util.log("Updating bound with id '%s'", bound.getId());
-                }
-            }
-        }
-        boundConfig.set(UPDATED_18_HEIGHTS, true);
-        saveAllBounds();
-    }
-
     public void saveBound(Bound bound) {
         boundsMap.put(bound.getId(), bound);
         if (!bound.isTemporary()) {
@@ -96,7 +72,7 @@ public class BoundConfig {
         return boundsMap.containsKey(id);
     }
 
-    public Bound getBoundFromID(String id) {
+    public @Nullable Bound getBoundFromID(String id) {
         if (boundsMap.containsKey(id))
             return boundsMap.get(id);
         return null;
@@ -111,6 +87,7 @@ public class BoundConfig {
         saveConfig();
     }
 
+    @SuppressWarnings("CallToPrintStackTrace")
     private void saveConfig() {
         try {
             boundConfig.save(boundFile);

--- a/src/main/java/com/shanebeestudios/skbee/config/BoundConfig.java
+++ b/src/main/java/com/shanebeestudios/skbee/config/BoundConfig.java
@@ -2,87 +2,114 @@ package com.shanebeestudios.skbee.config;
 
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.bound.Bound;
+import com.shanebeestudios.skbee.api.bound.BoundWorld;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class BoundConfig {
 
-    private final SkBee plugin;
-    private File boundFile;
-    private FileConfiguration boundConfig;
+    private final File boundFile;
+    private final FileConfiguration boundConfig;
     private final Map<String, Bound> boundsMap = new HashMap<>();
+    private final Map<World, BoundWorld> boundWorldMap = new HashMap<>();
 
     /**
      * @hidden
      */
     public BoundConfig(SkBee plugin) {
-        this.plugin = plugin;
-        loadBoundConfig();
-    }
-
-    private void loadBoundConfig() {
-        if (boundFile == null) {
-            boundFile = new File(plugin.getDataFolder(), "bounds.yml");
-        }
-        if (!boundFile.exists()) {
+        // Load config
+        this.boundFile = new File(plugin.getDataFolder(), "bounds.yml");
+        if (!this.boundFile.exists()) {
             plugin.saveResource("bounds.yml", false);
         }
-        boundConfig = YamlConfiguration.loadConfiguration(boundFile);
-        loadBounds();
-    }
+        this.boundConfig = YamlConfiguration.loadConfiguration(this.boundFile);
 
-    private void loadBounds() {
-        ConfigurationSection section = boundConfig.getConfigurationSection("bounds");
+        // Load bounds
+        ConfigurationSection section = this.boundConfig.getConfigurationSection("bounds");
         if (section == null) return;
         for (String key : section.getKeys(true)) {
-            Object bound = section.get(key);
-            if (bound instanceof Bound) {
-                boundsMap.put(key, ((Bound) bound));
+            Object object = section.get(key);
+            if (object instanceof Bound bound) {
+                addBoundToRegionAndMap(bound);
             }
         }
     }
 
-    public void saveBound(Bound bound) {
-        boundsMap.put(bound.getId(), bound);
+    /**
+     * Save a bound to regions, map and config
+     *
+     * @param bound         Bound to save
+     * @param updateRegions Whether to update in regions
+     *                      (this can be false when just updating
+     *                      specifics of a bound rather than its shape)
+     */
+    public void saveBound(Bound bound, boolean updateRegions) {
+        if (updateRegions) {
+            removeBoundFromRegion(bound);
+            addBoundToRegionAndMap(bound);
+        }
         if (!bound.isTemporary()) {
-            boundConfig.set("bounds." + bound.getId(), bound);
+            this.boundConfig.set("bounds." + bound.getId(), bound);
             saveConfig();
         }
     }
 
+    /**
+     * Remove a bound
+     * <br>Will remove from regions, map and config
+     *
+     * @param bound Bound to remove
+     */
     public void removeBound(Bound bound) {
-        boundsMap.remove(bound.getId());
+        removeBoundFromRegionAndMap(bound);
         if (!bound.isTemporary()) {
-            boundConfig.set("bounds." + bound.getId(), null);
+            this.boundConfig.set("bounds." + bound.getId(), null);
             saveConfig();
         }
     }
 
+    /**
+     * Check if a bound ID already exists
+     *
+     * @param id ID to check
+     * @return True if exists, else false
+     */
     public boolean boundExists(String id) {
-        return boundsMap.containsKey(id);
+        return this.boundsMap.containsKey(id);
     }
 
+    /**
+     * Get a bound from ID
+     *
+     * @param id ID of bound to grab
+     * @return Bound from ID or null if not available
+     */
     public @Nullable Bound getBoundFromID(String id) {
-        if (boundsMap.containsKey(id))
-            return boundsMap.get(id);
+        if (this.boundsMap.containsKey(id))
+            return this.boundsMap.get(id);
         return null;
     }
 
+    /**
+     * Save all bounds to file
+     */
     public void saveAllBounds() {
-        for (Bound bound : boundsMap.values()) {
+        for (Bound bound : this.boundsMap.values()) {
             if (bound.isTemporary()) continue;
-            boundConfig.set("bounds." + bound.getId(), bound);
-            boundsMap.put(bound.getId(), bound);
+            this.boundConfig.set("bounds." + bound.getId(), bound);
+            //boundsMap.put(bound.getId(), bound); why is this here?!?!?
         }
         saveConfig();
     }
@@ -90,25 +117,109 @@ public class BoundConfig {
     @SuppressWarnings("CallToPrintStackTrace")
     private void saveConfig() {
         try {
-            boundConfig.save(boundFile);
+            this.boundConfig.save(this.boundFile);
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
+    /**
+     * Get all bounds
+     *
+     * @return List of all bounds
+     */
     public Collection<Bound> getBounds() {
-        return boundsMap.values();
+        return this.boundsMap.values();
     }
 
+    /**
+     * Get all the bounds in a world
+     *
+     * @param world World to grab bounds from
+     * @return List of bounds in a world
+     */
     public Collection<Bound> getBoundsIn(World world) {
-        return boundsMap.values().stream().filter(bound -> {
-            World boundWorld = bound.getWorld();
-            return boundWorld != null && boundWorld.equals(world);
-        }).toList();
+        return this.boundsMap.values().stream().filter(bound -> world.equals(bound.getWorld())).toList();
     }
 
+    /**
+     * Get all the bounds at a specific location
+     *
+     * @param location Location to check for bounds
+     * @return Bounds at location
+     */
     public Collection<Bound> getBoundsAt(Location location) {
-        return boundsMap.values().stream().filter(bound -> bound.isInRegion(location)).toList();
+        return getBoundsInRegion(location).stream().filter(bound -> bound.isInRegion(location)).toList();
+    }
+
+    /**
+     * Get a BoundWorld for a world, or create one if it doesn't exist
+     *
+     * @param world World to reference BoundWorld to
+     * @return BoundWorld for a world
+     */
+    public @NotNull BoundWorld getOrCreateBoundWorld(World world) {
+        BoundWorld boundWorld = this.boundWorldMap.get(world);
+        if (boundWorld == null) {
+            boundWorld = new BoundWorld(world);
+            this.boundWorldMap.put(world, boundWorld);
+        }
+        return boundWorld;
+    }
+
+    /**
+     * Get a BoundWorld for a world
+     *
+     * @param world World to reference BoundWorld to
+     * @return BoundWorld if it exists, else null
+     */
+    public @Nullable BoundWorld getBoundWorld(World world) {
+        return this.boundWorldMap.get(world);
+    }
+
+    /**
+     * Get all the bounds in a region at a specific location
+     *
+     * @param location Location to check for bounds
+     * @return List of bounds in region
+     */
+    public List<Bound> getBoundsInRegion(Location location) {
+        BoundWorld boundWorld = getOrCreateBoundWorld(location.getWorld());
+        return boundWorld.getBoundsAtLocation(location);
+    }
+
+    /**
+     * Add a bound to region and bound map
+     *
+     * @param bound Bound to add
+     */
+    public void addBoundToRegionAndMap(Bound bound) {
+        BoundWorld boundWorld = getOrCreateBoundWorld(bound.getWorld());
+        boundWorld.addBoundToRegion(bound);
+        this.boundsMap.put(bound.getId(), bound);
+    }
+
+    /**
+     * Remove a bound from its region
+     * <br>This will NOT remove it from the bound map
+     *
+     * @param bound Bound to remove
+     */
+    public void removeBoundFromRegion(Bound bound) {
+        BoundWorld boundWorld = getBoundWorld(bound.getWorld());
+        if (boundWorld != null) {
+            boundWorld.removeBoundFromRegion(bound);
+        }
+    }
+
+    /**
+     * Remove a bound from its region and the bound map
+     *
+     * @param bound Bound to remove
+     */
+    public void removeBoundFromRegionAndMap(Bound bound) {
+        removeBoundFromRegion(bound);
+        this.boundsMap.remove(bound.getId());
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/effects/EffBoundResize.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/effects/EffBoundResize.java
@@ -9,44 +9,43 @@ import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import com.shanebeestudios.skbee.api.util.WorldUtils;
 import com.shanebeestudios.skbee.api.bound.Bound;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 @Name("Bound - Resize")
-@Description({"Resize a current bound. Full will stretch it to the lowest/highest points of the world.",
-        "The second syntax will resize the bound to be full without changing the locations.",
-        "\nNOTE: World of a bound cannot be changed."})
+@Description({"Resize a current bound.",
+    "Full will mark the bound to use the lowest/highest points of the world.",
+    "The second pattern will mark as a full bound without changing the locations.",
+    "\nNOTE: World of a bound cannot be changed."})
 @Examples({"resize bound bound with id \"test\" between {_l1} and {_l1}",
-        "resize full bound bound with id \"test\""})
+    "resize full bound bound with id \"test\""})
 @Since("2.5.3")
 public class EffBoundResize extends Effect {
 
     static {
         Skript.registerEffect(EffBoundResize.class,
-                "resize [:full] bound %bound% (within|between) %location% and %location%",
-                "resize full bound %bound%");
+            "resize [:full] bound %bound% (within|between) %location% and %location%",
+            "resize full bound %bound%");
     }
 
     private Expression<Bound> bound;
     private Expression<Location> loc1, loc2;
     private boolean full;
-    private boolean fullOnly;
+    private int pattern;
 
     @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        this.fullOnly = matchedPattern == 1;
+        this.full = matchedPattern == 1 || parseResult.hasTag("full");
         this.bound = (Expression<Bound>) exprs[0];
         if (matchedPattern == 0) {
             this.loc1 = (Expression<Location>) exprs[1];
             this.loc2 = (Expression<Location>) exprs[2];
-            this.full = parseResult.hasTag("full");
         }
+        this.pattern = matchedPattern;
         return true;
     }
 
@@ -55,8 +54,8 @@ public class EffBoundResize extends Effect {
     protected void execute(Event event) {
         Bound bound = this.bound.getSingle(event);
         if (bound == null) return;
-        if (this.fullOnly) {
-            bound.makeFull();
+        if (this.full) {
+            bound.setFull(true);
             return;
         }
         Location loc1 = this.loc1.getSingle(event);
@@ -64,28 +63,19 @@ public class EffBoundResize extends Effect {
         if (loc1 == null || loc2 == null) return;
 
         World world = bound.getWorld();
-        if (loc1.getWorld() != world || loc2.getWorld() != world) return;
+        if (world == null || loc1.getWorld() != world || loc2.getWorld() != world) return;
 
-        if (full) {
-            loc1 = loc1.clone();
-            loc2 = loc2.clone();
-
-            int max = world.getMaxHeight() - 1;
-            int min = WorldUtils.getMinHeight(world);
-            loc1.setY(min);
-            loc2.setY(max);
-        }
         bound.resize(loc1, loc2);
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
-        if (this.fullOnly) {
-            return "resize full bound " + this.bound.toString(e,d);
+    public @NotNull String toString(Event e, boolean d) {
+        if (this.pattern == 1) {
+            return "resize full bound " + this.bound.toString(e, d);
         }
         String full = this.full ? "full " : "";
         return "resize " + full + "bound " + this.bound.toString(e, d) + " within " +
-                this.loc1.toString(e, d) + " and " + this.loc2.toString(e, d);
+            this.loc1.toString(e, d) + " and " + this.loc2.toString(e, d);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundBlocks.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundBlocks.java
@@ -10,28 +10,27 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.bound.Bound;
 import org.bukkit.block.Block;
 import org.bukkit.event.Event;
-import com.shanebeestudios.skbee.api.bound.Bound;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 @Name("Bound - Blocks")
-@Description("All the blocks within a bound")
+@Description("Get all of the blocks within a bound.")
 @Examples({"set {_blocks::*} to all blocks within bound {bound}",
-        "set {_blocks::*} to all blocks within bound bound with id \"le-bound\"",
-        "set all blocks within bound {bound} to stone",
-        "loop all blocks within bound {bound}:",
-        "\tif loop-block is stone:",
-        "\t\tset loop-block to grass"})
+    "set {_blocks::*} to bound blocks within bound with id \"le-bound\"",
+    "set all bound blocks within {bound} to stone",
+    "loop all bound blocks within {bound}:",
+    "\tif loop-block is stone:",
+    "\t\tset loop-block to grass"})
 @Since("1.0.0")
 public class ExprBoundBlocks extends SimpleExpression<Block> {
 
     static {
         Skript.registerExpression(ExprBoundBlocks.class, Block.class, ExpressionType.SIMPLE,
-                "[(all [[of] the]|the)] blocks within bound %bound%");
+            "[(all [[of] the]|the)] bound blocks within %bound%",
+            "[(all [[of] the]|the)] blocks within bound %bound%");
     }
 
     private Expression<Bound> bound;
@@ -39,19 +38,18 @@ public class ExprBoundBlocks extends SimpleExpression<Block> {
     @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
-        bound = (Expression<Bound>) exprs[0];
+        this.bound = (Expression<Bound>) exprs[0];
         return true;
     }
 
     @SuppressWarnings("NullableProblems")
     @Override
-    protected Block[] get(Event event) {
-        Bound single = bound.getSingle(event);
-        if (single == null) {
+    protected Block @Nullable [] get(Event event) {
+        Bound bound = this.bound.getSingle(event);
+        if (bound == null) {
             return null;
         }
-        List<Block> list = new ArrayList<>(single.getBlocks());
-        return list.toArray(new Block[0]);
+        return bound.getBlocks().toArray(new Block[0]);
     }
 
     @Override
@@ -66,7 +64,7 @@ public class ExprBoundBlocks extends SimpleExpression<Block> {
 
     @Override
     public @NotNull String toString(Event e, boolean d) {
-        return "the blocks within bound " + bound.toString(e, d);
+        return "bound blocks within " + this.bound.toString(e, d);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundCoords.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundCoords.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 @Since("1.0.0")
 public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
 
+    private static final BoundConfig BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
     static {
         Skript.registerExpression(ExprBoundCoords.class, Object.class, ExpressionType.PROPERTY,
             "lesser (x|1:y|2:z) coord[inate] of [bound] %bound%",
@@ -90,7 +91,6 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
     @SuppressWarnings("NullableProblems")
     @Override
     public void change(Event e, Object[] delta, ChangeMode mode) {
-        BoundConfig boundConfig = SkBee.getPlugin().getBoundConfig();
         for (Bound bound : getExpr().getArray(e)) {
             int coord = ((Number) delta[0]).intValue();
             if (mode == ChangeMode.REMOVE) coord = -coord;
@@ -113,7 +113,7 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
             }
 
             bound.resize(less, great);
-            boundConfig.saveBound(bound);
+            BOUND_CONFIG.saveBound(bound, true);
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundCoords.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundCoords.java
@@ -9,22 +9,24 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.PropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Getter;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.bound.Bound;
-import com.shanebeestudios.skbee.api.bound.Bound.Axis;
-import com.shanebeestudios.skbee.api.bound.Bound.Corner;
 import com.shanebeestudios.skbee.config.BoundConfig;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+@Deprecated
 @Name("Bound - Coords")
-@Description({"The coords and world of a bounding box. You can get the world/coords for a specific bound, you can also " +
-    "set the coords of a bounding box. You can NOT set the world of a bounding box. ",
+@Description({"DEPRECATED - Use bound locations/world expressions instead",
+    "The coords and world of a bounding box. You can get the world/coords for a specific bound, you can also " +
+        "set the coords of a bounding box. You can NOT set the world of a bounding box. ",
     "Greater will always equal the higher south-east corner. ",
     "Lesser will always equal the lower north-west corner."})
 @Examples({"set lesser y coord of {bound} to 10", "set {_x} to greater x coord of bound with id \"my.bound\""})
@@ -44,11 +46,16 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
 
     @SuppressWarnings({"unchecked", "null", "NullableProblems"})
     @Override
-    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
         setExpr((Expression<Bound>) exprs[0]);
         this.WORLD = matchedPattern == 2;
         this.LESSER = matchedPattern == 0;
         this.parse = parseResult.mark;
+        if (matchedPattern == 2) {
+            Skript.warning("Depreacted - use the 'bound world of %bounds%' expression instead.");
+        } else {
+            Skript.warning("Deprecated - use the 'Bound - Locations' expression instead.");
+        }
         return true;
     }
 
@@ -62,27 +69,18 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
                     return bound.getWorld();
                 } else {
                     return switch (parse) {
-                        case 0 -> LESSER ? bound.getLesserX() : bound.getGreaterX();
-                        case 1 -> LESSER ? bound.getLesserY() : bound.getGreaterY();
-                        default -> LESSER ? bound.getLesserZ() : bound.getGreaterZ();
+                        case 0 -> LESSER ? bound.getLesserCorner().getX() : bound.getGreaterCorner().getX();
+                        case 1 -> LESSER ? bound.getLesserCorner().getY() : bound.getGreaterCorner().getY();
+                        default -> LESSER ? bound.getLesserCorner().getZ() : bound.getGreaterCorner().getZ();
                     };
                 }
             }
         });
     }
 
-    @Override
-    public @NotNull Class<?> getReturnType() {
-        if (WORLD) {
-            return World.class;
-        } else {
-            return Integer.class;
-        }
-    }
-
     @SuppressWarnings("NullableProblems")
     @Override
-    public Class<?>[] acceptChange(ChangeMode mode) {
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
         if (!WORLD && (mode == ChangeMode.SET || mode == ChangeMode.ADD || mode == ChangeMode.REMOVE)) {
             return CollectionUtils.array(Number.class);
         }
@@ -95,27 +93,36 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
         BoundConfig boundConfig = SkBee.getPlugin().getBoundConfig();
         for (Bound bound : getExpr().getArray(e)) {
             int coord = ((Number) delta[0]).intValue();
-            Corner corner = LESSER ? Corner.LESSER : Corner.GREATER;
-            Axis axis = parse == 0 ? Axis.X : parse == 1 ? Axis.Y : Axis.Z;
-            if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) {
-                bound.change(axis, corner, mode == ChangeMode.REMOVE ? -coord : coord);
-            } else {
-                switch (parse) {
-                    case 0:
-                        if (LESSER) bound.setLesserX(coord);
-                        else bound.setGreaterX(coord);
-                        break;
-                    case 1:
-                        if (LESSER) bound.setLesserY(coord);
-                        else bound.setGreaterY(coord);
-                        break;
-                    case 2:
-                        if (LESSER) bound.setLesserZ(coord);
-                        else bound.setGreaterZ(coord);
-                        break;
+            if (mode == ChangeMode.REMOVE) coord = -coord;
+
+            Location less = bound.getLesserCorner();
+            Location great = bound.getGreaterCorner().subtract(1, 1, 1);
+            switch (this.parse) {
+                case 0 -> {
+                    if (LESSER) less.setX(mode == ChangeMode.SET ? coord : less.getX() + coord);
+                    else great.setX(mode == ChangeMode.SET ? coord : great.getX() + coord);
+                }
+                case 1 -> {
+                    if (LESSER) less.setY(mode == ChangeMode.SET ? coord : less.getY() + coord);
+                    else great.setY(mode == ChangeMode.SET ? coord : great.getY() + coord);
+                }
+                case 2 -> {
+                    if (LESSER) less.setZ(mode == ChangeMode.SET ? coord : less.getZ() + coord);
+                    else great.setZ(mode == ChangeMode.SET ? coord : great.getZ() + coord);
                 }
             }
+
+            bound.resize(less, great);
             boundConfig.saveBound(bound);
+        }
+    }
+
+    @Override
+    public @NotNull Class<?> getReturnType() {
+        if (WORLD) {
+            return World.class;
+        } else {
+            return Integer.class;
         }
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundEntities.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundEntities.java
@@ -8,7 +8,6 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
@@ -22,17 +21,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Name("Bound - Entities")
-@Description("Get all the entities within a bound. NOTE: If the chunk in a bound is unloaded, entities will also be unloaded.")
+@Description({"Get all the entities within a bound.",
+    "NOTE: If the chunk in a bound is unloaded, entities will also be unloaded."})
 @Examples({"set {_b} to bound with id \"my-bound\"",
-        "loop entities in bound {_b}:",
-        "\tif loop-entity is a cow or pig:",
-        "\t\tkill loop-entity"})
+    "loop entities in bound {_b}:",
+    "\tif loop-entity is a cow or pig:",
+    "\t\tkill loop-entity"})
 @Since("1.15.0")
 public class ExprBoundEntities extends SimpleExpression<Entity> {
 
     static {
         Skript.registerExpression(ExprBoundEntities.class, Entity.class, ExpressionType.SIMPLE,
-                "[(all [[of] the]|the)] %*entitydatas% (of|in|within) bound[s] %bounds%");
+            "[(all [[of] the]|the)] %*entitydatas% (of|in|within) bound[s] %bounds%");
     }
 
     private Expression<EntityData<?>> entityDatas;
@@ -41,8 +41,8 @@ public class ExprBoundEntities extends SimpleExpression<Entity> {
     @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        entityDatas = (Expression<EntityData<?>>) exprs[0];
-        bounds = (Expression<Bound>) exprs[1];
+        this.entityDatas = (Expression<EntityData<?>>) exprs[0];
+        this.bounds = (Expression<Bound>) exprs[1];
         return true;
     }
 
@@ -51,8 +51,8 @@ public class ExprBoundEntities extends SimpleExpression<Entity> {
     @Override
     protected Entity[] get(Event event) {
         List<Entity> entities = new ArrayList<>();
-        for (Bound bound : bounds.getArray(event)) {
-            for (EntityData<?> entityData : entityDatas.getArray(event)) {
+        for (Bound bound : this.bounds.getArray(event)) {
+            for (EntityData<?> entityData : this.entityDatas.getArray(event)) {
                 Class<? extends Entity> type = entityData.getType();
                 entities.addAll(bound.getEntities(type));
             }
@@ -71,7 +71,7 @@ public class ExprBoundEntities extends SimpleExpression<Entity> {
     }
 
     @Override
-    public @NotNull String toString(@Nullable Event e, boolean d) {
+    public @NotNull String toString(Event e, boolean d) {
         return this.entityDatas.toString(e, d) + " of bound[s] " + this.bounds.toString(e, d);
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundEntities.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundEntities.java
@@ -21,10 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Name("Bound - Entities")
-@Description({"Get all the entities within a bound.",
+@Description({"Get all of the entities within a bound.",
     "NOTE: If the chunk in a bound is unloaded, entities will also be unloaded."})
 @Examples({"set {_b} to bound with id \"my-bound\"",
-    "loop entities in bound {_b}:",
+    "loop bound entities in {_b}:",
     "\tif loop-entity is a cow or pig:",
     "\t\tkill loop-entity"})
 @Since("1.15.0")
@@ -32,6 +32,7 @@ public class ExprBoundEntities extends SimpleExpression<Entity> {
 
     static {
         Skript.registerExpression(ExprBoundEntities.class, Entity.class, ExpressionType.SIMPLE,
+            "[(all [[of] the]|the)] bound %*entitydatas% (of|in|within) %bounds%",
             "[(all [[of] the]|the)] %*entitydatas% (of|in|within) bound[s] %bounds%");
     }
 
@@ -72,7 +73,7 @@ public class ExprBoundEntities extends SimpleExpression<Entity> {
 
     @Override
     public @NotNull String toString(Event e, boolean d) {
-        return this.entityDatas.toString(e, d) + " of bound[s] " + this.bounds.toString(e, d);
+        return "bound " + this.entityDatas.toString(e, d) + " of " + this.bounds.toString(e, d);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundFullState.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundFullState.java
@@ -1,0 +1,59 @@
+package com.shanebeestudios.skbee.elements.bound.expressions;
+
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.bound.Bound;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Bound - Full State")
+@Description("Get/set whether this bound is a full bound (reaches from lowest to highest points of a world).")
+@Examples("set bound full state of bound with id \"home\" to true")
+@Since("INSERT VERSION")
+public class ExprBoundFullState extends SimplePropertyExpression<Bound, Boolean> {
+
+    static {
+        register(ExprBoundFullState.class, Boolean.class, "bound full state", "bounds");
+    }
+
+    @Override
+    @Nullable
+    public Boolean convert(Bound bound) {
+        return bound.isFull();
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    @Nullable
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET) return CollectionUtils.array(Boolean.class);
+        return null;
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantValue"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        if (mode == ChangeMode.SET && delta != null && delta[0] instanceof Boolean full) {
+            for (Bound bound : getExpr().getArray(event)) {
+                bound.setFull(full);
+            }
+        }
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "full state";
+    }
+
+    @Override
+    public @NotNull Class<? extends Boolean> getReturnType() {
+        return Boolean.class;
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundID.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundID.java
@@ -9,23 +9,25 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.bound.Bound;
 import com.shanebeestudios.skbee.api.util.Util;
 import com.shanebeestudios.skbee.config.BoundConfig;
-import com.shanebeestudios.skbee.api.bound.Bound;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Bound - ID")
 @Description({"Get/set the id of a bound. When setting the ID of a bound, if another bound has that ID, this will fail with an error in console.",
-        "You cannot set the IDs of multiple bounds at once."})
+    "You cannot set the IDs of multiple bounds at once."})
 @Examples({"set {_id} to id of first element of bounds at player",
-        "loop all bounds at player:",
-        "\tset id of loop-bound to \"%player%-%id of loop-bound%\"",
-        "set {_id} to id of event-bound",
-        "send \"You entered bound '%id of loop-bound%'\""})
+    "loop all bounds at player:",
+    "\tset id of loop-bound to \"%player%-%id of loop-bound%\"",
+    "set {_id} to id of event-bound",
+    "send \"You entered bound '%id of loop-bound%'\""})
 @Since("1.15.0")
 public class ExprBoundID extends SimplePropertyExpression<Bound, String> {
+
+    private static final BoundConfig BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
 
     static {
         register(ExprBoundID.class, String.class, "[bound] id", "bounds");
@@ -60,15 +62,14 @@ public class ExprBoundID extends SimplePropertyExpression<Bound, String> {
         Bound bound = getExpr().getSingle(event);
         if (bound == null) return;
 
-        BoundConfig boundConfig = SkBee.getPlugin().getBoundConfig();
-        if (boundConfig.boundExists(id)) {
+        if (BOUND_CONFIG.boundExists(id)) {
             // We don't want to rename a bound if the name already exists
             Util.skriptError("Bound with ID '%s' already exists, you can not rename bound with id '%s' to that.", id, bound.getId());
             return;
         }
-        boundConfig.removeBound(bound);
+        BOUND_CONFIG.removeBound(bound);
         bound.setId(id);
-        boundConfig.saveBound(bound);
+        BOUND_CONFIG.saveBound(bound, false);
 
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundLocations.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundLocations.java
@@ -1,5 +1,7 @@
 package com.shanebeestudios.skbee.elements.bound.expressions;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -8,17 +10,26 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.bound.Bound;
 import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("Bound - Locations")
-@Description({"Get the locations of a bound.",
+@Description({"Get/modify the locations of a bound.",
     "Greater will always equal the higher south-east corner. ",
-    "Lesser will always equal the lower north-west corner."})
+    "Lesser will always equal the lower north-west corner.",
+    "You can set the two corners of the bound to new values.",
+    "You can also add/subtract vectors to/from the corners."})
 @Examples({"set {_center} to bound center of bound with id \"spawn-bound\"",
-    "set block at bound greater corner of {_bound} to pink wool"})
+    "set block at bound greater corner of {_bound} to pink wool",
+    "set bound lesser corner of {_bound} to location of player",
+    "set bound greater corner of bound with id \"ma_bound\" to {_loc}",
+    "add vector(5,5,5) to bound greater corner of {_bound}",
+    "subtract vector(0,10,0) from bound greater corner of {_bound}"})
 @Since("3.5.9")
 public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location> {
 
@@ -43,6 +54,53 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
             case 2 -> bound.getLesserCorner();
             default -> bound.getCenter();
         };
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Class<?> @Nullable [] acceptChange(@NotNull ChangeMode mode) {
+        if (type == 0) {
+            Skript.error("You cannot modify the center of a bound. You can modify the lesser/greater corners.");
+            return null;
+        }
+        return switch (mode) {
+            case SET -> CollectionUtils.array(Location.class);
+            case ADD, REMOVE -> CollectionUtils.array(Vector.class);
+            default -> null;
+        };
+    }
+
+    @SuppressWarnings({"NullableProblems", "ConstantValue"})
+    @Override
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        if (delta == null) return;
+
+        if (mode == ChangeMode.SET) {
+            if (delta[0] instanceof Location location) {
+                for (Bound bound : getExpr().getArray(event)) {
+                    Location less = this.type == 2 ? location : bound.getLesserCorner();
+                    Location great = this.type == 1 ? location : bound.getGreaterCorner();
+                    bound.resize(less, great);
+                }
+            }
+        } else {
+            if (delta[0] instanceof Vector vector) {
+                for (Bound bound : getExpr().getArray(event)) {
+                    Location less = bound.getLesserCorner();
+                    Location great = bound.getGreaterCorner();
+                    if (mode == ChangeMode.ADD) {
+                        if (this.type == 1) great.add(vector);
+                        else less.add(vector);
+                    } else {
+                        if (this.type == 1) great.subtract(vector);
+                        else less.subtract(vector);
+                    }
+                    // since bounds add 1 to each axis, let's subtract first
+                    great.subtract(new Vector(1, 1, 1));
+                    bound.resize(less, great);
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundLocations.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundLocations.java
@@ -35,6 +35,8 @@ import org.jetbrains.annotations.Nullable;
 @Since("3.5.9")
 public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location> {
 
+    private static final BoundConfig BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
+
     static {
         register(ExprBoundLocations.class, Location.class,
             "bound (0:center|(1:greater|2:lesser) corner)", "bounds");
@@ -75,7 +77,6 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
     @SuppressWarnings({"NullableProblems", "ConstantValue"})
     @Override
     public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-        BoundConfig boundConfig = SkBee.getPlugin().getBoundConfig();
         if (delta == null) return;
 
         if (mode == ChangeMode.SET) {
@@ -84,14 +85,14 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
                     Location less = this.type == 2 ? location : bound.getLesserCorner();
                     Location great = this.type == 1 ? location : bound.getGreaterCorner();
                     bound.resize(less, great);
-                    boundConfig.saveBound(bound);
+                    BOUND_CONFIG.saveBound(bound, true);
                 }
             }
         } else {
             if (delta[0] instanceof Vector vector) {
                 for (Bound bound : getExpr().getArray(event)) {
                     Location less = bound.getLesserCorner();
-                    Location great = bound.getGreaterCorner().subtract(1,1,1);
+                    Location great = bound.getGreaterCorner().subtract(1, 1, 1);
                     if (mode == ChangeMode.ADD) {
                         if (this.type == 1) great.add(vector);
                         else less.add(vector);
@@ -100,7 +101,7 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
                         else less.subtract(vector);
                     }
                     bound.resize(less, great);
-                    boundConfig.saveBound(bound);
+                    BOUND_CONFIG.saveBound(bound, true);
                 }
             }
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundLocations.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundLocations.java
@@ -11,7 +11,9 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.bound.Bound;
+import com.shanebeestudios.skbee.config.BoundConfig;
 import org.bukkit.Location;
 import org.bukkit.event.Event;
 import org.bukkit.util.Vector;
@@ -73,6 +75,7 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
     @SuppressWarnings({"NullableProblems", "ConstantValue"})
     @Override
     public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        BoundConfig boundConfig = SkBee.getPlugin().getBoundConfig();
         if (delta == null) return;
 
         if (mode == ChangeMode.SET) {
@@ -81,13 +84,14 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
                     Location less = this.type == 2 ? location : bound.getLesserCorner();
                     Location great = this.type == 1 ? location : bound.getGreaterCorner();
                     bound.resize(less, great);
+                    boundConfig.saveBound(bound);
                 }
             }
         } else {
             if (delta[0] instanceof Vector vector) {
                 for (Bound bound : getExpr().getArray(event)) {
                     Location less = bound.getLesserCorner();
-                    Location great = bound.getGreaterCorner();
+                    Location great = bound.getGreaterCorner().subtract(1,1,1);
                     if (mode == ChangeMode.ADD) {
                         if (this.type == 1) great.add(vector);
                         else less.add(vector);
@@ -95,9 +99,8 @@ public class ExprBoundLocations extends SimplePropertyExpression<Bound, Location
                         if (this.type == 1) great.subtract(vector);
                         else less.subtract(vector);
                     }
-                    // since bounds add 1 to each axis, let's subtract first
-                    great.subtract(new Vector(1, 1, 1));
                     bound.resize(less, great);
+                    boundConfig.saveBound(bound);
                 }
             }
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundOwnerMember.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundOwnerMember.java
@@ -14,6 +14,7 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.bound.Bound;
+import com.shanebeestudios.skbee.config.BoundConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Event;
@@ -33,6 +34,8 @@ import java.util.UUID;
         "\t\tteleport loop-offline player to spawn of world \"world\""})
 @Since("1.15.0")
 public class ExprBoundOwnerMember extends SimpleExpression<OfflinePlayer> {
+
+    private static final BoundConfig BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
 
     static {
         Skript.registerExpression(ExprBoundOwnerMember.class, OfflinePlayer.class, ExpressionType.PROPERTY,
@@ -126,7 +129,7 @@ public class ExprBoundOwnerMember extends SimpleExpression<OfflinePlayer> {
             default:
                 return;
         }
-        SkBee.getPlugin().getBoundConfig().saveBound(bound);
+        BOUND_CONFIG.saveBound(bound, false);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundWorld.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/expressions/ExprBoundWorld.java
@@ -1,0 +1,37 @@
+package com.shanebeestudios.skbee.elements.bound.expressions;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import com.shanebeestudios.skbee.api.bound.Bound;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+
+@Name("Bound - World")
+@Description("Get the world of a bound.")
+@Examples("set {world} to bound world of bound with id \"el-boundo\"")
+@Since("INSERT VERSION")
+public class ExprBoundWorld extends SimplePropertyExpression<Bound, World> {
+
+    static {
+        register(ExprBoundWorld.class, World.class, "bound world", "bounds");
+    }
+
+    @Override
+    public World convert(Bound bound) {
+        return bound.getWorld();
+    }
+
+    @Override
+    protected @NotNull String getPropertyName() {
+        return "bound world";
+    }
+
+    @Override
+    public @NotNull Class<? extends World> getReturnType() {
+        return World.class;
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCopy.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCopy.java
@@ -34,10 +34,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Since("2.15.0")
 public class EffSecBoundCopy extends EffectSection {
 
-    private static final BoundConfig BOUND_CONFIG;
+    private static final BoundConfig BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
 
     static {
-        BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
         Skript.registerSection(EffSecBoundCopy.class,
             "create [a] copy of [bound] %bound% (with|using) [the] id %string%");
     }
@@ -80,7 +79,7 @@ public class EffSecBoundCopy extends EffectSection {
             Variables.setLocalVariables(event, Variables.copyLocalVariables(boundCreateEvent));
             Variables.removeLocals(boundCreateEvent);
         }
-        BOUND_CONFIG.saveBound(newBound);
+        BOUND_CONFIG.saveBound(newBound, true);
         return super.walk(event, false);
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCopy.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCopy.java
@@ -53,7 +53,8 @@ public class EffSecBoundCopy extends EffectSection {
         this.id = (Expression<String>) exprs[1];
         if (sectionNode != null) {
             AtomicBoolean delayed = new AtomicBoolean(false);
-            this.trigger = loadCode(sectionNode, "bound copy", BoundCreateEvent.class);
+            Runnable afterLoading = () -> delayed.set(!getParser().getHasDelayBefore().isFalse());
+            this.trigger = loadCode(sectionNode, "bound copy", afterLoading, BoundCreateEvent.class);
             if (delayed.get()) {
                 Skript.error("Delays can't be within a Copy Bound section.");
                 return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCopy.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCopy.java
@@ -19,6 +19,7 @@ import com.shanebeestudios.skbee.api.event.bound.BoundCreateEvent;
 import com.shanebeestudios.skbee.config.BoundConfig;
 import com.shanebeestudios.skbee.elements.bound.expressions.ExprLastCreatedBound;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -27,18 +28,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Name("Bound - Copy Bound")
 @Description("Create an exact replica of an existing bound with a new id.")
 @Examples({"create a copy of bound with id \"some_bound\" with id \"some_bound_copy\"",
-        "create a copy of bound with id \"some_bound\" with id \"some_bound_copy\":",
-        "\tresize the bound between {_pos1} and {_pos2}",
-        "\tadd {_player} to bound owners of bound"})
+    "create a copy of bound with id \"some_bound\" with id \"some_bound_copy\":",
+    "\tresize the bound between {_pos1} and {_pos2}",
+    "\tadd {_player} to bound owners of bound"})
 @Since("2.15.0")
 public class EffSecBoundCopy extends EffectSection {
 
-    private static final BoundConfig boundConfig;
+    private static final BoundConfig BOUND_CONFIG;
 
     static {
-        boundConfig = SkBee.getPlugin().getBoundConfig();
+        BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
         Skript.registerSection(EffSecBoundCopy.class,
-                "create [a] copy of [bound] %bound% (with|using) [the] id %string%");
+            "create [a] copy of [bound] %bound% (with|using) [the] id %string%");
     }
 
     private Expression<Bound> bound;
@@ -48,11 +49,11 @@ public class EffSecBoundCopy extends EffectSection {
     @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> list) {
-        bound = (Expression<Bound>) exprs[0];
-        id = (Expression<String>) exprs[1];
+        this.bound = (Expression<Bound>) exprs[0];
+        this.id = (Expression<String>) exprs[1];
         if (sectionNode != null) {
             AtomicBoolean delayed = new AtomicBoolean(false);
-            trigger = loadCode(sectionNode, "bound copy", BoundCreateEvent.class);
+            this.trigger = loadCode(sectionNode, "bound copy", BoundCreateEvent.class);
             if (delayed.get()) {
                 Skript.error("Delays can't be within a Copy Bound section.");
                 return false;
@@ -61,29 +62,30 @@ public class EffSecBoundCopy extends EffectSection {
         return true;
     }
 
+    @SuppressWarnings("NullableProblems")
     @Override
     protected @Nullable TriggerItem walk(Event event) {
         Object localVars = Variables.copyLocalVariables(event);
 
-        Bound bound = this.bound.getSingle(event);
+        Bound boundToCopy = this.bound.getSingle(event);
         String id = this.id.getSingle(event);
-        if (id == null || bound == null) return super.walk(event, false);
-        bound = bound.copy(bound, id);
-        ExprLastCreatedBound.lastCreated = bound;
-        boundConfig.saveBound(bound);
-        if (trigger != null) {
-            BoundCreateEvent boundCreateEvent = new BoundCreateEvent(bound);
+        if (id == null || boundToCopy == null) return super.walk(event, false);
+        Bound newBound = boundToCopy.copy(id);
+        ExprLastCreatedBound.lastCreated = newBound;
+        if (this.trigger != null) {
+            BoundCreateEvent boundCreateEvent = new BoundCreateEvent(newBound);
             Variables.setLocalVariables(boundCreateEvent, localVars);
-            TriggerItem.walk(trigger, boundCreateEvent);
+            TriggerItem.walk(this.trigger, boundCreateEvent);
             Variables.setLocalVariables(event, Variables.copyLocalVariables(boundCreateEvent));
             Variables.removeLocals(boundCreateEvent);
         }
+        BOUND_CONFIG.saveBound(newBound);
         return super.walk(event, false);
     }
 
     @Override
-    public String toString(@Nullable Event event, boolean debug) {
-        return "create a copy of bound " + bound.toString(event, debug) + " with id " + id.toString(event,debug);
+    public @NotNull String toString(Event event, boolean debug) {
+        return "create a copy of bound " + this.bound.toString(event, debug) + " with id " + this.id.toString(event, debug);
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCreate.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCreate.java
@@ -24,6 +24,7 @@ import com.shanebeestudios.skbee.elements.bound.expressions.ExprLastCreatedBound
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.event.Event;
+import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 
@@ -120,9 +121,8 @@ public class EffSecBoundCreate extends EffectSection {
             greater.setY(max);
         }
         Bound bound = new Bound(lesser, greater, id, isTemporary);
-        if (bound.getGreaterY() - bound.getLesserY() < 1 ||
-                bound.getGreaterX() - bound.getLesserX() < 1 ||
-                bound.getGreaterZ() - bound.getLesserZ() < 1) {
+        BoundingBox box = bound.getBoundingBox();
+        if (box.getWidthX() < 1 || box.getWidthZ() < 1 || box.getHeight() < 1) {
             Util.skriptError("&cBounding box must have a size of at least 2x2x2 &7(&6%s&7)", toString(event, true));
             return super.walk(event, false);
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCreate.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bound/sections/EffSecBoundCreate.java
@@ -45,10 +45,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Since("2.5.3, 2.10.0 (temporary bounds)")
 public class EffSecBoundCreate extends EffectSection {
 
-    private static final BoundConfig BOUND_CONFIG;
+    private static final BoundConfig BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
 
     static {
-        BOUND_CONFIG = SkBee.getPlugin().getBoundConfig();
         Skript.registerSection(EffSecBoundCreate.class,
             "create [a] [new] [:temporary] [:full] bound with id %string% (within|between) %location% and %location%");
     }
@@ -127,7 +126,7 @@ public class EffSecBoundCreate extends EffectSection {
             return super.walk(event, false);
         }
         ExprLastCreatedBound.lastCreated = bound;
-        BOUND_CONFIG.saveBound(bound);
+        BOUND_CONFIG.saveBound(bound, true);
 
         if (this.trigger != null) {
             BoundCreateEvent boundCreateEvent = new BoundCreateEvent(bound);

--- a/src/main/java/com/shanebeestudios/skbee/elements/generator/structure/StructChunkGen.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/generator/structure/StructChunkGen.java
@@ -29,57 +29,57 @@ import org.skriptlang.skript.lang.structure.Structure;
 
 @Name("ChunkGenerator - Register Generator")
 @Description({"Register a chunk generator to manipulate the world layout to your liking.",
-        "ENTRIES:",
-        "(These are all optional, and will default to false)",
-        "`vanilla decor` = Whether Minecraft will decorate the surface based on biomes.",
-        "`vanilla caves` = Whether Minecraft will carve caves.",
-        "`vanilla structures` = Whether Minecraft will generate structures based on biomes.",
-        "`vanilla mobs` = Whether Minecraft will spawn mobs based on biomes.",
-        "SECTIONS:",
-        "(These are all optional, but some do rely on others. `height gen` and `block pop` require `chunk gen`)",
-        "`biome gen` = Generate the biomes to be placed in the world.",
-        "`chunk gen` = Generate your surface layer of your world.",
-        "`height gen` = Tell Minecraft where the highest block in a chunk is for generating structures.",
-        "`block pop` = Used to decorate after initial surface is generated (Structures can be placed during this stage).",
-        "NOTES:",
-        "- `world-creator` needs to be enabled in the config",
-        "- Please see the [**Chunk Generator**](https://github.com/ShaneBeee/SkBee/wiki/Chunk-Generator) wiki for further details."})
+    "ENTRIES:",
+    "(These are all optional, and will default to false)",
+    "`vanilla decor` = Whether Minecraft will decorate the surface based on biomes.",
+    "`vanilla caves` = Whether Minecraft will carve caves.",
+    "`vanilla structures` = Whether Minecraft will generate structures based on biomes.",
+    "`vanilla mobs` = Whether Minecraft will spawn mobs based on biomes.",
+    "SECTIONS:",
+    "(These are all optional, but some do rely on others. `height gen` and `block pop` require `chunk gen`)",
+    "`biome gen` = Generate the biomes to be placed in the world.",
+    "`chunk gen` = Generate your surface layer of your world.",
+    "`height gen` = Tell Minecraft where the highest block in a chunk is for generating structures.",
+    "`block pop` = Used to decorate after initial surface is generated (Structures can be placed during this stage).",
+    "NOTES:",
+    "- `world-creator` needs to be enabled in the config",
+    "- Please see the [**Chunk Generator**](https://github.com/ShaneBeee/SkBee/wiki/Chunk-Generator) wiki for further details."})
 @Examples({"register chunk generator with id \"mars\":",
-        "\tvanilla decor: false",
-        "\tvanilla caves: false",
-        "\tvanilla structures: false",
-        "\tvanilla mobs: false",
-        "\tchunk gen:",
-        "\t\tloop 16 times:",
-        "\t\t\tloop 16 times:",
-        "\t\t\t\tset {_x} to (loop-number-1) - 1",
-        "\t\t\t\tset {_z} to (loop-number-2) - 1",
-        "",
-        "\t\t\t\t# This is just an expression I created with reflect to give you an idea how it can work",
-        "\t\t\t\tset {_y} to biome noise at vector({_x} + (chunkdata chunk x * 16), 1, {_z} + (chunkdata chunk z * 16))",
-        "\t\t\t\t# Fill blocks from 0 to y level with concrete",
-        "\t\t\t\tset chunkdata blocks within vector({_x}, 0, {_z}) and vector({_x}, {_y}, {_z}) to red_concrete[]",
-        "\t\t\t\t# Set the surface layer to concrete powder",
-        "\t\t\t\tset chunkdata block at vector({_x}, {_y}, {_z}) to red_concrete_powder[]",
-        "",
-        "\tbiome gen:",
-        "\t\t# Set our biome to something mars like",
-        "\t\tset chunkdata biome to crimson forest"})
+    "\tvanilla decor: false",
+    "\tvanilla caves: false",
+    "\tvanilla structures: false",
+    "\tvanilla mobs: false",
+    "\tchunk gen:",
+    "\t\tloop 16 times:",
+    "\t\t\tloop 16 times:",
+    "\t\t\t\tset {_x} to (loop-number-1) - 1",
+    "\t\t\t\tset {_z} to (loop-number-2) - 1",
+    "",
+    "\t\t\t\t# This is just an expression I created with reflect to give you an idea how it can work",
+    "\t\t\t\tset {_y} to biome noise at vector({_x} + (chunkdata chunk x * 16), 1, {_z} + (chunkdata chunk z * 16))",
+    "\t\t\t\t# Fill blocks from 0 to y level with concrete",
+    "\t\t\t\tset chunkdata blocks within vector({_x}, 0, {_z}) and vector({_x}, {_y}, {_z}) to red_concrete[]",
+    "\t\t\t\t# Set the surface layer to concrete powder",
+    "\t\t\t\tset chunkdata block at vector({_x}, {_y}, {_z}) to red_concrete_powder[]",
+    "",
+    "\tbiome gen:",
+    "\t\t# Set our biome to something mars like",
+    "\t\tset chunkdata biome to crimson forest"})
 @Since("3.5.0")
-public class StrucChunkGen extends Structure {
+public class StructChunkGen extends Structure {
 
     static {
         EntryValidator validator = EntryValidator.builder()
-                .addEntryData(new LiteralEntryData<>("vanilla decor", false, true, Boolean.class))
-                .addEntryData(new LiteralEntryData<>("vanilla caves", false, true, Boolean.class))
-                .addEntryData(new LiteralEntryData<>("vanilla structures", false, true, Boolean.class))
-                .addEntryData(new LiteralEntryData<>("vanilla mobs", false, true, Boolean.class))
-                .addSection("chunk gen", true)
-                .addSection("biome gen", true)
-                .addSection("height gen", true)
-                .addSection("block pop", true)
-                .build();
-        Skript.registerStructure(StrucChunkGen.class, validator, "register chunk generator with id %string%");
+            .addEntryData(new LiteralEntryData<>("vanilla decor", false, true, Boolean.class))
+            .addEntryData(new LiteralEntryData<>("vanilla caves", false, true, Boolean.class))
+            .addEntryData(new LiteralEntryData<>("vanilla structures", false, true, Boolean.class))
+            .addEntryData(new LiteralEntryData<>("vanilla mobs", false, true, Boolean.class))
+            .addSection("chunk gen", true)
+            .addSection("biome gen", true)
+            .addSection("height gen", true)
+            .addSection("block pop", true)
+            .build();
+        Skript.registerStructure(StructChunkGen.class, validator, "register chunk generator with id %string%");
     }
 
     private Literal<String> id;
@@ -146,6 +146,29 @@ public class StrucChunkGen extends Structure {
             }
         }
         return true;
+    }
+
+    @Override
+    public @NotNull Priority getPriority() {
+        // For Reference:
+        // 15 = ch.njol.skript.structures.StructUsing
+        // 100 = ch.njol.skript.structures.StructOptions
+        // 150 = org.skriptlang.reflect.java.elements.structures.StructImport
+        // 200 = ch.njol.skript.structures.StructAliases
+        // 300 = ch.njol.skript.structures.StructVariables
+        // 350 = org.skriptlang.reflect.syntax.condition.elements.StructCustomCondition
+        // 350 = org.skriptlang.reflect.syntax.effect.elements.StructCustomEffect
+        // 350 = org.skriptlang.reflect.syntax.event.elements.StructCustomEvent
+        // 350 = org.skriptlang.reflect.syntax.expression.elements.StructCustomConstant
+        // 350 = org.skriptlang.reflect.syntax.expression.elements.StructCustomExpression
+        // 400 = ch.njol.skript.structures.StructFunction
+        // 401 = com.shanebeestudios.skbee.elements.generator.structure.StructChunkGen
+        // 500 = ch.njol.skript.structures.StructCommand
+        // 600 = ch.njol.skript.structures.StructEvent
+        // Load after Options/Aliases/Variables/Function/CustomSyntax structures
+        // Load before Command/Event structures
+        // This ensures custom chunk generators can be used in WorldCreator within the load event
+        return new Priority(401);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/nbt/expressions/ExprTagOfNBT.java
@@ -93,7 +93,7 @@ import java.util.ArrayList;
     "set string tag \"minecraft:rarity\" of nbt of player's tool to \"epic\"",
     "",
     "# All custom data must be within the \"minecraft:custom_data\" compound",
-    "# See NBT Compound expression for futher details on the `component nbt` expression",
+    "# See NBT Compound expression for futher details on the `custom nbt` expression",
     "set byte tag \"Points\" of custom nbt of player's tool to 10",
     "set int tag \"MyBloop\" of custom nbt of player's tool to 152",
     "# These examples will do the same as above",

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAverageTickTime.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprAverageTickTime.java
@@ -15,8 +15,9 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@Name("Average Tick Time")
-@Description("Represents the average amount of time (in milliseconds) it takes for the server to finish a tick. Requires PaperMC.")
+@Name("Average Tick Time - MSPT")
+@Description({"Represents the average amount of time (in milliseconds) it takes for the server to finish a tick, also know as MSPT",
+    "Requires PaperMC."})
 @Examples({"set {_avg} to average tick time",
     "if average tick time > 40:"})
 @Since("3.5.4")

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockDataItem.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockDataItem.java
@@ -33,7 +33,7 @@ public class ExprBlockDataItem extends SimplePropertyExpression<ItemType, BlockD
     public @Nullable BlockData convert(ItemType itemType) {
         if (itemType.getItemMeta() instanceof BlockDataMeta meta) {
             Material blockForm = BlockDataUtils.getBlockForm(itemType.getMaterial());
-            if (blockForm.isBlock()) return meta.getBlockData(blockForm);
+            if (blockForm != null && blockForm.isBlock()) return meta.getBlockData(blockForm);
         }
         return null;
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockDataItemTag.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockDataItemTag.java
@@ -47,7 +47,7 @@ public class ExprBlockDataItemTag extends PropertyExpression<ItemType, Object> {
             if (!(itemType.getItemMeta() instanceof BlockDataMeta meta)) return null;
 
             Material blockForm = BlockDataUtils.getBlockForm(itemType.getMaterial());
-            if (!blockForm.isBlock()) return null;
+            if (blockForm == null || !blockForm.isBlock()) return null;
 
             BlockData blockData = meta.getBlockData(blockForm);
 
@@ -68,13 +68,11 @@ public class ExprBlockDataItemTag extends PropertyExpression<ItemType, Object> {
         if (delta == null) return;
         for (ItemType itemType : getExpr().getAll(event)) {
             Material blockForm = BlockDataUtils.getBlockForm(itemType.getMaterial());
+            if (blockForm == null || !blockForm.isBlock()) continue;
+
             BlockDataMeta itemMeta = (BlockDataMeta) itemType.getItemMeta();
-            BlockData oldBlockData;
-            if (itemMeta.hasBlockData()) {
-                oldBlockData = itemMeta.getBlockData(blockForm);
-            } else {
-                oldBlockData = blockForm.createBlockData();
-            }
+            BlockData oldBlockData = itemMeta.getBlockData(blockForm);
+
             BlockData newBlockData = BlockDataUtils.setBlockDataTag(oldBlockData, this.tag.getSingle(event), delta[0]);
             itemMeta.setBlockData(newBlockData);
             itemType.setItemMeta(itemMeta);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockDataItemTags.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockDataItemTags.java
@@ -50,7 +50,7 @@ public class ExprBlockDataItemTags extends SimpleExpression<String> {
             if (!(itemType.getItemMeta() instanceof BlockDataMeta blockDataMeta)) continue;
 
             Material blockForm = BlockDataUtils.getBlockForm(itemType.getMaterial());
-            if (!blockForm.isBlock()) continue;
+            if (blockForm == null || !blockForm.isBlock()) continue;
 
             BlockData blockData = blockDataMeta.getBlockData(blockForm);
             String[] data = BlockDataUtils.getBlockDataTags(blockData);

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemFlags.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemFlags.java
@@ -1,7 +1,7 @@
 package com.shanebeestudios.skbee.elements.other.expressions;
 
 import ch.njol.skript.aliases.ItemType;
-import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
@@ -11,26 +11,28 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.util.ItemUtils;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Name("ItemFlag - ItemFlags of Items")
-@Description("Get/Set the ItemFlags of an item.")
+@Description({"Get/Set the ItemFlags of an item. Delete/reset will remove all item flags.",
+    "As of Minecraft 1.20.5, the `hide attributes` flag doesn't work as intended. ",
+    "See [**SkBee Wiki**](https://github.com/ShaneBeee/SkBee/wiki/Tricks-Hide-Attribute-Modifiers) for more info."})
 @Examples({"set {_flags::*} to item flags of player's tool",
-        "add hide enchants to item flags of player's tool",
-        "add hide attributes to item flags of player's tool",
-        "add hide enchants and hide attributes to item flags of player's tool",
-        "remove hide enchants from item flags of player's tool",
-        "remove hide attributes from item flags of player's tool",
-        "delete item flags of player's tool",
-        "reset item flags of player's tool"})
+    "set item flags of player's tool to hide enchants",
+    "add hide enchants to item flags of player's tool",
+    "add hide attributes to item flags of player's tool",
+    "add hide enchants and hide attributes to item flags of player's tool",
+    "remove hide enchants from item flags of player's tool",
+    "remove hide attributes from item flags of player's tool",
+    "delete item flags of player's tool",
+    "reset item flags of player's tool"})
 @Since("3.4.0")
 public class ExprItemFlags extends PropertyExpression<ItemType, ItemFlag> {
 
@@ -57,36 +59,41 @@ public class ExprItemFlags extends PropertyExpression<ItemType, ItemFlag> {
 
     @SuppressWarnings("NullableProblems")
     @Override
-    public Class<?> @Nullable [] acceptChange(Changer.ChangeMode mode) {
-        if (mode == Changer.ChangeMode.ADD || mode == Changer.ChangeMode.REMOVE) {
-            return CollectionUtils.array(ItemFlag[].class);
-        } else if (mode == Changer.ChangeMode.DELETE || mode == Changer.ChangeMode.RESET) {
-            return CollectionUtils.array();
-        }
-        return null;
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+        return switch (mode) {
+            case SET, ADD, REMOVE -> CollectionUtils.array(ItemFlag.class);
+            case DELETE, RESET -> CollectionUtils.array();
+            default -> null;
+        };
     }
 
     @SuppressWarnings({"NullableProblems", "ConstantValue"})
     @Override
-    public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) {
-        if (mode == Changer.ChangeMode.DELETE || mode == Changer.ChangeMode.RESET) {
-            for (ItemType itemType : getExpr().getArray(event)) {
-                ItemMeta itemMeta = itemType.getItemMeta();
-                Set<ItemFlag> itemFlags = itemMeta.getItemFlags();
-                itemMeta.removeItemFlags(itemFlags.toArray(new ItemFlag[0]));
-                itemType.setItemMeta(itemMeta);
-            }
-        } else if (mode == Changer.ChangeMode.ADD || mode == Changer.ChangeMode.REMOVE) {
+    public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+        if (mode == ChangeMode.SET) {
             if (delta != null && delta instanceof ItemFlag[] itemFlags) {
                 for (ItemType itemType : getExpr().getArray(event)) {
-                    ItemMeta itemMeta = itemType.getItemMeta();
-                    if (mode == Changer.ChangeMode.ADD) {
+                    ItemUtils.modifyItemMeta(itemType, itemMeta -> {
+                        itemMeta.removeItemFlags(ItemFlag.values());
                         itemMeta.addItemFlags(itemFlags);
-                    } else {
-                        itemMeta.removeItemFlags(itemFlags);
-                    }
-                    itemType.setItemMeta(itemMeta);
+                    });
                 }
+            }
+        } else if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE) {
+            if (delta != null && delta instanceof ItemFlag[] itemFlags) {
+                for (ItemType itemType : getExpr().getArray(event)) {
+                    ItemUtils.modifyItemMeta(itemType, itemMeta -> {
+                        if (mode == ChangeMode.ADD) {
+                            itemMeta.addItemFlags(itemFlags);
+                        } else {
+                            itemMeta.removeItemFlags(itemFlags);
+                        }
+                    });
+                }
+            }
+        } else if (mode == ChangeMode.DELETE || mode == ChangeMode.RESET) {
+            for (ItemType itemType : getExpr().getArray(event)) {
+                ItemUtils.modifyItemMeta(itemType, itemMeta -> itemMeta.removeItemFlags(ItemFlag.values()));
             }
         }
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemFlags.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemFlags.java
@@ -61,7 +61,7 @@ public class ExprItemFlags extends PropertyExpression<ItemType, ItemFlag> {
     @Override
     public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
         return switch (mode) {
-            case SET, ADD, REMOVE -> CollectionUtils.array(ItemFlag.class);
+            case SET, ADD, REMOVE -> CollectionUtils.array(ItemFlag[].class);
             case DELETE, RESET -> CollectionUtils.array();
             default -> null;
         };

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemFlagsItem.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprItemFlagsItem.java
@@ -11,28 +11,30 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.ItemUtils;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Name("ItemFlag - Item with ItemFlags")
-@Description("Get an item with ItemFlags.")
+@Description({"Get an item with ItemFlags.",
+    "As of Minecraft 1.20.5, the `hide attributes` flag doesn't work as intended. ",
+    "See [**SkBee Wiki**](https://github.com/ShaneBeee/SkBee/wiki/Tricks-Hide-Attribute-Modifiers) for more info."})
 @Examples({"set {_sword} to diamond sword with all item flags",
-        "set {_sword} to diamond sword of sharpness 3 with hide enchants item flag",
-        "set {_sword} to diamond sword of sharpness 3 with item flag hide enchants",
-        "give player fishing rod of lure 10 with item flag hide enchants",
-        "give player potion of extended regeneration with hide enchants itemflag",
-        "give player netherite leggings with itemflag hide attributes"})
+    "set {_sword} to diamond sword of sharpness 3 with hide enchants item flag",
+    "set {_sword} to diamond sword of sharpness 3 with item flag hide enchants",
+    "give player fishing rod of lure 10 with item flag hide enchants",
+    "give player potion of extended regeneration with hide enchants itemflag",
+    "give player netherite leggings with itemflag hide attributes"})
 @Since("3.4.0")
 public class ExprItemFlagsItem extends SimpleExpression<ItemType> {
 
     static {
         Skript.registerExpression(ExprItemFlagsItem.class, ItemType.class, ExpressionType.COMBINED,
-                "%itemtype% with all item[ ]flags",
-                "%itemtype% with item[ ]flag[s] %itemflags%",
-                "%itemtype% with %itemflags% item[ ]flag[s]");
+            "%itemtype% with all item[ ]flags",
+            "%itemtype% with item[ ]flag[s] %itemflags%",
+            "%itemtype% with %itemflags% item[ ]flag[s]");
     }
 
     private int pattern;
@@ -54,13 +56,12 @@ public class ExprItemFlagsItem extends SimpleExpression<ItemType> {
     @Override
     protected ItemType @Nullable [] get(Event event) {
         ItemType itemType = this.itemType.getSingle(event);
+        ItemFlag[] flags = this.pattern == 0 ? ItemFlag.values() : this.itemFlags.getArray(event);
         if (itemType == null) return null;
 
         itemType = itemType.clone();
-        ItemMeta itemMeta = itemType.getItemMeta();
-        ItemFlag[] flags = this.pattern == 0 ? ItemFlag.values() : this.itemFlags.getArray(event);
-        itemMeta.addItemFlags(flags);
-        itemType.setItemMeta(itemMeta);
+        ItemUtils.modifyItemMeta(itemType, itemMeta -> itemMeta.addItemFlags(flags));
+
         return new ItemType[]{itemType};
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCookingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCookingRecipe.java
@@ -35,7 +35,7 @@ import org.bukkit.inventory.SmokingRecipe;
 @Description({"Register new cooking recipes. On 1.13+ you can register recipes for furnaces.",
         "On 1.14+ you can also register recipes for smokers, blast furnaces and campfires.",
         "The ID will be the name given to this recipe. IDs may only contain letters, numbers, periods, hyphens, a single colon and underscores,",
-        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"skbee:\",",
+        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"minecraft:\",",
         "this can be changed in the config to whatever you want. IDs are used for recipe discovery/unlocking recipes for players.",
         "You may also include an optional group for recipes. These will group the recipes together in the recipe book.",})
 @Examples({"on skript load:",

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCraftingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffCraftingRecipe.java
@@ -33,7 +33,7 @@ import java.util.List;
 @Description({"Register a new shaped/shapeless recipe for a specific item using custom ingredients.",
         "Recipes support items and material choices for ingredients. Material choices allow you to use Minecraft tags or lists of items.",
         "The ID will be the name given to this recipe. IDs may only contain letters, numbers, periods, hyphens, a single colon and underscores,",
-        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"skbee:\",",
+        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"minecraft:\",",
         "this can be changed in the config to whatever you want. IDs are used for recipe discovery/unlocking recipes for players.",
         "You may also include an optional group for recipes. These will group the recipes together in the recipe book.",
         "<b>NOTE:</b> Recipes with 4 or less ingredients will be craftable in the player's crafting grid.",

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffSmithingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffSmithingRecipe.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 @Name("Recipe - Smithing")
 @Description({"Register a new smithing recipe.",
         "The ID will be the name given to this recipe. IDs may only contain letters, numbers, periods, hyphens, a single colon and underscores,",
-        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"skbee:\",",
+        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"minecraft:\",",
         "this can be changed in the config to whatever you want. IDs are used for recipe discovery/unlocking recipes for players.",
         "Note: While 'custom' items will work in these recipes, it appears the smithing table will not recognize them. Requires MC 1.16+",
         "\n<b>NOTE:</b>Temporarily removed in 1.20+ as Minecraft has changed how these recipes work!"})

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffStonecuttingRecipe.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/effects/EffStonecuttingRecipe.java
@@ -29,7 +29,7 @@ import org.bukkit.inventory.StonecuttingRecipe;
 @Name("Recipe - StoneCutting")
 @Description({"Register a new stone cutting recipe.",
         "The ID will be the name given to this recipe. IDs may only contain letters, numbers, periods, hyphens, a single colon and underscores,",
-        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"skbee:\",",
+        "NOT SPACES!!! By default, if no namespace is provided, recipes will start with the namespace \"minecraft:\",",
         "this can be changed in the config to whatever you want. IDs are used for recipe discovery/unlocking recipes for players.",
         "You may also include an optional group for recipes. These will group the recipes together in the recipe book.",
         "Requires MC 1.13+"})

--- a/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldCreator.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/worldcreator/objects/BeeWorldCreator.java
@@ -3,6 +3,7 @@ package com.shanebeestudios.skbee.elements.worldcreator.objects;
 import ch.njol.skript.Skript;
 import com.shanebeestudios.skbee.SkBee;
 import com.shanebeestudios.skbee.api.util.Util;
+import net.kyori.adventure.util.TriState;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
@@ -24,6 +25,8 @@ import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "CallToPrintStackTrace"})
 public class BeeWorldCreator implements Keyed {
+
+    private static final boolean HAS_KEEP_SPAWN_LOADED = Skript.methodExists(WorldCreator.class, "keepSpawnLoaded");
 
     private final String worldName;
     private final NamespacedKey key;
@@ -200,6 +203,11 @@ public class BeeWorldCreator implements Keyed {
                 worldCreator.biomeProvider(biomeProvider);
             }
 
+            if (this.keepSpawnLoaded.isPresent() && HAS_KEEP_SPAWN_LOADED) {
+                TriState state = this.keepSpawnLoaded.get() ? TriState.TRUE : TriState.FALSE;
+                worldCreator.keepSpawnLoaded(state);
+            }
+
             genStructures.ifPresent(worldCreator::generateStructures);
             hardcore.ifPresent(worldCreator::hardcore);
 
@@ -229,7 +237,9 @@ public class BeeWorldCreator implements Keyed {
                 }
 
                 // Let's update the world with some other values
-                keepSpawnLoaded.ifPresent(world::setKeepSpawnInMemory);
+                if (keepSpawnLoaded.isPresent() && !HAS_KEEP_SPAWN_LOADED) {
+                    keepSpawnLoaded.ifPresent(world::setKeepSpawnInMemory);
+                }
             }
 
             SkBee.getPlugin().getBeeWorldConfig().saveWorldToFile(this);

--- a/src/main/resources/bounds.yml
+++ b/src/main/resources/bounds.yml
@@ -1,9 +1,4 @@
 # This file will save all bounds
 
-# Checks if old bound height needs to be changed
-# This is used internally and can be ignored
-# This value should not be changed manually
-updated_18_heights: true
-
 # A list of all bounds
 bounds:

--- a/src/test/scripts/elements/expressions/ExprBlockDataItem.sk
+++ b/src/test/scripts/elements/expressions/ExprBlockDataItem.sk
@@ -1,0 +1,3 @@
+test "block data item":
+    set {_i} to 1 of wheat seeds
+    assert item blockdata of {_i} = wheat[age=0] with "BlockData of 'wheat seeds' should have been 'wheat[age=0]'"

--- a/src/test/scripts/elements/expressions/ExprItemFlags.sk
+++ b/src/test/scripts/elements/expressions/ExprItemFlags.sk
@@ -1,10 +1,10 @@
 test "item flags of item":
-    set {_i} to diamond sword of unbreaking 3 with hide enchants item flag
+    set {_i} to unbreakable diamond sword of unbreaking 3 with hide enchants item flag
     assert size of (item flags of {_i}) = 1 with "size of item flags should have been 1"
     assert item flags of {_i} contains hide enchants with "item flags of item should have enchanted 'hide_enchants'"
 
-    add hide attributes to item flags of {_i}
+    add hide unbreakable to item flags of {_i}
     assert size of (item flags of {_i}) = 2 with "size of item flags should have been 2"
 
-    remove hide attributes and hide enchants from item flags of {_i}
+    remove hide unbreakable and hide enchants from item flags of {_i}
     assert size of (item flags of {_i}) = 0 with "size of item flags should have been 0"


### PR DESCRIPTION
Temp changelog:

## FIXED:
- Fixed a bug on older server versions where spawning particles with force threw an error

## CHANGED:
- Changed how tag type of nbt expression returns list (hopefully producing the correct list type, or null)
- Changed priority of chunk gen structure to load before events (this ensures custom generators can be used in world creators in the load event)
- Deprecated bound coords expression (use Bound Locations/World expressions instead)
- Changed bounds to use a new region system, see below.
- Full bounds now don't actually stretch the locations. You can now modify if the bound is full or not afterwards.
- Bounds now use locations 2 different ways, see below for more info.
- Bound saving has changed:
  - Previous behaviour: each bound would save when it was created/modified.
 This could cause massive lag if creating/modifying many in a short period of time.
  - New behaviour: bounds are only saved every 5 minutes (off the main thread) and when the server stops. 
This is a massive performance boost.

## ADDED:
- Added support for `set` in the item flags of item expression (it was documented that this worked, but never actually worked)
- Added support for `set` in the bound locations expression (allowing you to set greater/lesser corners)
- Added support for `add/remove` in the bound locations expression (allowing you to add/remove vectors to/from greater/lesser corners to offset size) 
- Added an expression to get the world of a bound
- Added an expression to get/set the full state of a bound

## BOUND REGIONS:
Bounds internally now use a region system.
The issue before with bound events was when a player moved, ALL bounds were looped and checked if the player moved in/out of that bound.
Now, bounds are put into regions with a size of 16x16 chunks. So when a player moves, only the bounds within that region at the player are checked.
This GREATLY increases performance.
### Spark Test:
- 19200 bounds
- 50 players (all moving)

#### Old System:
- SkBee was using about 50% of server resources per tick
#### New System:
- SkBee was using about 0.3% of server resources per tick

## BOUND CREATION CHANGES:
When creating a bound, you have 2 options as what to pass in for your 2 points:
- **LOCATIONS**: If you use locations, your bound will be created using the exact location you pass in.        
In the image on the left, locations were used, and the bound created using the exact location of the blocks.
Example: `create bound with id "test" within (location of {_a}) and (location of {_b})` (a/b representing blocks)
- **BLOCKS**: If you use blocks, 1 will be added to the x/y/z axes of the bound to account for the blocks on the edge.
In the  image on the right, blocks were used. The x/y/z axes had 1 added to account for those blocks.
Example: `create bound with id "test" within {_c} and {_d}` (c/d representing blocks)
<img width="966" alt="Screenshot 2024-09-14 at 12 35 32 AM" src="https://github.com/user-attachments/assets/25e2b88c-411b-45ef-bc15-1b61d3ddccef">


