### PR TITLE
Dev/feature - Future Feature Release

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/AddonLoader.java
+++ b/src/main/java/com/shanebeestudios/skbee/AddonLoader.java
@@ -9,6 +9,7 @@ import com.shanebeestudios.skbee.api.listener.EntityListener;
 import com.shanebeestudios.skbee.api.listener.NBTListener;
 import com.shanebeestudios.skbee.api.nbt.NBTApi;
 import com.shanebeestudios.skbee.api.scoreboard.BoardManager;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.structure.StructureManager;
 import com.shanebeestudios.skbee.api.util.LoggerBee;
 import com.shanebeestudios.skbee.api.util.SkriptUtils;
@@ -126,6 +127,8 @@ public class AddonLoader {
         loadWorldCreatorElements();
         loadChunkGenElements();
         loadTestingElements();
+
+        Experiments.init(this.addon);
 
         int[] elementCountAfter = SkriptUtils.getElementCount();
         int[] finish = new int[elementCountBefore.length];

--- a/src/main/java/com/shanebeestudios/skbee/api/command/SkBeeInfo.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/command/SkBeeInfo.java
@@ -2,6 +2,7 @@ package com.shanebeestudios.skbee.api.command;
 
 import ch.njol.skript.Skript;
 import com.shanebeestudios.skbee.SkBee;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -11,8 +12,11 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.experiment.Experiment;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import static com.shanebeestudios.skbee.api.util.Util.sendColMsg;
@@ -44,14 +48,22 @@ public class SkBeeInfo implements TabExecutor {
             });
             sendColMsg(sender, "&7SkBee Version: &b" + desc.getVersion());
             sendColMsg(sender, "&7SkBee Website: &b" + desc.getWebsite());
+        } else if (args.length > 0 && args[0].equalsIgnoreCase("experiments")) {
+            sendColMsg(sender, "&7--- [&bExperiments Info&7] ---");
+            for (Experiment experiment : Arrays.stream(Skript.experiments().registered()).sorted(Comparator.comparing(experiment -> experiment.codeName())).toList()) {
+                String owner = experiment instanceof Experiments ? "&bSkBee" : "&eSkript";
+                sendColMsg(sender, "&7- Experiment &r'&a%s&r' &7[%s&7]", experiment.codeName(), owner);
+            }
         }
         return true;
     }
 
+    private static final List<String> commands = List.of("info", "experiments");
+
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length == 1) {
-            return StringUtil.copyPartialMatches(args[0], List.of("info"), new ArrayList<>());
+            return StringUtil.copyPartialMatches(args[0], commands, new ArrayList<>());
         }
         return null;
     }

--- a/src/main/java/com/shanebeestudios/skbee/api/skript/Experiments.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/skript/Experiments.java
@@ -1,0 +1,56 @@
+package com.shanebeestudios.skbee.api.skript;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptAddon;
+import ch.njol.skript.patterns.PatternCompiler;
+import ch.njol.skript.patterns.SkriptPattern;
+import org.skriptlang.skript.lang.experiment.Experiment;
+import org.skriptlang.skript.lang.experiment.ExperimentRegistry;
+import org.skriptlang.skript.lang.experiment.LifeCycle;
+
+/**
+ * SkBee's experimental features
+ * <p>Mostly copied from {@link ch.njol.skript.registrations.Feature}</p>
+ */
+public enum Experiments implements Experiment {
+
+    ITEM_COMPONENT("item_component", LifeCycle.EXPERIMENTAL, "item(_| )component"),
+    ;
+
+    private final String codeName;
+    private final LifeCycle phase;
+    private final SkriptPattern compiledPattern;
+
+    Experiments(String codeName, LifeCycle phase, String... patterns) {
+        this.codeName = codeName;
+        this.phase = phase;
+        this.compiledPattern = switch (patterns.length) {
+            case 0 -> PatternCompiler.compile(codeName);
+            case 1 -> PatternCompiler.compile(patterns[0]);
+            default -> PatternCompiler.compile('(' + String.join("|", patterns) + ')');
+        };
+    }
+
+    public static void init(SkriptAddon addon) {
+        ExperimentRegistry experiments = Skript.experiments();
+        for (Experiments value : values()) {
+            experiments.register(addon, value);
+        }
+    }
+
+    @Override
+    public String codeName() {
+        return this.codeName;
+    }
+
+    @Override
+    public LifeCycle phase() {
+        return this.phase;
+    }
+
+    @Override
+    public SkriptPattern pattern() {
+        return this.compiledPattern;
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/api/skript/base/SimplePropertyExpression.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/skript/base/SimplePropertyExpression.java
@@ -1,7 +1,10 @@
 package com.shanebeestudios.skbee.api.skript.base;
 
+import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.config.Node;
 import com.shanebeestudios.skbee.api.skript.runtime.SyntaxRuntimeErrorProducer;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Extension of Skript's SimplePropertyExpression which implements SyntaxRuntimeErrorProducer
@@ -18,6 +21,16 @@ public abstract class SimplePropertyExpression<F, T>
     @Override
     public Node getNode() {
         return this.node;
+    }
+
+    @Override
+    public void change(Event event, Object @Nullable [] delta, ChangeMode mode) {
+        for (F f : getExpr().getArray(event)) {
+            change(f, delta, mode);
+        }
+    }
+
+    public void change(F from, Object @Nullable [] delta, ChangeMode mode) {
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/api/util/ItemComponentUtils.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/ItemComponentUtils.java
@@ -4,13 +4,17 @@ import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.util.slot.Slot;
 import io.papermc.paper.datacomponent.DataComponentType;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.PotionContents;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class for {@link DataComponentType DataComponents}
  */
+@SuppressWarnings("UnstableApiUsage")
 public class ItemComponentUtils {
 
     /**
@@ -22,7 +26,6 @@ public class ItemComponentUtils {
      * @param value   Value to set
      * @param <T>     DataComponentType value
      */
-    @SuppressWarnings("UnstableApiUsage")
     public static <T> void modifyComponent(Object[] objects, Changer.ChangeMode mode, @NotNull DataComponentType.Valued<T> type, @Nullable T value) {
         ItemUtils.modifyItems(objects, itemStack -> {
             if (mode == Changer.ChangeMode.SET && value != null) {
@@ -33,6 +36,23 @@ public class ItemComponentUtils {
                 itemStack.resetData(type);
             }
         });
+    }
+
+    public static PotionType getPotionType(ItemStack itemStack) {
+        if (itemStack.hasData(DataComponentTypes.POTION_CONTENTS)) {
+            PotionContents data = itemStack.getData(DataComponentTypes.POTION_CONTENTS);
+            if (data != null) return data.potion();
+        }
+        return null;
+    }
+
+    public static void setPotionType(ItemStack itemStack, @Nullable PotionType potionType) {
+        if (potionType != null) {
+            PotionContents potionContents = PotionContents.potionContents().potion(potionType).build();
+            itemStack.setData(DataComponentTypes.POTION_CONTENTS, potionContents);
+        } else {
+            itemStack.unsetData(DataComponentTypes.POTION_CONTENTS);
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyToComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyToComponent.java
@@ -9,6 +9,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.skript.base.Effect;
 import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecConsumableComponent.ConsumeEffectsEvent;
 import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecPotionContentsComponent.PotionContentsEvent;
@@ -67,6 +68,10 @@ public class EffApplyToComponent extends Effect {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.pattern = matchedPattern;
         if (this.pattern == 0 && !getParser().isCurrentEvent(PotionContentsEvent.class)) {
             Skript.error("'apply effect -> potion effects' can only be used in a potion contents section.");

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyToComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyToComponent.java
@@ -1,0 +1,65 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.effects;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.base.Effect;
+import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecPotionContentsComponent.PotionContentsEvent;
+import io.papermc.paper.datacomponent.item.PotionContents;
+import org.bukkit.event.Event;
+import org.bukkit.potion.PotionEffect;
+
+@Name("ItemComponent - Apply Effects")
+@Description("Used to apply a potion effect in a potion contents section's `custom_effects` section.")
+@Examples({"apply potion contents to {_i}:",
+    "\tpotion: long_swiftness",
+    "\tcustom_color: rgb(126, 207, 243)",
+    "",
+    "apply potion contents component to {_i}:",
+    "\tcustom_color: pink",
+    "\tcustom_name: \"harming\"",
+    "\tcustom_effects:",
+    "\t\tapply -> potion effect of night vision for 5 minutes",
+    "\t\tapply -> potion effect of slowness for 6 minutes"})
+@Since("INSERT VERSION")
+public class EffApplyToComponent extends Effect {
+
+    static {
+        Skript.registerEffect(EffApplyToComponent.class, "apply (effect[s]|->) %potioneffects%");
+    }
+
+    private Expression<PotionEffect> effects;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!getParser().isCurrentEvent(PotionContentsEvent.class)) {
+            Skript.error("'apply effect' can only be used in a potion contents 'custom_effects' section.");
+            return false;
+        }
+        this.effects = (Expression<PotionEffect>) exprs[0];
+        return true;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    protected void execute(Event event) {
+        if (event instanceof PotionContentsEvent potionContentsEvent) {
+            PotionContents.Builder builder = potionContentsEvent.getPotionContentsBuilder();
+            for (PotionEffect potionEffect : this.effects.getArray(event)) {
+                builder.addCustomEffect(potionEffect);
+            }
+        }
+    }
+
+    @Override
+    public String toString(Event e, boolean d) {
+        return "apply " + this.effects.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyToComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffApplyToComponent.java
@@ -8,58 +8,168 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.registry.KeyUtils;
 import com.shanebeestudios.skbee.api.skript.base.Effect;
+import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecConsumableComponent.ConsumeEffectsEvent;
 import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecPotionContentsComponent.PotionContentsEvent;
+import io.papermc.paper.datacomponent.item.Consumable;
+import io.papermc.paper.datacomponent.item.DeathProtection;
 import io.papermc.paper.datacomponent.item.PotionContents;
+import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import io.papermc.paper.registry.set.RegistrySet;
+import net.kyori.adventure.key.Key;
 import org.bukkit.event.Event;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.shanebeestudios.skbee.elements.itemcomponent.sections.SecDeathProtectionComponent.DeathProtectionEvent;
+
+@SuppressWarnings("UnstableApiUsage")
 @Name("ItemComponent - Apply Effects")
-@Description("Used to apply a potion effect in a potion contents section's `custom_effects` section.")
-@Examples({"apply potion contents to {_i}:",
-    "\tpotion: long_swiftness",
-    "\tcustom_color: rgb(126, 207, 243)",
+@Description({"Used to apply potion/consume effects in a potion contents's `custom_effects` section, " +
+    "death protection's' `death_effects` section and consumable's `on_consume_effects` section.",
     "",
-    "apply potion contents component to {_i}:",
-    "\tcustom_color: pink",
-    "\tcustom_name: \"harming\"",
-    "\tcustom_effects:",
-    "\t\tapply -> potion effect of night vision for 5 minutes",
-    "\t\tapply -> potion effect of slowness for 6 minutes"})
+    "**Patterns**:",
+    "- `%potioneffects%` = Used to apply a potion effect in a potion contents section.",
+    "- `%potioneffects% with probability %-number%` = " +
+        "Used to apply a potion/consume effect in a death protection/consumable section.",
+    "- `remove effects %potioneffecttypes/typedkeys%` = Used to apply a `remove effects` consume effect in a death protection/consumable section.",
+    "- `clear all effects` = Used to apply a `clear all effects` consume effect in a death protection/consumable section.",
+    "- `teleport randomly within [[a] diameter [of]] %number% [blocks|meters]` = " +
+        "Used to apply a `teleport randomly` consume effect in a death protection/consumable section.",
+    "- `play sound %string/typedkey%` - Used to apply a `play sound` consume effect in a death protection/consumable section."})
+@Examples("See examples of the respective sections that use this effect.")
 @Since("INSERT VERSION")
 public class EffApplyToComponent extends Effect {
 
     static {
-        Skript.registerEffect(EffApplyToComponent.class, "apply (effect[s]|->) %potioneffects%");
+        Skript.registerEffect(EffApplyToComponent.class,
+            "apply -> %potioneffects%",
+            "apply -> %potioneffects% with probability %-number%",
+            "apply -> remove effects %potioneffecttypes/typedkeys%",
+            "apply -> clear all effects",
+            "apply -> teleport randomly within [[a] diameter [of]] %number% [blocks|meters]",
+            "apply -> play sound %string/typedkey%");
     }
 
-    private Expression<PotionEffect> effects;
+    private int pattern;
+    private Expression<?> effects;
+    private Expression<?> potionEffectTypes;
+    private Expression<Number> numberExp;
+    private Expression<?> sound;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        if (!getParser().isCurrentEvent(PotionContentsEvent.class)) {
-            Skript.error("'apply effect' can only be used in a potion contents 'custom_effects' section.");
+        this.pattern = matchedPattern;
+        if (this.pattern == 0 && !getParser().isCurrentEvent(PotionContentsEvent.class)) {
+            Skript.error("'apply effect -> potion effects' can only be used in a potion contents section.");
             return false;
         }
-        this.effects = (Expression<PotionEffect>) exprs[0];
+        if (this.pattern > 0 && !getParser().isCurrentEvent(ConsumeEffectsEvent.class, DeathProtectionEvent.class)) {
+            Skript.error("'apply effect' can only be used in a consumeable/deathprotection sections.");
+            return false;
+        }
+
+        if (this.pattern < 2) {
+            this.effects = exprs[0];
+        }
+        if (this.pattern == 2) {
+            this.potionEffectTypes = exprs[0];
+        }
+        if (this.pattern == 1) {
+            this.numberExp = (Expression<Number>) exprs[1];
+        } else if (this.pattern == 4) {
+            this.numberExp = (Expression<Number>) exprs[0];
+        }
+        if (this.pattern == 5) {
+            this.sound = exprs[0];
+        }
         return true;
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @Override
     protected void execute(Event event) {
-        if (event instanceof PotionContentsEvent potionContentsEvent) {
-            PotionContents.Builder builder = potionContentsEvent.getPotionContentsBuilder();
-            for (PotionEffect potionEffect : this.effects.getArray(event)) {
-                builder.addCustomEffect(potionEffect);
+        if (event instanceof PotionContentsEvent potionEvent) {
+            PotionContents.Builder builder = potionEvent.getPotionContentsBuilder();
+            for (Object object : this.effects.getArray(event)) {
+                if (object instanceof PotionEffect potionEffect) {
+                    builder.addCustomEffect(potionEffect);
+                }
             }
+        } else if (event instanceof ConsumeEffectsEvent consumeEvent) {
+            Consumable.Builder builder = consumeEvent.getConsumableBuilder();
+            ConsumeEffect effect = createEffect(event);
+            if (effect != null) builder.addEffect(effect);
+        } else if (event instanceof DeathProtectionEvent deathEvent) {
+            DeathProtection.Builder builder = deathEvent.getDeathProtectionBuilder();
+            ConsumeEffect effect = createEffect(event);
+            if (effect != null) builder.addEffect(effect);
         }
+    }
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    private ConsumeEffect createEffect(Event event) {
+        return switch (this.pattern) {
+            case 1 -> {
+                float prob = this.numberExp != null ? this.numberExp.getOptionalSingle(event).orElse(16f).floatValue() : 16f;
+                List<PotionEffect> effects = new ArrayList<>();
+                for (Object object : this.effects.getArray(event)) {
+                    if (object instanceof PotionEffect potionEffect) effects.add(potionEffect);
+                }
+                yield ConsumeEffect.applyStatusEffects(effects, prob);
+            }
+            case 2 -> {
+                List<TypedKey<PotionEffectType>> keys = new ArrayList<>();
+                for (Object object : this.potionEffectTypes.getArray(event)) {
+                    if (object instanceof PotionEffectType potionEffectType) {
+                        keys.add(TypedKey.create(RegistryKey.MOB_EFFECT, potionEffectType.key()));
+                    } else if (object instanceof TypedKey<?> typedKey && typedKey.registryKey() == RegistryKey.MOB_EFFECT) {
+                        keys.add((TypedKey<PotionEffectType>) typedKey);
+                    }
+                }
+                RegistryKeySet<PotionEffectType> keySet = RegistrySet.keySet(RegistryKey.MOB_EFFECT, keys);
+                yield ConsumeEffect.removeEffects(keySet);
+            }
+            case 3 -> ConsumeEffect.clearAllStatusEffects();
+            case 4 -> {
+                float diameter = this.numberExp != null ? this.numberExp.getOptionalSingle(event).orElse(1f).floatValue() : 1f;
+                yield ConsumeEffect.teleportRandomlyEffect(diameter);
+            }
+            case 5 -> {
+                Key key = null;
+                Object object = this.sound.getSingle(event);
+                if (object instanceof String string) {
+                    key = KeyUtils.getKey(string);
+                } else if (object instanceof TypedKey<?> typedKey && typedKey.registryKey() == RegistryKey.SOUND_EVENT) {
+                    key = typedKey.key();
+                }
+                if (key == null) key = Key.key("block.stone.break");
+                yield ConsumeEffect.playSoundConsumeEffect(key);
+
+            }
+            default -> null;
+        };
     }
 
     @Override
     public String toString(Event e, boolean d) {
-        return "apply " + this.effects.toString(e, d);
+        return switch (this.pattern) {
+            case 0 -> "apply -> " + this.effects.toString(e, d);
+            case 1 -> "apply " + this.effects.toString(e, d) + " with duration " + this.numberExp.toString(e, d);
+            case 2 -> "remove effects " + this.potionEffectTypes.toString(e, d);
+            case 3 -> "clear all effects";
+            case 4 ->
+                "teleport randomly" + (this.numberExp != null ? " within diameter of " + this.numberExp.toString(e, d) : "");
+            case 5 -> "play sound " + this.sound.toString(e, d);
+            default -> null;
+        };
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffClearComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/effects/EffClearComponent.java
@@ -10,12 +10,13 @@ import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
 @Name("ItemComponent - Clear Components")
-@Description({"Clear components of an item. Requires Minecraft 1.21+",
+@Description({"Clear components of an item. Requires Minecraft 1.21+ and `item_component` feature.",
     "**NOTE**: This will **NOT** clear vanilla components, it will only clear custom added components."})
 @Examples({"clear food component of player's tool",
     "clear tool component of player's tool",
@@ -33,6 +34,10 @@ public class EffClearComponent extends Effect {
     @SuppressWarnings({"NullableProblems", "unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.type = parseResult.hasTag("food") ? 0 : parseResult.hasTag("tool") ? 1 : 2;
         this.itemTypes = (Expression<ItemType>) exprs[0];
         return true;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprBundleContents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprBundleContents.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
@@ -43,6 +44,10 @@ public class ExprBundleContents extends SimpleExpression<ItemType> {
     @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.itemTypes = (Expression<ItemType>) exprs[0];
         return true;
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprChargedProjectilesComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprChargedProjectilesComponent.java
@@ -14,6 +14,7 @@ import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.slot.Slot;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.ChargedProjectiles;
@@ -27,7 +28,7 @@ import java.util.List;
 @Name("ItemComponent - Charged Projectiles")
 @Description({"The items loaded as projectiles into a crossbow. If not present, the crossbow is not charged.",
     "See [**Charged Projectiles Component**](https://minecraft.wiki/w/Data_component_format#charged_projectiles) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "- `set` = Set the items to be loaded by the crossbow.",
@@ -50,6 +51,10 @@ public class ExprChargedProjectilesComponent extends SimpleExpression<Object> {
 
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.items = exprs[0];
         return true;
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprEnchantableComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprEnchantableComponent.java
@@ -1,12 +1,17 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -18,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 @Name("ItemComponent - Enchantable")
 @Description({"If present, and applicable enchantments are available, items with the component can be enchanted in an enchanting table.",
     "Positive integer representing the item's enchantability. A higher value allows enchantments with a higher cost to be picked.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Enchantable Component**](https://minecraft.wiki/w/Data_component_format#enchantable) on McWiki for more details.",
     "",
     "**Changers**:",
@@ -35,6 +40,15 @@ public class ExprEnchantableComponent extends SimplePropertyExpression<Object, N
     static {
         register(ExprEnchantableComponent.class, Number.class,
             "enchantable component", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprEnchantmentGlintOverride.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprEnchantmentGlintOverride.java
@@ -1,12 +1,17 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -17,13 +22,14 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage")
 @Name("ItemComponent - Enchantment Glint Override")
-@Description({"Represents the enchantment glint override of an item (Requires Minecraft 1.20.5+).",
+@Description({"Represents the enchantment glint override of an item. ",
+    "Requires Minecraft 1.20.5+ and `item_component` feature.",
     "Overrides the enchantment glint effect on an item.",
     "When `true`, the item will display a glint, even without enchantments.",
     "When `false`, the item will not display a glint, even with enchantments.",
     "**Note**: If no override is applied, will return null.",
     "See [**EnchantmentGlintOverride**](https://minecraft.wiki/w/Data_component_format#enchantment_glint_override) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "- `set` = Allows you to override the glint.",
@@ -37,6 +43,15 @@ public class ExprEnchantmentGlintOverride extends SimplePropertyExpression<Objec
     static {
         register(ExprEnchantmentGlintOverride.class, Boolean.class,
             "[enchantment] glint [override]", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprGliderComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprGliderComponent.java
@@ -1,12 +1,17 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import org.bukkit.event.Event;
@@ -17,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 @Description({"If applied, allows players to glide (as with elytra) when equipped.",
     "If the item does not have a glider, it will return null, not false.",
     "See [**Glider Component**](https://minecraft.wiki/w/Data_component_format#glider) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "- `set` = If set to true, a glider will be applied, otherwise removed.",
@@ -35,6 +40,15 @@ public class ExprGliderComponent extends SimplePropertyExpression<Object, Boolea
     static {
         register(ExprGliderComponent.class, Boolean.class,
             "glider component", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprIntangibleProjectileComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprIntangibleProjectileComponent.java
@@ -1,5 +1,6 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
@@ -7,7 +8,11 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import org.bukkit.event.Event;
@@ -18,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 @Description({"If applied, a projectile item can't be picked up by a player when fired, except in creative mode.",
     "If the item does not have this component, it will return null, not false.",
     "See [**Intangible Projectile Component**](https://minecraft.wiki/w/Data_component_format#intangible_projectile) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "- `set` = If set to true, the component will be applied, otherwise removed.",
@@ -34,6 +39,15 @@ public class ExprIntangibleProjectileComponent extends SimplePropertyExpression<
     static {
         register(ExprIntangibleProjectileComponent.class, Boolean.class,
             "intangible projectile component", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprItemModel.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprItemModel.java
@@ -1,12 +1,17 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -18,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 @Name("ItemComponent - Item Model")
 @Description({"Represents the item model component of an item.",
     "See [**ItemModel**](https://minecraft.wiki/w/Data_component_format#item_model) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "`set` = Will set the item model of the item.",
@@ -35,6 +40,15 @@ public class ExprItemModel extends SimplePropertyExpression<Object, String> {
 
     static {
         register(ExprItemModel.class, String.class, "item model", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprMaxStackSizeComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprMaxStackSizeComponent.java
@@ -1,12 +1,17 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.MathUtil;
@@ -20,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 @Name("ItemComponent - Max Stack Size")
 @Description({"Represents the max stack size of an item.",
     "See [**MaxStackSize**](https://minecraft.wiki/w/Data_component_format#max_stack_size) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "- `set` = Set the max stack size, must be an integer between 1 and 99.",
@@ -34,6 +39,15 @@ public class ExprMaxStackSizeComponent extends SimplePropertyExpression<Object, 
     static {
         register(ExprMaxStackSizeComponent.class, Number.class,
             "max stack size component", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprRepairCost.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprRepairCost.java
@@ -1,13 +1,18 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.Math2;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import org.bukkit.event.Event;
@@ -30,6 +35,15 @@ public class ExprRepairCost extends SimplePropertyExpression<Object, Number> {
 
     static {
         register(ExprRepairCost.class, Number.class, "repair cost component", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprRepairableComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprRepairableComponent.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.SyntaxStringBuilder;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.Util;
@@ -41,7 +42,7 @@ import java.util.List;
 @Name("ItemComponent - Repairable")
 @Description({"Represents the items/tags that will be used to repair an item in an anvil.",
     "See [**Repairable Component**](https://minecraft.wiki/w/Data_component_format#repairable) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Patterns**:",
     "`repairable items` = A list of items that are used.",
@@ -77,6 +78,10 @@ public class ExprRepairableComponent extends SimpleExpression<Object> {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.items = (Expression<Object>) exprs[0];
         this.tag = matchedPattern == 1;
         return true;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprTooltipStyleComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprTooltipStyleComponent.java
@@ -1,13 +1,18 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -19,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 @Name("ItemComponent - Tooltip Style")
 @Description({"The key of the custom sprites for the tooltip background and frame which references textures.",
     "See [**Tooltip Style Component**](https://minecraft.wiki/w/Data_component_format#tooltip_style) on McWiki for more details.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "",
     "**Changers**:",
     "- `set` = Set the key of the texture to use.",
@@ -35,6 +40,15 @@ public class ExprTooltipStyleComponent extends SimplePropertyExpression<Object, 
     static {
         register(ExprTooltipStyleComponent.class, String.class,
             "tool[ ]tip style [component]", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprUseRemainderComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/expressions/ExprUseRemainderComponent.java
@@ -1,12 +1,17 @@
 package com.shanebeestudios.skbee.elements.itemcomponent.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -17,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("ItemComponent - Use Remainder")
 @Description({"If present, replaces the item with a remainder item if its stack count has decreased after use.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Use Remainder Component**](https://minecraft.wiki/w/Data_component_format#use_remainder) on McWiki for more details.",
     "",
     "**Changers**:",
@@ -34,6 +39,15 @@ public class ExprUseRemainderComponent extends SimplePropertyExpression<Object, 
     static {
         register(ExprUseRemainderComponent.class, ItemStack.class,
             "use remainder [component]", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
+        return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecAdventureComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecAdventureComponent.java
@@ -15,6 +15,7 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.registry.RegistryUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.block.BlockPredicate;
@@ -40,7 +41,7 @@ import java.util.List;
 
 @Name("ItemComponent - Adventure Predicate Apply")
 @Description({"Apply an adventure can break/can place on predicate to items.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Can Break**](https://minecraft.wiki/w/Data_component_format#can_break)/" +
         "[**Can Place On**](https://minecraft.wiki/w/Data_component_format#can_place_on) components on McWiki for more info.",
     "",
@@ -82,6 +83,10 @@ public class SecAdventureComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         if (sectionNode == null) return false;
         EntryContainer validate = VALIDATOR.validate(sectionNode);
         if (validate == null) {

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecAdventureComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecAdventureComponent.java
@@ -82,6 +82,7 @@ public class SecAdventureComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (sectionNode == null) return false;
         EntryContainer validate = VALIDATOR.validate(sectionNode);
         if (validate == null) {
             return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecConsumableComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecConsumableComponent.java
@@ -15,6 +15,7 @@ import ch.njol.skript.util.Timespan;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -35,7 +36,7 @@ import java.util.Locale;
 @Name("ItemComponent - Consumable Component Apply")
 @Description({"Apply a consumable component to an item.",
     "If present, this item can be consumed by the player.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Consumable Component**](https://minecraft.wiki/w/Data_component_format#consumable) on McWiki for more info.",
     "**Entries**:",
     "- `consume_seconds` = The amount of time it takes for a player to consume the item. Defaults to 1.6 seconds. [Optional]",
@@ -114,6 +115,10 @@ public class SecConsumableComponent extends EffectSection {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.items = (Expression<Object>) exprs[0];
         if (sectionNode == null) return false;
         EntryContainer container = VALIDATOR.validate(sectionNode);

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecConsumableComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecConsumableComponent.java
@@ -9,8 +9,10 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.EffectSection;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.Timespan;
+import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
@@ -21,6 +23,8 @@ import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import net.kyori.adventure.key.Key;
 import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryContainer;
 import org.skriptlang.skript.lang.entry.EntryValidator;
@@ -39,20 +43,50 @@ import java.util.Locale;
     "  Must be one of \"none\", \"eat\", \"drink\", \"block\", \"bow\", \"spear\", \"crossbow\", \"spyglass\", \"toot_horn\" or \"brush\". Defaults to \"eat\"]",
     "- `sound` = A sound key to player when consumed. Defaults to \"entity.generic.eat\" [Optional]",
     "- `has_consume_particles` = Whether consumption particles are emitted while consuming this item. Defaults to true. [Optional]",
-    "- `on_consume_effects` = A `consume effect` to by applied to the component (supports a list) [Optional]."})
-@Examples({"set {_effects} to apply_effects(potion effect of night vision for 10 seconds, 0.5)",
+    "- `on_consume_effect` = A `consume effect` to by applied to the component (supports a list) [Optional].",
+    "- `on_consume_effects` = A section to apply `consume effects` [Optional]."})
+@Examples({"apply consumable to {_i}:",
+    "\tanimation: \"drink\"",
+    "\tconsume_seconds: 2.5 seconds",
+    "\ton_consume_effects:",
+    "\t\tapply -> potion effect of slowness for 10 seconds with probability 0.5",
+    "\t\tapply -> clear all effects",
+    "\t\tapply -> remove effects night vision",
+    "\t\tapply -> play sound \"blah.blah\"",
+    "\t\tapply -> teleport randomly within 15",
+    "\t\tapply -> teleport randomly within 20 meters",
+    "\t\tapply -> teleport randomly within 100 blocks",
     "",
+    "set {_effects} to apply_effects(potion effect of night vision for 10 seconds, 0.5)",
     "set {_i} to 1 of stick",
     "apply consumable component to {_i}:",
     "\tconsume_seconds: 3.2 seconds",
     "\tanimation: \"brush\"",
     "\tsound: \"block.stone.break\"",
     "\thas_consume_particles: false",
-    "\ton_consume_effects: {_effects}",
+    "\ton_consume_effect: {_effects}",
     "give {_i} to player"})
 @Since("3.8.0")
 @SuppressWarnings("UnstableApiUsage")
 public class SecConsumableComponent extends EffectSection {
+
+    public static class ConsumeEffectsEvent extends Event {
+
+        private final Consumable.Builder builder;
+
+        public ConsumeEffectsEvent(Consumable.Builder builder) {
+            this.builder = builder;
+        }
+
+        public Consumable.Builder getConsumableBuilder() {
+            return this.builder;
+        }
+
+        @Override
+        public @NotNull HandlerList getHandlers() {
+            throw new IllegalStateException("ConsumeEffectsEvent should never be called");
+        }
+    }
 
     private static final EntryValidator VALIDATOR;
 
@@ -62,7 +96,8 @@ public class SecConsumableComponent extends EffectSection {
             .addOptionalEntry("animation", String.class)
             .addOptionalEntry("sound", String.class)
             .addOptionalEntry("has_consume_particles", Boolean.class)
-            .addOptionalEntry("on_consume_effects", ConsumeEffect.class)
+            .addOptionalEntry("on_consume_effect", ConsumeEffect.class)
+            .addOptionalSection("on_consume_effects")
             .build();
         Skript.registerSection(SecConsumableComponent.class,
             "apply consumable [component] to %itemstacks/itemtypes/slots%");
@@ -73,21 +108,27 @@ public class SecConsumableComponent extends EffectSection {
     private Expression<String> animation;
     private Expression<String> sound;
     private Expression<Boolean> hasConsumeParticles;
-    private Expression<ConsumeEffect> onConsumeEffects;
+    private Expression<ConsumeEffect> onConsumeEffect;
+    private Trigger onConsumeEffectsSection;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
         this.items = (Expression<Object>) exprs[0];
-        if (sectionNode != null) {
-            EntryContainer container = VALIDATOR.validate(sectionNode);
-            if (container != null) {
-                this.consumeSeconds = (Expression<Timespan>) container.getOptional("consume_seconds", false);
-                this.animation = (Expression<String>) container.getOptional("animation", false);
-                this.sound = (Expression<String>) container.getOptional("sound", false);
-                this.hasConsumeParticles = (Expression<Boolean>) container.getOptional("has_consume_particles", false);
-                this.onConsumeEffects = (Expression<ConsumeEffect>) container.getOptional("on_consume_effects", false);
-            }
+        if (sectionNode == null) return false;
+        EntryContainer container = VALIDATOR.validate(sectionNode);
+        if (container == null) {
+            return false;
+        }
+        this.consumeSeconds = (Expression<Timespan>) container.getOptional("consume_seconds", false);
+        this.animation = (Expression<String>) container.getOptional("animation", false);
+        this.sound = (Expression<String>) container.getOptional("sound", false);
+        this.hasConsumeParticles = (Expression<Boolean>) container.getOptional("has_consume_particles", false);
+        this.onConsumeEffect = (Expression<ConsumeEffect>) container.getOptional("on_consume_effect", false);
+
+        SectionNode effectsNode = container.getOptional("on_consume_effects", SectionNode.class, false);
+        if (effectsNode != null) {
+            this.onConsumeEffectsSection = loadCode(effectsNode, "on_consume_effects", ConsumeEffectsEvent.class);
         }
         return true;
     }
@@ -116,16 +157,23 @@ public class SecConsumableComponent extends EffectSection {
             Boolean hasConsumeParticles = this.hasConsumeParticles.getOptionalSingle(event).orElse(true);
             builder.hasConsumeParticles(hasConsumeParticles);
         }
-        if (this.onConsumeEffects != null) {
-            for (ConsumeEffect consumeEffect : this.onConsumeEffects.getArray(event)) {
+        if (this.onConsumeEffect != null) {
+            for (ConsumeEffect consumeEffect : this.onConsumeEffect.getArray(event)) {
                 builder.addEffect(consumeEffect);
             }
         }
 
+        if (this.onConsumeEffectsSection != null) {
+            ConsumeEffectsEvent consumeEffectsEvent = new ConsumeEffectsEvent(builder);
+            Variables.setLocalVariables(consumeEffectsEvent, Variables.copyLocalVariables(event));
+            Trigger.walk(this.onConsumeEffectsSection, consumeEffectsEvent);
+            Variables.setLocalVariables(event, Variables.copyLocalVariables(consumeEffectsEvent));
+            Variables.copyLocalVariables(consumeEffectsEvent);
+        }
+
         Consumable consumable = builder.build();
-        ItemUtils.modifyItems(this.items.getArray(event), itemStack -> {
-            itemStack.setData(DataComponentTypes.CONSUMABLE, consumable);
-        });
+        ItemUtils.modifyItems(this.items.getArray(event), itemStack ->
+            itemStack.setData(DataComponentTypes.CONSUMABLE, consumable));
         return super.walk(event, false);
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecCustomModelDataComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecCustomModelDataComponent.java
@@ -12,6 +12,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.Color;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -25,7 +26,7 @@ import java.util.List;
 
 @Name("ItemComponent - CustomModelData Component Apply")
 @Description({"Apply a custom model data component to items.",
-    "Requires Paper 1.21.4+",
+    "Requires Paper 1.21.4+ and `item_component` feature.",
     "See [**CustomModelData Component**](https://minecraft.wiki/w/Data_component_format#custom_model_data) on McWiki for more info.",
     "",
     "**Entries**:",
@@ -67,6 +68,10 @@ public class SecCustomModelDataComponent extends Section {
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
         if (!HAS_SUPPORT) {
             Skript.error("CustomModelData with fields requires Minecraft 1.21.4+");
+            return false;
+        }
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
             return false;
         }
         EntryContainer validate = VALIDATOR.validate(sectionNode);

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecDeathProtectionComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecDeathProtectionComponent.java
@@ -14,6 +14,7 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.registrations.Feature;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -32,7 +33,7 @@ import java.util.List;
 @Name("ItemComponent - Death Protection Component Apply")
 @Description({"Apply a death protection component to an item.",
     "If present, this item protects the holder from dying by restoring a single health point.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Death Protection Component**](https://minecraft.wiki/w/Data_component_format#death_protection) on McWiki for more info.",
     "`death_effect` = A `consume effect` to by applied to the component (supports a list) [Optional].",
     "`death_effects` = A section to apply `consume effects` [Optional]."})
@@ -94,6 +95,10 @@ public class SecDeathProtectionComponent extends EffectSection {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         if (sectionNode == null) return false;
         this.items = (Expression<Object>) exprs[0];
         EntryContainer container = VALIDATOR.validate(sectionNode);

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecDeathProtectionComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecDeathProtectionComponent.java
@@ -9,7 +9,10 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.EffectSection;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.registrations.Feature;
+import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
@@ -17,9 +20,12 @@ import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.DeathProtection;
 import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.lang.entry.EntryContainer;
 import org.skriptlang.skript.lang.entry.EntryValidator;
+import org.skriptlang.skript.lang.experiment.Experiment;
 
 import java.util.List;
 
@@ -28,7 +34,8 @@ import java.util.List;
     "If present, this item protects the holder from dying by restoring a single health point.",
     "Requires Paper 1.21.3+",
     "See [**Death Protection Component**](https://minecraft.wiki/w/Data_component_format#death_protection) on McWiki for more info.",
-    "`death_effects` = A `consume effect` to by applied to the component (supports a list)."})
+    "`death_effect` = A `consume effect` to by applied to the component (supports a list) [Optional].",
+    "`death_effects` = A section to apply `consume effects` [Optional]."})
 @Examples({"set {_p::1} to potion effect of night vision for 10 seconds",
     "set {_p::2} to potion effect of slow mining for 5 seconds",
     "set {_effects} to apply_effects({_p::*}, 0.5)",
@@ -36,33 +43,67 @@ import java.util.List;
     "set {_i} to 1 of stick",
     "apply death protection component to {_i}:",
     "\tdeath_effects: {_effects}",
-    "give {_i} to player"})
+    "give {_i} to player",
+    "",
+    "apply death protection to {_i}:",
+    "\tdeath_effects:",
+    "\t\tapply -> potion effect of slowness for 10 seconds with probability 0.5",
+    "\t\tapply -> clear all effects",
+    "\t\tapply -> remove effects night vision",
+    "\t\tapply -> play sound \"blah.blah\"",
+    "\t\tapply -> teleport randomly within 15",
+    "\t\tapply -> teleport randomly within 20 meters",
+    "\t\tapply -> teleport randomly within 100 blocks"})
 @Since("3.8.0")
 @SuppressWarnings("UnstableApiUsage")
 public class SecDeathProtectionComponent extends EffectSection {
+
+    public static class DeathProtectionEvent extends Event {
+
+        private final DeathProtection.Builder builder;
+
+        public DeathProtectionEvent(DeathProtection.Builder builder) {
+            this.builder = builder;
+        }
+
+        public DeathProtection.Builder getDeathProtectionBuilder() {
+            return this.builder;
+        }
+
+        @Override
+        public @NotNull HandlerList getHandlers() {
+            throw new IllegalStateException("DeathProtectionEvent should never be called");
+        }
+    }
 
     private static final EntryValidator VALIDATOR;
 
     static {
         VALIDATOR = SimpleEntryValidator.builder()
-            .addOptionalEntry("death_effects", ConsumeEffect.class)
+            .addOptionalEntry("death_effect", ConsumeEffect.class)
+            .addOptionalSection("death_effects")
             .build();
         Skript.registerSection(SecDeathProtectionComponent.class,
             "apply death protection [component] to %itemstacks/itemtypes/slots%");
     }
 
     private Expression<Object> items;
-    private Expression<ConsumeEffect> effects;
+    private Expression<ConsumeEffect> effect;
+    private Trigger effectsSection;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+        if (sectionNode == null) return false;
         this.items = (Expression<Object>) exprs[0];
-        if (sectionNode != null) {
-            EntryContainer container = VALIDATOR.validate(sectionNode);
-            if (container != null) {
-                this.effects = (Expression<ConsumeEffect>) container.getOptional("death_effects", false);
-            }
+        EntryContainer container = VALIDATOR.validate(sectionNode);
+        if (container == null) {
+            return false;
+        }
+        this.effect = (Expression<ConsumeEffect>) container.getOptional("death_effect", false);
+        SectionNode node = container.getOptional("death_effects", SectionNode.class, false);
+        if (node != null) {
+            this.effectsSection = loadCode(node, "death_effects", DeathProtectionEvent.class);
         }
         return true;
     }
@@ -70,15 +111,21 @@ public class SecDeathProtectionComponent extends EffectSection {
     @Override
     protected @Nullable TriggerItem walk(Event event) {
         DeathProtection.Builder builder = DeathProtection.deathProtection();
-        if (this.effects != null) {
-            for (ConsumeEffect consumeEffect : this.effects.getArray(event)) {
+        if (this.effect != null) {
+            for (ConsumeEffect consumeEffect : this.effect.getArray(event)) {
                 builder.addEffect(consumeEffect);
             }
         }
+        if (this.effectsSection != null) {
+            DeathProtectionEvent deathProtectionEvent = new DeathProtectionEvent(builder);
+            Variables.setLocalVariables(deathProtectionEvent, Variables.copyLocalVariables(event));
+            Trigger.walk(this.effectsSection, deathProtectionEvent);
+            Variables.setLocalVariables(event, Variables.copyLocalVariables(deathProtectionEvent));
+            Variables.copyLocalVariables(deathProtectionEvent);
+        }
         DeathProtection deathProtection = builder.build();
-        ItemUtils.modifyItems(this.items.getArray(event), itemStack -> {
-            itemStack.setData(DataComponentTypes.DEATH_PROTECTION, deathProtection);
-        });
+        ItemUtils.modifyItems(this.items.getArray(event), itemStack ->
+            itemStack.setData(DataComponentTypes.DEATH_PROTECTION, deathProtection));
         return super.walk(event, false);
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecEquippableComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecEquippableComponent.java
@@ -16,6 +16,7 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
 import com.shanebeestudios.skbee.api.registry.RegistryUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -39,7 +40,7 @@ import java.util.List;
 
 @Name("ItemComponent - Equippable Component Apply")
 @Description({"Apply an equippable component to any item so it can be equipped in the specified slot.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Equippable Component**](https://minecraft.wiki/w/Data_component_format#equippable) on McWiki for more info.",
     "",
     "**Entries**:",
@@ -98,6 +99,10 @@ public class SecEquippableComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, @Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.items = (Expression<Object>) exprs[0];
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFireworkExplosionComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFireworkExplosionComponent.java
@@ -12,6 +12,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.Color;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecFireworksComponent.FireworksExplosionsSectionEvent;
@@ -28,7 +29,7 @@ import java.util.List;
 @Name("ItemComponent - Firework Explosion Component Apply")
 @Description({"Apply a firework explosion effect to a firework star.",
     "This can also be used within the Fireworks Component's `explosions:` section.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Firework Explosion Component**](https://minecraft.wiki/w/Data_component_format#firework_explosion) on McWiki for more info.",
     "",
     "**Entries**:",
@@ -89,6 +90,10 @@ public class SecFireworkExplosionComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         EntryContainer validate = VALIDATOR.validate(sectionNode);
         if (validate == null) {
             return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFireworksComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFireworksComponent.java
@@ -14,6 +14,7 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import ch.njol.util.Math2;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -29,7 +30,7 @@ import java.util.List;
 
 @Name("ItemComponent - Fireworks Component Apply")
 @Description({"Apply a fireworks component to a firework rocket.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Fireworks Component**](https://minecraft.wiki/w/Data_component_format#fireworks) on McWiki for more info.",
     "",
     "**Entries**:",
@@ -91,6 +92,10 @@ public class SecFireworksComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         EntryContainer validate = VALIDATOR.validate(sectionNode);
         if (validate == null) {
             return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecFoodComponent.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.Section;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -27,7 +28,7 @@ import java.util.List;
 @Name("ItemComponent - Food Component Apply")
 @Description({"Apply a food component to any item giving it food properties.",
     "You will also require a `consumable` component to actually make the item consumable.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Food Component**](https://minecraft.wiki/w/Data_component_format#food) on McWiki for more details.",
     "",
     "**Entries/Sections**:",
@@ -66,6 +67,10 @@ public class SecFoodComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) return false;
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecInstrumentComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecInstrumentComponent.java
@@ -10,6 +10,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.skript.base.Section;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
@@ -26,7 +27,7 @@ import java.util.List;
 @Description({"Apply an instrument component to an item that supports it (such as a goat horn).",
     "It may seem silly that this is a section with only 1 value, " +
         "but I'm hoping that Paper updates the API to support all the features Minecraft has for this.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Instrument Component**](https://minecraft.wiki/w/Data_component_format#instrument) on McWiki for more info.",
     "",
     "**Entries**:",
@@ -53,6 +54,10 @@ public class SecInstrumentComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.items = exprs[0];
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecJukeboxPlayableComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecJukeboxPlayableComponent.java
@@ -10,6 +10,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.skript.base.Section;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
@@ -26,7 +27,7 @@ import java.util.List;
 @Name("ItemComponent - JukeboxPlayable Component Apply")
 @Description({"Apply an jukebox playable component to an item.",
     "When applied, the item can be inserted into a jukebox and plays the specified song.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**JukeboxPlayable Component**](https://minecraft.wiki/w/Data_component_format#jukebox_playable) on McWiki for more info.",
     "",
     "**Entries**:",
@@ -55,6 +56,10 @@ public class SecJukeboxPlayableComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         this.items = exprs[0];
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecPotionContentsComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecPotionContentsComponent.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.Color;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.skript.base.Section;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
@@ -30,7 +31,7 @@ import java.util.List;
 
 @Name("ItemComponent - Potion Contents Component Apply")
 @Description({"Apply a potion contents component to an item (can be used on a potion/arrow or any consumable item).",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Potion Contents Component**](https://minecraft.wiki/w/Data_component_format#potion_contents) on McWiki for more info.",
     "Note: `potion` and `custom_effects` entries cannot be used together.",
     "",
@@ -102,6 +103,10 @@ public class SecPotionContentsComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) {
             return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecPotionContentsComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecPotionContentsComponent.java
@@ -1,0 +1,173 @@
+package com.shanebeestudios.skbee.elements.itemcomponent.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.util.Color;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.base.Section;
+import com.shanebeestudios.skbee.api.util.ItemUtils;
+import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.PotionContents;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.lang.entry.EntryContainer;
+import org.skriptlang.skript.lang.entry.EntryValidator;
+
+import java.util.List;
+
+@Name("ItemComponent - Potion Contents Component Apply")
+@Description({"Apply a potion contents component to an item (can be used on a potion/arrow or any consumable item).",
+    "Requires Paper 1.21.3+",
+    "See [**Potion Contents Component**](https://minecraft.wiki/w/Data_component_format#potion_contents) on McWiki for more info.",
+    "Note: `potion` and `custom_effects` entries cannot be used together.",
+    "",
+    "**Entries**:",
+    "- `potion` = The base potion of the item.",
+    "- `custom_color` = The overriding color of this potion texture, and/or the particles of the area effect cloud created.",
+    "- `custom_name` = An optional string used to generate containing stack name. (See McWiki for more details on this) [Optional]",
+    "- `custom_effects` = A list of the additional effects that this item should apply. [Optional]"})
+@Examples({"apply potion contents to {_i}:",
+    "\tpotion: long_swiftness",
+    "\tcustom_color: rgb(126, 207, 243)",
+    "",
+    "apply potion contents component to {_i}:",
+    "\tcustom_color: pink",
+    "\tcustom_name: \"harming\"",
+    "\tcustom_effects:",
+    "\t\tapply -> potion effect of night vision for 5 minutes",
+    "\t\tapply -> potion effect of slowness for 6 minutes",
+    "",
+    "set {_i} to 1 of potion",
+    "set {_pe::*} to active potion effects of player",
+    "apply potion contents to {_i}:",
+    "\tcustom_color: rgb(126, 207, 243)",
+    "\tcustom_effects:",
+    "\t\tapply effects {_pe::*}",
+    "give {_i} to player"})
+@Since("INSERT VERSION")
+@SuppressWarnings("UnstableApiUsage")
+public class SecPotionContentsComponent extends Section {
+
+    public static class PotionContentsEvent extends Event {
+
+        private final PotionContents.Builder potionContents;
+
+        public PotionContentsEvent(PotionContents.Builder potionContents) {
+            this.potionContents = potionContents;
+        }
+
+        public PotionContents.Builder getPotionContentsBuilder() {
+            return this.potionContents;
+        }
+
+        @Override
+        public @NotNull HandlerList getHandlers() {
+            throw new IllegalStateException("PotionContentsEvent should never be called");
+        }
+    }
+
+    private static final EntryValidator VALIDATOR;
+
+    static {
+        VALIDATOR = SimpleEntryValidator.builder()
+            .addOptionalEntry("potion", PotionType.class)
+            .addOptionalEntry("custom_color", Color.class)
+            .addOptionalEntry("custom_name", String.class)
+            .addOptionalSection("custom_effects")
+            .build();
+        Skript.registerSection(SecPotionContentsComponent.class,
+            "apply potion contents [component] to %itemstacks/itemtypes/slots%");
+    }
+
+    private Expression<?> items;
+    private Expression<PotionType> potionType;
+    private Expression<Color> customColor;
+    private Expression<String> customName;
+    private Trigger customEffects;
+
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        EntryContainer container = VALIDATOR.validate(sectionNode);
+        if (container == null) {
+            return false;
+        }
+        this.items = exprs[0];
+        this.potionType = (Expression<PotionType>) container.getOptional("potion", false);
+        this.customColor = (Expression<Color>) container.getOptional("custom_color", false);
+        this.customName = (Expression<String>) container.getOptional("custom_name", false);
+
+        SectionNode rulesNode = container.getOptional("custom_effects", SectionNode.class, false);
+        if (rulesNode != null) {
+            this.customEffects = loadCode(rulesNode, "custom_effects", PotionContentsEvent.class);
+        }
+        if (this.potionType != null && this.customEffects != null) {
+            Skript.error("You cannot have both a 'potion' AND 'custom_effects'");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected @Nullable TriggerItem walk(Event event) {
+        PotionContents.Builder builder = PotionContents.potionContents();
+        if (this.potionType != null) {
+            PotionType potionType = this.potionType.getSingle(event);
+            if (potionType != null) {
+                builder.potion(potionType);
+            } else {
+                error("Invalid potion type: " + this.potionType.toString(event, true));
+            }
+        }
+        if (this.customColor != null) {
+            Color color = this.customColor.getSingle(event);
+            if (color != null) {
+                builder.customColor(color.asBukkitColor());
+            } else {
+                error("Invalid color: " + this.customColor.toString(event, true));
+            }
+        }
+        if (this.customName != null) {
+            String name = this.customName.getSingle(event);
+            if (name != null) {
+                builder.customName(name);
+            } else {
+                error("Invalid name: " + this.customName.toString(event, true));
+            }
+        }
+
+        if (this.customEffects != null) {
+            PotionContentsEvent potionSection = new PotionContentsEvent(builder);
+            Variables.setLocalVariables(potionSection, Variables.copyLocalVariables(event));
+            Trigger.walk(this.customEffects, potionSection);
+            Variables.setLocalVariables(event, Variables.copyLocalVariables(potionSection));
+            Variables.copyLocalVariables(potionSection);
+        }
+
+        PotionContents potionContents = builder.build();
+        ItemUtils.modifyItems(this.items.getArray(event), itemStack ->
+            itemStack.setData(DataComponentTypes.POTION_CONTENTS, potionContents));
+
+        return super.walk(event, false);
+    }
+
+    @Override
+    public String toString(Event e, boolean d) {
+        return "apply potion contents to " + this.items.toString(e, d);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolComponent.java
@@ -15,6 +15,7 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -31,7 +32,7 @@ import java.util.List;
 @SuppressWarnings("UnstableApiUsage")
 @Name("ItemComponent - Tool Component Apply")
 @Description({"Apply a tool component to any item making it usable tool.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Tool Component**](https://minecraft.wiki/w/Data_component_format#tool) on McWiki for more details.",
     "",
     "**Entries/Sections**:",
@@ -92,6 +93,10 @@ public class SecToolComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) return false;
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecToolRule.java
@@ -14,6 +14,7 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import com.shanebeestudios.skbee.api.registry.RegistryUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import com.shanebeestudios.skbee.elements.itemcomponent.sections.SecToolComponent.ToolComponentApplyRulesEvent;
 import io.papermc.paper.datacomponent.item.Tool;
@@ -86,6 +87,10 @@ public class SecToolRule extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         if (!getParser().isCurrentEvent(ToolComponentApplyRulesEvent.class)) {
             Skript.error("Tool rules can only be applied in a 'rules' section of a tool component section.");
             return false;

--- a/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecUseCooldownComponent.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/itemcomponent/sections/SecUseCooldownComponent.java
@@ -13,6 +13,7 @@ import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.registry.KeyUtils;
+import com.shanebeestudios.skbee.api.skript.Experiments;
 import com.shanebeestudios.skbee.api.util.ItemUtils;
 import com.shanebeestudios.skbee.api.util.SimpleEntryValidator;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -28,7 +29,7 @@ import java.util.List;
 
 @Name("ItemComponent - Use Cooldown")
 @Description({"Apply a cooldown to all items of the same type when it has been used.",
-    "Requires Paper 1.21.3+",
+    "Requires Paper 1.21.3+ and `item_component` feature.",
     "See [**Use Cooldown Component**](https://minecraft.wiki/w/Data_component_format#use_cooldown) on McWiki for more details.",
     "",
     "**Entries**:",
@@ -60,6 +61,10 @@ public class SecUseCooldownComponent extends Section {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+        if (!getParser().hasExperiment(Experiments.ITEM_COMPONENT)) {
+            Skript.error("requires '" + Experiments.ITEM_COMPONENT.codeName() + "' feature.");
+            return false;
+        }
         EntryContainer container = VALIDATOR.validate(sectionNode);
         if (container == null) return false;
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprPotionTypeItem.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprPotionTypeItem.java
@@ -1,0 +1,85 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer.ChangeMode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.util.coll.CollectionUtils;
+import com.shanebeestudios.skbee.api.skript.base.SimplePropertyExpression;
+import com.shanebeestudios.skbee.api.util.ItemComponentUtils;
+import com.shanebeestudios.skbee.api.util.ItemUtils;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.Nullable;
+
+@Name("PotionType of Item")
+@Description({"Get/set/delete the potion type of an item.",
+    "This is not the same as the potion effect type, this is the base potion Minecraft uses for the potion items in the creative menu."})
+@Examples({"set potion type of player's tool to strong_leaping",
+    "if potion type of player's tool = strong leaping:",
+    "delete potion type of player's tool"})
+@Since("INSERT VERSION")
+public class ExprPotionTypeItem extends SimplePropertyExpression<Object, PotionType> {
+
+    private static final boolean HAS_COMPONENTS = Skript.classExists("io.papermc.paper.datacomponent.DataComponentType");
+
+    static {
+        register(ExprPotionTypeItem.class, PotionType.class,
+            "potion type", "itemstacks/itemtypes/slots");
+    }
+
+    @Override
+    public @Nullable PotionType convert(Object from) {
+        ItemStack itemStack = ItemUtils.getItemStackFromObjects(from);
+        if (itemStack == null) {
+            error("Invalid item: " + Classes.toString(from));
+            return null;
+        }
+        if (HAS_COMPONENTS) {
+            return ItemComponentUtils.getPotionType(itemStack);
+        } else if (itemStack.getItemMeta() instanceof PotionMeta potionMeta) {
+            return potionMeta.getBasePotionType();
+        } else {
+            error("Item doesn't have an attached potion type: " + Classes.toString(itemStack));
+        }
+        return null;
+    }
+
+    @Override
+    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+        if (mode == ChangeMode.SET) return CollectionUtils.array(PotionType.class);
+        else if (mode == ChangeMode.DELETE) return CollectionUtils.array();
+        return null;
+    }
+
+    @Override
+    public void change(Object from, Object @Nullable [] delta, ChangeMode mode) {
+        PotionType potionType = delta != null && delta[0] instanceof PotionType pt ? pt : null;
+
+        ItemUtils.modifyItems(from, itemStack -> {
+            if (HAS_COMPONENTS) {
+                ItemComponentUtils.setPotionType(itemStack, potionType);
+            } else {
+                if (itemStack.getItemMeta() instanceof PotionMeta meta) {
+                    meta.setBasePotionType(potionType);
+                    itemStack.setItemMeta(meta);
+                }
+            }
+        });
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "potion type";
+    }
+
+    @Override
+    public Class<? extends PotionType> getReturnType() {
+        return PotionType.class;
+    }
+
+}

--- a/src/test/scripts/elements/other/expressions/ExprPotionTypeItem.sk
+++ b/src/test/scripts/elements/other/expressions/ExprPotionTypeItem.sk
@@ -1,0 +1,8 @@
+test "SkBee - ExprPotionTypeItem":
+
+	set {_i} to 1 of potion
+	assert potion type of {_i} is not set with "Shouldnt have a potion type"
+	set potion type of {_i} to strong slowness
+	assert potion type of {_i} = strong slowness with "It should now be strong slowness"
+	delete potion type of {_i}
+	assert potion type of {_i} is not set with "Shouldnt have a potion type after deleting"

--- a/src/test/scripts/general/item-component.sk
+++ b/src/test/scripts/general/item-component.sk
@@ -168,6 +168,23 @@ test "SkBee - Item Component test" when running minecraft "1.21.3":
 	reset max stack size component of {_i}
 	assert max stack size component of {_i} = 64 with "Reset max stack size component should be 64 for oak planks"
 
+	# Potion Contents
+	set {_i} to 1 of potion
+	assert active potion effects of {_i} is not set with "Shouldn't have any effects yet"
+	apply potion contents to {_i}:
+		potion: swiftness
+		custom_color: blue
+	assert active potion effects of {_i} is set with "Should have an effects now"
+	assert type of (active potion effects of {_i}) contains swiftness with "Should have swiftness"
+	delete {_i}
+	set {_i} to 1 of tipped arrow
+	apply potion contents to {_i}:
+		custom_color: rgb(1,1,1)
+		custom_effects:
+			apply -> potion effect of night vision for 3 minutes
+			apply -> potion effect of slowness for 10 days
+	assert type of (active potion effects of {_i}) contains slowness and night vision with "Should have slowness and night vision"
+
 	# Repairable
 	set {_i} to 1 of stick
 	assert repairable items of {_i} is not set with "A stick should not have any repairable items"

--- a/src/test/scripts/general/item-component.sk
+++ b/src/test/scripts/general/item-component.sk
@@ -1,3 +1,4 @@
+using item_component
 test "SkBee - Item Component test" when running minecraft "1.21.3":
 
 	# Can Break/Can Place On section
@@ -30,15 +31,41 @@ test "SkBee - Item Component test" when running minecraft "1.21.3":
 		animation: "brush"
 		sound: "block.stone.break"
 		has_consume_particles: false
-		on_consume_effects: {_effects}
+		on_consume_effect: {_effects}
 	assert {_i} has item component minecraft:consumable with "The stick should have a consumable component"
+	set {_i} to 1 of stone
+	apply consumable component to {_i}:
+		consume_seconds: 3.2 seconds
+		animation: "brush"
+		sound: "block.stone.break"
+		has_consume_particles: false
+		on_consume_effects:
+			apply -> potion effect of slowness for 10 seconds with probability 0.5
+			apply -> clear all effects
+			apply -> remove effects night vision
+			apply -> play sound "blah.blah"
+			apply -> teleport randomly within 15
+			apply -> teleport randomly within 20 meters
+			apply -> teleport randomly within 100 blocks
+	assert {_i} has item component minecraft:consumable with "The stone should have a consumable component"
 
 	# Death Protection Section
 	set {_i} to 1 of diamond sword
 	set {_effects} to apply_effects(potion effect of night vision for 10 seconds, 0.5)
 	apply death protection component to {_i}:
-		death_effects: {_effects}
+		death_effect: {_effects}
 	assert {_i} has item component minecraft:death_protection with "The diamond sword should have a death protection component"
+	set {_i} to 1 of stick
+	apply death protection to {_i}:
+		death_effects:
+			apply -> potion effect of slowness for 10 seconds with probability 0.5
+			apply -> clear all effects
+			apply -> remove effects night vision
+			apply -> play sound "blah.blah"
+			apply -> teleport randomly within 15
+			apply -> teleport randomly within 20 meters
+			apply -> teleport randomly within 100 blocks
+	assert {_i} has item component minecraft:death_protection with "The stick should have a death protection component"
 
 	# Enchantable
 	set {_i} to 1 of diamond sword


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
This PR is for the elements of a future **feature** release.

Temp changelog:

> [!WARNING]
> ItemComponents are now locked behind `item_component` experimental feature.
> Paper has these listed as experimental and may change anytime, possibly with breaking changes.

## ADDED:
- Added an expression for the potion type of an item
- Added a [potion contents](https://minecraft.wiki/w/Data_component_format#potion_contents) component section
- Added a section for applying potion effects/consume effects

## CHANGED:
- Changed the structure of the death protection component to use a section for applying consume effects.
- Changed the structure of the consumable component to use a section for applying consume effects.
- ItemComponents are now locked behind `item_component` experimental feature.
Paper has these listed as experimental and may change anytime, possibly with breaking changes.


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
