### PR TITLE
SwitchCase - fix normal/inline cases not working together

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/recipe/RecipeUtil.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/recipe/RecipeUtil.java
@@ -26,8 +26,6 @@ import org.bukkit.inventory.TransmuteRecipe;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -74,7 +72,7 @@ public class RecipeUtil {
             return getRecipeChoice(itemType.getRandom());
         } else if (object instanceof RecipeChoice choice) {
             return choice;
-        } else if (object instanceof Tag<?> tag && isMaterialTag(tag)) {
+        } else if (object instanceof Tag<?> tag && Util.isMaterialTag(tag)) {
             return new MaterialChoice((Tag<Material>) tag);
         }
         return null;
@@ -249,22 +247,6 @@ public class RecipeUtil {
             joiner.add(exactChoice.toString());
         }
         return joiner.toString();
-    }
-
-    /**
-     * Check if a {@link Tag} is a Material Tag
-     *
-     * @param object Object to check
-     * @return True if material tag
-     */
-    public static boolean isMaterialTag(Object object) {
-        if (object instanceof Tag<?> tag) {
-            ParameterizedType superC = (ParameterizedType) tag.getClass().getGenericSuperclass();
-            for (Type arg : superC.getActualTypeArguments()) {
-                if (arg.equals(Material.class)) return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/Util.java
@@ -6,11 +6,16 @@ import ch.njol.skript.util.Version;
 import com.shanebeestudios.skbee.SkBee;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -139,6 +144,34 @@ public class Util {
         long most = uuid.getMostSignificantBits();
         long least = uuid.getLeastSignificantBits();
         return new int[]{(int) (most >> 32), (int) most, (int) (least >> 32), (int) least};
+    }
+
+    /**
+     * Check if a {@link Tag} is a {@link Material} Tag
+     *
+     * @param tag tag to check
+     * @return True if material tag
+     */
+    public static boolean isMaterialTag(Tag<?> tag) {
+        ParameterizedType superC = (ParameterizedType) tag.getClass().getGenericSuperclass();
+        for (Type arg : superC.getActualTypeArguments()) {
+            if (arg.equals(Material.class)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if a {@link Tag} is an {@link EntityType} Tag
+     *
+     * @param tag tag to check
+     * @return True if EntityType tag
+     */
+    public static boolean isEntityTypeTag(Tag<?> tag) {
+        ParameterizedType superC = (ParameterizedType) tag.getClass().getGenericSuperclass();
+        for (Type arg : superC.getActualTypeArguments()) {
+            if (arg.equals(EntityType.class)) return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Comps.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Comps.java
@@ -1,14 +1,63 @@
 package com.shanebeestudios.skbee.elements.other.type;
 
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.bukkitutil.EntityUtils;
+import ch.njol.skript.entity.EntityData;
+import com.shanebeestudios.skbee.api.util.Util;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.EntityType;
 import org.skriptlang.skript.lang.comparator.Comparators;
 import org.skriptlang.skript.lang.comparator.Relation;
 
+@SuppressWarnings("unchecked")
 public class Comps {
 
     static {
         Comparators.registerComparator(NamespacedKey.class, String.class, (o1, o2) ->
             Relation.get(o1.toString().equalsIgnoreCase(o2)));
+
+        if (!Comparators.exactComparatorExists(ItemType.class, Tag.class)) {
+            // Add this comparator until Skript adds it!
+            Comparators.registerComparator(ItemType.class, Tag.class, (itemType, tag) -> {
+                if (Util.isMaterialTag(tag)) {
+                    return Relation.get(((Tag<Material>) tag).isTagged(itemType.getMaterial()));
+                }
+                return Relation.NOT_EQUAL;
+            });
+        }
+
+        if (!Comparators.exactComparatorExists(BlockData.class, Tag.class)) {
+            // Add this comparator until Skript adds it!
+            Comparators.registerComparator(BlockData.class, Tag.class, (blockData, tag) -> {
+                if (Util.isMaterialTag(tag)) {
+                    return Relation.get(((Tag<Material>) tag).isTagged(blockData.getMaterial()));
+                }
+                return Relation.NOT_EQUAL;
+            });
+        }
+
+        if (!Comparators.exactComparatorExists(EntityData.class, Tag.class)) {
+            // Add this comparator until Skript adds it!
+            Comparators.registerComparator(EntityData.class, Tag.class, (entityData, tag) -> {
+                if (Util.isEntityTypeTag(tag)) {
+                    EntityType bukkitEntityType = EntityUtils.toBukkitEntityType(entityData);
+                    return Relation.get(((Tag<EntityType>) tag).isTagged(bukkitEntityType));
+                }
+                return Relation.NOT_EQUAL;
+            });
+        }
+
+        if (!Comparators.exactComparatorExists(EntityType.class, Tag.class)) {
+            Comparators.registerComparator(EntityType.class, Tag.class, (entityType, tag) -> {
+                if (Util.isEntityTypeTag(tag)) {
+                    return Relation.get(((Tag<EntityType>) tag).isTagged(entityType));
+                }
+                return Relation.NOT_EQUAL;
+            });
+        }
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprMaterialChoice.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprMaterialChoice.java
@@ -12,7 +12,7 @@ import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
-import com.shanebeestudios.skbee.api.recipe.RecipeUtil;
+import com.shanebeestudios.skbee.api.util.Util;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.event.Event;
@@ -59,8 +59,8 @@ public class ExprMaterialChoice extends SimpleExpression<MaterialChoice> {
                     if (!materials.contains(material) && material.isItem() && !material.isAir())
                         materials.add(material);
                 });
-            } else if (RecipeUtil.isMaterialTag(object)) {
-                MaterialChoice materialChoice = new MaterialChoice((Tag<Material>) object);
+            } else if (object instanceof Tag<?> tag && Util.isMaterialTag(tag)) {
+                MaterialChoice materialChoice = new MaterialChoice((Tag<Material>) tag);
                 materialChoice.getChoices().forEach(material -> {
                     if (!materials.contains(material)) materials.add(material);
                 });

--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/type/Types.java
@@ -7,7 +7,7 @@ import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.StringUtils;
 import com.shanebeestudios.skbee.api.recipe.RecipeType;
-import com.shanebeestudios.skbee.api.recipe.RecipeUtil;
+import com.shanebeestudios.skbee.api.util.Util;
 import com.shanebeestudios.skbee.api.wrapper.EnumWrapper;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -80,7 +80,7 @@ public class Types {
             @SuppressWarnings("unchecked")
             @Override
             public @Nullable RecipeChoice convert(Tag from) {
-                if (RecipeUtil.isMaterialTag(from)) {
+                if (Util.isMaterialTag(from)) {
                     return new MaterialChoice((Tag<Material>) from);
                 }
                 return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
@@ -76,7 +76,7 @@ import org.jetbrains.annotations.Nullable;
     "\t\tdefault -> 1 of stick",
     "\tgive {_item} to attacker",})
 @Since("3.8.0")
-public class EffCase extends com.shanebeestudios.skbee.api.skript.base.Effect {
+public class EffCase extends Effect {
 
     static {
         Skript.registerEffect(EffCase.class,
@@ -174,11 +174,7 @@ public class EffCase extends com.shanebeestudios.skbee.api.skript.base.Effect {
                 }
             }
         }
-        TriggerItem next = getActualNext();
-        if (next != null) {
-            return super.walk(event);
-        }
-        return null;
+        return super.walk(event);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
@@ -176,11 +176,7 @@ public class EffCase extends com.shanebeestudios.skbee.api.skript.base.Effect {
         }
         TriggerItem next = getActualNext();
         if (next != null) {
-            if (next instanceof SecCase || next instanceof EffCase) {
-                return super.walk(event);
-            } else {
-                error("Cannot walk non-case element '" + next + "' in a switch section.");
-            }
+            return super.walk(event);
         }
         return null;
     }

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
@@ -76,10 +76,10 @@ import org.jetbrains.annotations.Nullable;
     "\t\tdefault -> 1 of stick",
     "\tgive {_item} to attacker",})
 @Since("3.8.0")
-public class EffCaseReturn extends Effect {
+public class EffCase extends com.shanebeestudios.skbee.api.skript.base.Effect {
 
     static {
-        Skript.registerEffect(EffCaseReturn.class,
+        Skript.registerEffect(EffCase.class,
             "case %objects% -> <.+>",
             "default -> <.+>");
     }
@@ -174,7 +174,15 @@ public class EffCaseReturn extends Effect {
                 }
             }
         }
-        return super.walk(event);
+        TriggerItem next = getActualNext();
+        if (next != null) {
+            if (next instanceof SecCase || next instanceof EffCase) {
+                return super.walk(event);
+            } else {
+                error("Cannot walk non-case element '" + next + "' in a switch section.");
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/effects/EffCase.java
@@ -160,7 +160,7 @@ public class EffCase extends Effect {
     protected @Nullable TriggerItem walk(Event event) {
         if (event instanceof SwitchReturnEvent switchReturnEvent) {
             if (this.defaultCase || SecCase.compare(this.caseObject.getArray(event), switchReturnEvent.getSwitchedObject())) {
-                Object returnObject = this.returnObject.getSingle(event);
+                Object returnObject = this.returnObject.getSingle(switchReturnEvent.getParentEvent());
                 if (returnObject != null) {
                     switchReturnEvent.setReturnedObject(returnObject);
                     return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/expressions/ExprSwitchedObject.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/expressions/ExprSwitchedObject.java
@@ -21,13 +21,9 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage")
 @Name("SwitchCase - Switched Value")
-@Description("Represents the object that was 'switched' in a switch section/expression.")
-@Examples({"function getBiome(b: biome) :: string:",
-    "\treturn switch return {_b}:",
-    "\t\tcase plains, sunflower plains, beach -> \"&a%switched value%\"",
-    "\t\tcase desert, savanna, badlands -> \"&e%switched value%\"",
-    "\t\tcase snowy beach, frozen peaks, grove -> \"&b%switched value%\"",
-    "\t\tdefault -> \"&7%switched value%\""})
+@Description({"Represents the object that was 'switched' in a switch section/expression.",
+    "**DEPRECATED** - This is no longer needed (was originally a bandaid for an issue with event-values)."})
+@Examples("")
 @Since("3.8.0")
 public class ExprSwitchedObject extends SimpleExpression<Object> {
 
@@ -40,6 +36,7 @@ public class ExprSwitchedObject extends SimpleExpression<Object> {
 
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        Skript.warning("Deprecated");
         if (getParser().getCurrentStructure() instanceof SectionSkriptEvent skriptEvent) {
             if (skriptEvent.getSection() instanceof SecSwitch secSwitch) {
                 this.switchSection = secSwitch;

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
@@ -2,6 +2,7 @@ package com.shanebeestudios.skbee.elements.switchcase.sections;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.conditions.CondCompare;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -19,6 +20,7 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.elements.switchcase.effects.EffCase;
 import com.shanebeestudios.skbee.elements.switchcase.events.SwitchBaseEvent;
 import com.shanebeestudios.skbee.elements.switchcase.events.SwitchReturnEvent;
 import org.bukkit.event.Event;
@@ -58,7 +60,7 @@ import java.util.List;
     "\t\tdefault:",
     "\t\t\tgive attacker a diamond"})
 @Since("3.8.0")
-public class SecCase extends Section implements ReturnHandler<Object> {
+public class SecCase extends com.shanebeestudios.skbee.api.skript.base.Section implements ReturnHandler<Object> {
 
     static {
         Skript.registerSection(SecCase.class, "case %objects%", "(default [case]|case default)");
@@ -113,6 +115,7 @@ public class SecCase extends Section implements ReturnHandler<Object> {
     @Override
     protected @Nullable TriggerItem walk(Event event) {
         if (event instanceof SwitchBaseEvent switchEvent) {
+            TriggerItem next = getActualNext();
             if (this.defaultCase || compare(this.caseObject.getArray(event), switchEvent.getSwitchedObject())) {
                 Trigger.walk(this.caseSection, switchEvent.getParentEvent());
                 if (event instanceof SwitchReturnEvent switchReturnEvent) {
@@ -121,8 +124,12 @@ public class SecCase extends Section implements ReturnHandler<Object> {
                 }
                 // TODO somehow handle functions?!?!
                 return null;
-            } else if (getActualNext() instanceof SecCase) {
-                return super.walk(event, false);
+            } else if (next != null) {
+                if (next instanceof SecCase || next instanceof EffCase) {
+                    return super.walk(event, false);
+                } else {
+                    error("Cannot walk non-case element '" + next + "' in a switch section.");
+                }
             }
         }
         return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
@@ -67,7 +67,7 @@ public class SecCase extends Section implements ReturnHandler<Object> {
     private Expression<Object> caseObject;
     private boolean defaultCase;
     private ReturnableTrigger<?> caseSection;
-    private Expression<?> returnObject;
+    private Object returnObject;
 
     @SuppressWarnings("UnstableApiUsage")
     @Override
@@ -116,8 +116,7 @@ public class SecCase extends Section implements ReturnHandler<Object> {
             if (this.defaultCase || compare(this.caseObject.getArray(event), switchEvent.getSwitchedObject())) {
                 Trigger.walk(this.caseSection, switchEvent.getParentEvent());
                 if (event instanceof SwitchReturnEvent switchReturnEvent) {
-                    Object returnObject = this.returnObject.getSingle(event);
-                    if (returnObject != null) switchReturnEvent.setReturnedObject(returnObject);
+                    if (this.returnObject != null) switchReturnEvent.setReturnedObject(this.returnObject);
                 }
                 // TODO somehow handle functions?!?!
                 return null;
@@ -154,7 +153,7 @@ public class SecCase extends Section implements ReturnHandler<Object> {
 
     @Override
     public void returnValues(Event event, Expression<?> value) {
-        this.returnObject = value;
+        this.returnObject = value.getSingle(event);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
@@ -58,7 +58,7 @@ import java.util.List;
     "\t\tdefault:",
     "\t\t\tgive attacker a diamond"})
 @Since("3.8.0")
-public class SecCase extends com.shanebeestudios.skbee.api.skript.base.Section implements ReturnHandler<Object> {
+public class SecCase extends Section implements ReturnHandler<Object> {
 
     static {
         Skript.registerSection(SecCase.class, "case %objects%", "(default [case]|case default)");
@@ -113,7 +113,6 @@ public class SecCase extends com.shanebeestudios.skbee.api.skript.base.Section i
     @Override
     protected @Nullable TriggerItem walk(Event event) {
         if (event instanceof SwitchBaseEvent switchEvent) {
-            TriggerItem next = getActualNext();
             if (this.defaultCase || compare(this.caseObject.getArray(event), switchEvent.getSwitchedObject())) {
                 Trigger.walk(this.caseSection, switchEvent.getParentEvent());
                 if (event instanceof SwitchReturnEvent switchReturnEvent) {
@@ -122,7 +121,7 @@ public class SecCase extends com.shanebeestudios.skbee.api.skript.base.Section i
                 }
                 // TODO somehow handle functions?!?!
                 return null;
-            } else if (next != null) {
+            } else if (getActualNext() != null) {
                 return super.walk(event, false);
             }
         }

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecCase.java
@@ -2,7 +2,6 @@ package com.shanebeestudios.skbee.elements.switchcase.sections;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.conditions.CondCompare;
-import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -20,7 +19,6 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
-import com.shanebeestudios.skbee.elements.switchcase.effects.EffCase;
 import com.shanebeestudios.skbee.elements.switchcase.events.SwitchBaseEvent;
 import com.shanebeestudios.skbee.elements.switchcase.events.SwitchReturnEvent;
 import org.bukkit.event.Event;
@@ -125,11 +123,7 @@ public class SecCase extends com.shanebeestudios.skbee.api.skript.base.Section i
                 // TODO somehow handle functions?!?!
                 return null;
             } else if (next != null) {
-                if (next instanceof SecCase || next instanceof EffCase) {
-                    return super.walk(event, false);
-                } else {
-                    error("Cannot walk non-case element '" + next + "' in a switch section.");
-                }
+                return super.walk(event, false);
             }
         }
         return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecSwitch.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/switchcase/sections/SecSwitch.java
@@ -1,6 +1,7 @@
 package com.shanebeestudios.skbee.elements.switchcase.sections;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -55,7 +56,6 @@ public class SecSwitch extends Section {
 
     private Expression<?> switchedObject;
     private Trigger caseSection;
-    public TriggerItem dirty;
 
     @SuppressWarnings({"unchecked", "DataFlowIssue"})
     @Override
@@ -68,9 +68,14 @@ public class SecSwitch extends Section {
 
         this.caseSection = loadCode(sectionNode, "switch case", events);
 
-        if (this.dirty != null) {
-            Skript.error("Only cases can be used in a switch section but found this: \n    ==> '" + this.dirty + "'");
-            return false;
+        // Search through the section and see if the lines are cases
+        for (Node node : sectionNode) {
+            String key = node.getKey();
+            if (!key.startsWith("case") && !key.startsWith("default")) {
+                Skript.error("Only cases can be used in a switch section but found this:");
+                this.caseSection = null;
+                break;
+            }
         }
 
         return LiteralUtils.canInitSafely(this.switchedObject);

--- a/src/test/scripts/general/switch-case.sk
+++ b/src/test/scripts/general/switch-case.sk
@@ -67,10 +67,10 @@ test "SkBee - Switch and Case":
 
 	set {_i} to 5
 	switch {_i}: # This is a silly test (could use return) but I wanted to test effects
-		case 1 -> set {_test} to "1-%switched value%"
-		case 2 -> set {_test} to "2-%switched value%"
-		case 5 -> set {_test} to "5-%switched value%"
-		default -> set {_test} to "default-%switched value%"
+		case 1 -> set {_test} to "1-%{_i}%"
+		case 2 -> set {_test} to "2-%{_i}%"
+		case 5 -> set {_test} to "5-%{_i}%"
+		default -> set {_test} to "default-%{_i}%"
 	assert {_test} = "5-5" with "The text should match"
 
 	set {_l} to location(1,1,1)
@@ -117,7 +117,6 @@ test "SkBee - Switch and Case":
 			default -> "5"
 	assert parse logs contains "Only cases can be used in a switch section but found this:" with "Should have caught that broadcast"
 
-
 	# Test Functions
 	assert testSwitch(1) = "i am one" with "This should be 'i am one'"
 	assert testSwitch(2) = "i am two" with "This should be 'i am two'"
@@ -131,3 +130,43 @@ test "SkBee - Switch and Case":
 	assert testItem(gravel) = "mushy blocks" with "This should be 'mushy blocks'"
 	assert testItem(sand) = "mushy blocks" with "This should be 'mushy blocks'"
 	assert testItem(pink wool) = "default blocks" with "This should be 'default blocks'"
+
+	# Test with event-values
+	set {test_spawn_switch_return_case_inline} to true
+	set {test_spawn_switch_return_case_normal} to true
+	set {test_spawn_switch_sec_case_normal} to true
+	set {test_spawn_switch_sec_case_inline} to true
+	spawn a sheep at event-location:
+		set {_e} to entity
+	assert {test_spawn_switch_return_case_inline} is "sheep: sheep" with "The switch return should have set this"
+	assert {test_spawn_switch_return_case_normal} is "sheep: sheep" with "The switch return should have set this"
+	assert {test_spawn_switch_sec_case_normal} is "sheep: sheep" with "The switch should have set this"
+	assert {test_spawn_switch_sec_case_inline} is "sheep: sheep" with "The switch should have set this"
+	delete {test_spawn_switch_return_case_inline}
+	delete {test_spawn_switch_return_case_normal}
+	delete {test_spawn_switch_sec_case_normal}
+	delete {test_spawn_switch_sec_case_inline}
+
+	delete entity within {_e}
+
+on spawn:
+	if {test_spawn_switch_return_case_inline} is true:
+		set {test_spawn_switch_return_case_inline} to switch return type of event-entity:
+			case a sheep -> "sheep: %type of event-entity%"
+			default -> "blah blah: %type of event-entity%"
+	if {test_spawn_switch_return_case_normal} is true:
+		set {test_spawn_switch_return_case_normal} to switch return type of event-entity:
+			case a sheep:
+				return "sheep: %type of event-entity%"
+			default:
+				return "blah blah: %type of event-entity%"
+	if {test_spawn_switch_sec_case_normal} is true:
+		switch type of event-entity:
+			case a sheep:
+				set {test_spawn_switch_sec_case_normal} to "sheep: sheep"
+			default:
+				set {test_spawn_switch_sec_case_normal} to "default"
+	if {test_spawn_switch_sec_case_inline} is true:
+		switch type of event-entity:
+			case a sheep -> set {test_spawn_switch_sec_case_inline} to "sheep: sheep"
+			default -> set {test_spawn_switch_sec_case_inline} to "default"

--- a/src/test/scripts/general/switch-case.sk
+++ b/src/test/scripts/general/switch-case.sk
@@ -94,7 +94,7 @@ test "SkBee - Switch and Case":
 		assert {_i} = "%loop-number%" with "Switch should work with both normal and inline cases together"
 
 	# Test other elements in switch sections
-	try:
+	parse:
 		set {_i} to switch return 5:
 			case 1:
 				return "1"
@@ -105,8 +105,18 @@ test "SkBee - Switch and Case":
 			case 4 -> "4"
 			default:
 				return "5"
-	catch:
-		assert runtime logs contains "Cannot walk non-case element 'broadcast ""MIDDLE""' in a switch section." with "Should have caught that broadcast"
+	assert parse logs contains "Only cases can be used in a switch section but found this:" with "Should have caught that broadcast"
+
+	parse:
+		set {_i} to switch return 5:
+			case 1 -> "one"
+			broadcast "MIDDLE"
+			case 2 -> "two"
+			case 3 -> "three"
+			case 4 -> "4"
+			default -> "5"
+	assert parse logs contains "Only cases can be used in a switch section but found this:" with "Should have caught that broadcast"
+
 
 	# Test Functions
 	assert testSwitch(1) = "i am one" with "This should be 'i am one'"

--- a/src/test/scripts/general/switch-case.sk
+++ b/src/test/scripts/general/switch-case.sk
@@ -80,6 +80,34 @@ test "SkBee - Switch and Case":
 	set block at {_l} to {_data}
 	assert {_item} = 1 of emerald named "Natural Gem" with "Should have returned the emerald"
 
+	# Test using normal and inline cases together
+	loop 5 times:
+		set {_i} to switch return loop-number:
+			case 1:
+				return "1"
+			case 2:
+				return "2"
+			case 3 -> "3"
+			case 4 -> "4"
+			default:
+				return "5"
+		assert {_i} = "%loop-number%" with "Switch should work with both normal and inline cases together"
+
+	# Test other elements in switch sections
+	try:
+		set {_i} to switch return 5:
+			case 1:
+				return "1"
+			case 2:
+				return "2"
+			broadcast "MIDDLE"
+			case 3 -> "3"
+			case 4 -> "4"
+			default:
+				return "5"
+	catch:
+		assert runtime logs contains "Cannot walk non-case element 'broadcast ""MIDDLE""' in a switch section." with "Should have caught that broadcast"
+
 	# Test Functions
 	assert testSwitch(1) = "i am one" with "This should be 'i am one'"
 	assert testSwitch(2) = "i am two" with "This should be 'i am two'"

--- a/src/test/scripts/general/switch-case.sk
+++ b/src/test/scripts/general/switch-case.sk
@@ -131,6 +131,15 @@ test "SkBee - Switch and Case":
 	assert testItem(sand) = "mushy blocks" with "This should be 'mushy blocks'"
 	assert testItem(pink wool) = "default blocks" with "This should be 'default blocks'"
 
+	# Test with tags
+	set {_logs::*} to oak log, birch log, spruce log, oak wood, stripped spruce wood, warped stem
+	loop {_logs::*}:
+		set {_l} to loop-value
+		set {_return} to switch return loop-value:
+			case minecraft block tag "minecraft:logs" -> "yay a log"
+			default -> "booo what are you: %{_l}%"
+		assert {_return} = "yay a log" with "Should have been tagged as a log"
+
 	# Test with event-values
 	set {test_spawn_switch_return_case_inline} to true
 	set {test_spawn_switch_return_case_normal} to true


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
This PR aims to fix/change some things with Switch Cases:
- Fix an issue where normal and inline cases cannot be used together in a switch section.
- Fix event-values not working in cases
- Added a check to prevent non-case code in switch sections.
- Temporarily add item/entitytype to tag comparators (until Skript adds them) so tags can be used in cases

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** #730, #733, https://github.com/SkriptLang/Skript/issues/7465

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
