### PR TITLE
Fix/bound region fix

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/Bound.java
@@ -442,6 +442,12 @@ public class Bound implements ConfigurationSerializable {
         return this.id;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Bound other)) return false;
+        return this.world.equals(other.world) && this.id.equals(other.id);
+    }
+
     /**
      * Serialize this bound into yaml configuration
      *

--- a/src/main/java/com/shanebeestudios/skbee/api/bound/BoundWorld.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/bound/BoundWorld.java
@@ -103,8 +103,8 @@ public class BoundWorld {
         BoundingBox box = bound.getBoundingBox();
         Vector min = box.getMin();
         Vector max = box.getMax();
-        for (int x = min.getBlockX(); x < max.getBlockX(); x += (1 << SHIFT_VALUE)) {
-            for (int z = min.getBlockZ(); z < max.getBlockZ(); z += (1 << SHIFT_VALUE)) {
+        for (int x = min.getBlockX(); x <= (max.getBlockX() + (1 << SHIFT_VALUE)); x += (1 << SHIFT_VALUE)) {
+            for (int z = min.getBlockZ(); z <= (max.getBlockZ() + (1 << SHIFT_VALUE)); z += (1 << SHIFT_VALUE)) {
                 locations.add(new Location(this.world, x, 0, z));
             }
         }

--- a/src/test/scripts/general/bound.sk
+++ b/src/test/scripts/general/bound.sk
@@ -97,3 +97,22 @@ test "SkBee - Bounds":
 	# Cleanup
 	delete bound with id "test_bound"
 	delete bound with id "test_bound_2"
+
+test "SkBee - Bound Regions":
+	# Test to make sure bounds on the brink of a region are actually getting regionalized
+	test:
+		loop 50 times:
+			set {_x} to random integer between -1000000 and 1000000
+			set {_z} to random integer between -1000000 and 1000000
+			set {_loc} to location({_x}, 64, {_z})
+			set {_l1} to {_loc} ~ vector(-20,-20,-20)
+			set {_l2} to {_loc} ~ vector(20,20,20)
+			create temporary bound with id "test-bound-temp-%loop-number%" within {_l1} and {_l2}
+			set {_bound} to last created bound
+			assert {_bound} is set with "The bound should have been created"
+			assert bounds at {_loc} contains {_bound} with "The location should contain the bound"
+
+			delete {_bound}, {_loc}, {_l1} and {_l2}
+	after:
+		# Ensure cleanup for re-run if need be
+		delete all temporary bounds


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
This PR aims to fix an issue with bounds, where when creating their regions, some bounds (touching edges of regions) dont actually initiate the other regions.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** #739 

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
