### PR TITLE
Fix NoMethodExists exception in ExprCraftingResultFromItems

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprCraftingResultFromItems.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/recipe/expressions/ExprCraftingResultFromItems.java
@@ -32,7 +32,8 @@ import org.jetbrains.annotations.Nullable;
 @Since("3.8.0")
 public class ExprCraftingResultFromItems extends SimpleExpression<Object> {
 
-    private static final World DEFAULT_WORLD = Bukkit.getWorlds().getFirst();
+    // note: usage of `get(0)` is used instead of `getFirst` as it's a java 21 feature
+    private static final World DEFAULT_WORLD = Bukkit.getWorlds().get(0);
     private static final ItemStack AIR = new ItemStack(Material.AIR);
 
     static {


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->

This PR aims to fix an issue with using `getFirst`, not being supported on older java versions such as java 17 for 1.19.4

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [ ] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
