### PR TITLE
Add missing ModrinthVersion#getUpdateVersion()

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/util/update/UpdateChecker.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/update/UpdateChecker.java
@@ -53,7 +53,7 @@ public class UpdateChecker implements Listener {
                 if (!player.hasPermission("skbee.update.check")) return;
 
                 TaskUtils.getEntityScheduler(player).runTaskLater(() -> getUpdateVersion(true).thenApply(version -> {
-                    Util.sendColMsg(player, "&7[&bSk&3Bee&7] Update available: &a" + version);
+                    Util.sendColMsg(player, "&7[&bSk&3Bee&7] Update available: &a" + version.getUpdateVersion());
                     Util.sendColMsg(player, "&7[&bSk&3Bee&7] Download at: &b" + version.getUpdateLink());
                     return true;
                 }), 30);


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->

The update checker for the `PlayerJoinEvent` listener, was using the plain `ModrinthVersion` object instead of calling `getUpdateVersion()` this is now called.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** #824 <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
