### PR TITLE
Fix health scaling exception if provided a negative value

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprHealthScale.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprHealthScale.java
@@ -34,7 +34,6 @@ public class ExprHealthScale extends SimplePropertyExpression<Player, Number> {
         return player.getHealthScale();
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
         if (mode == ChangeMode.SET || mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.RESET) {
@@ -43,12 +42,10 @@ public class ExprHealthScale extends SimplePropertyExpression<Player, Number> {
         return null;
     }
 
-    @SuppressWarnings({"NullableProblems", "ConstantValue", "DataFlowIssue"})
     @Override
     public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
-        Number changeNumber = delta != null ? ((Number) delta[0]) : 0;
-        double change = changeNumber.doubleValue();
-
+        Number changeNumber = delta != null && delta[0] instanceof Number ? ((Number) delta[0]) : 0;
+        double change = Math.max(changeNumber.doubleValue(), 1);
         for (Player player : getExpr().getArray(event)) {
             boolean scaled = true;
             double oldScale = player.getHealthScale();


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->
This PR aims to fix an illegal argument exception when passing a negative or `0` value through `health scale of player` expression.
Additionally I've removed a few unneeded suppressions. 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [ ] Tests have been added if necessary
- [X] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)


Test is not possible as far as I know, due to lack of a player object at the time required.
I have confirmed in-game tho that this works