### PR TITLE
Component replace effect changes

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
@@ -32,8 +32,8 @@ public class EffComponentReplace extends Effect {
 
     static {
         Skript.registerEffect(EffComponentReplace.class,
-            "component [:regex] replace [:first] %strings% with %string/textcomponent% in %~textcomponents%",
-            "component [:regex] replace [:first] %strings% in %~textcomponents% with %string/textcomponent%");
+            "component [:regex] replace [:first] %strings% with %object% in %~textcomponents%",
+            "component [:regex] replace [:first] %strings% in %~textcomponents% with %object%");
     }
 
     private boolean useRegex, replaceFirst;

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
@@ -16,17 +16,14 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 @Name("TextComponent - Replace Text")
-@Description({
-    "Replaces a given string with another string/text component.",
+@Description({"Replaces a given string with another string/text component.",
     "**NOTE:**",
     " - `regex` Defining the regex keyword will have the provided string be parsed as regex",
     " - `first` Defining the first keyword will only replace the first instance ",
     "If you're new to regex and want to see how it's parsed you can use https://regex101.com/ for debugging."})
-@Examples({
-    "component replace \"[item]\", \"[i]\" with getItemComponent(player's tool) in async chat message",
+@Examples({"component replace \"[item]\", \"[i]\" with getItemComponent(player's tool) in async chat message",
     "component regex replace \"\\[(item|i)]\" with getItemComponent(player's tool) in async chat message",
-    "component replace first \"Mom!\" in {_message} with \"Dad!\"",
-    ""})
+    "component replace first \"Mom!\" in {_message} with \"Dad!\""})
 @Since("2.18.0")
 public class EffComponentReplace extends Effect {
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
@@ -18,8 +18,8 @@ import org.jetbrains.annotations.NotNull;
 @Name("TextComponent - Replace Text")
 @Description({"Replaces a given string with another string/text component.",
     "**NOTE:**",
-    " - `regex` Defining the regex keyword will have the provided string be parsed as regex",
-    " - `first` Defining the first keyword will only replace the first instance ",
+    " - `regex` Defining the regex keyword will have the provided string be parsed as regex.",
+    " - `first` Defining the first keyword will only replace the first instance. ",
     "If you're new to regex and want to see how it's parsed you can use https://regex101.com/ for debugging."})
 @Examples({"component replace \"[item]\", \"[i]\" with getItemComponent(player's tool) in async chat message",
     "component regex replace \"\\[(item|i)]\" with getItemComponent(player's tool) in async chat message",

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/effects/EffComponentReplace.java
@@ -8,59 +8,71 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.SyntaxStringBuilder;
+import ch.njol.skript.util.LiteralUtils;
 import ch.njol.util.Kleenean;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 @Name("TextComponent - Replace Text")
-@Description({"Replace a string with another string or text component in a text component. Supports regex patterns.",
-    "NOTE: If you notice sometimes your symbols aren't replace, this could be a regex pattern issue and you may need to escape characters.",
-    "ex: `:(` -> `:\\(` and `[` -> `\\[`"})
-@Examples({"component replace \"puppy\" with \"***\" in {_comp}",
-    "component replace \"\\d+\" with \"0\" in {_comp}",
-    "component replace \":\\(\" with \"sad\" in {_comp}"})
+@Description({
+    "Replaces a given string with another string/text component.",
+    "**NOTE:**",
+    " - `regex` Defining the regex keyword will have the provided string be parsed as regex",
+    " - `first` Defining the first keyword will only replace the first instance ",
+    "If you're new to regex and want to see how it's parsed you can use https://regex101.com/ for debugging."})
+@Examples({
+    "component replace \"[item]\", \"[i]\" with getItemComponent(player's tool) in async chat message",
+    "component regex replace \"\\[(item|i)]\" with getItemComponent(player's tool) in async chat message",
+    "component replace first \"Mom!\" in {_message} with \"Dad!\"",
+    ""})
 @Since("2.18.0")
 public class EffComponentReplace extends Effect {
 
     static {
         Skript.registerEffect(EffComponentReplace.class,
-            "component replace %strings% with %string/textcomponent% in %textcomponents%");
+            "component [:regex] replace [:first] %strings% with %string/textcomponent% in %~textcomponents%",
+            "component [:regex] replace [:first] %strings% in %~textcomponents% with %string/textcomponent%");
     }
 
-    private Expression<String> toReplace;
-    private Expression<Object> replacement;
+    private boolean useRegex, replaceFirst;
+    private Expression<String> patterns;
+    private Expression<?> replacement;
     private Expression<ComponentWrapper> components;
 
-    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        this.toReplace = (Expression<String>) exprs[0];
-        this.replacement = (Expression<Object>) exprs[1];
-        this.components = (Expression<ComponentWrapper>) exprs[2];
-        return true;
+        this.useRegex = parseResult.hasTag("regex");
+        this.replaceFirst = parseResult.hasTag("first");
+        this.patterns = (Expression<String>) exprs[0];
+        this.components = (Expression<ComponentWrapper>) exprs[(2 - matchedPattern % 2)];
+        this.replacement = LiteralUtils.defendExpression(exprs[(1 + matchedPattern % 2)]);
+        return LiteralUtils.canInitSafely(this.replacement);
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     protected void execute(Event event) {
         Object replacement = this.replacement.getSingle(event);
-        String replacementString = replacement instanceof String s ? s : null;
-        ComponentWrapper replacementComp = replacement instanceof ComponentWrapper w ? w : null;
-        for (ComponentWrapper component : this.components.getArray(event)) {
-            for (String s : this.toReplace.getArray(event)) {
-                if (replacementString != null) component.replace(s, replacementString);
-                else if (replacementComp != null) component.replace(s, replacementComp);
-            }
-        }
+        String[] patterns = this.patterns.getArray(event);
+        if (replacement == null || patterns.length == 0) return;
+        //noinspection UnstableApiUsage - Skript marks changeInPlace as internal but is fine to use
+        this.components.changeInPlace(event, component -> {
+            component.replace(this.useRegex, this.replaceFirst, replacement, patterns);
+            return component;
+        });
     }
 
     @Override
-    public @NotNull String toString(Event e, boolean d) {
-        String toReplace = this.toReplace.toString(e, d);
-        String replace = this.replacement.toString(e, d);
-        String comp = this.components.toString(e, d);
-        return "component replace " + toReplace + " with " + replace + " in " + comp;
+    public @NotNull String toString(Event event, boolean debug) {
+        SyntaxStringBuilder syntaxBuilder = new SyntaxStringBuilder(event, debug);
+        syntaxBuilder.append("component");
+        if (this.useRegex) syntaxBuilder.append("regex");
+        syntaxBuilder.append("replace");
+        if (this.replaceFirst) syntaxBuilder.append("first");
+        syntaxBuilder.append(this.patterns, "with", this.replacement, "in", this.components);
+        return syntaxBuilder.toString();
     }
 
 }

--- a/src/test/scripts/elements/text/effects/EffComponentReplace.sk
+++ b/src/test/scripts/elements/text/effects/EffComponentReplace.sk
@@ -1,6 +1,14 @@
 test "SkBee - Text/EffComponentReplace":
 
-	set {_m} to mini message from "look mom im on tv"
-	assert {_m} = "look mom im on tv" with "Should be the same"
-	component replace "mom" with "dad" in {_m}
-	assert {_m} = "look dad im on tv" with "Should have changed"
+	set {_component} to text component from "Mom! Look! I'm on television!"
+	component replace "Mom" with "Dad" in {_component}
+	assert {_component} is "Dad! Look! I'm on television!"
+
+	set {_component} to text component from "Mom! Mom! Look at me!"
+	component replace first "Mom" in {_component} with "Dad"
+	assert {_component} is "Dad! Mom! Look at me!"
+
+	set {_component} to text component from "Hello! Hi! Howdy! Sup!"
+	component regex replace "(Hello|Howdy)" with "Salut" in {_component}
+	component regex replace "(Hi|Sup)" with "Hola" in {_component}
+	assert {_component} is "Salut! Hola! Salut! Hola!"


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->
Yeah more, this time I've focused changes onto the EffComponentReplace class, as it's something I always use and have been annoyed with more times than I can count (not very high).


- The changes proposed here are to allow the ability to opt into regex replacement rather than forcing it.
- As well as the option to only replace the first of each matched keyword.
- Add support for using objects for replacement (minor but just a bit more flexible usage + lazy support)

### NOTE:
Using `component replace first "X" and "Y" in {_var} with "Z"` will replace the first instance of both X and Y not one or the other this is due to patterns being reapplied each time.

Breaking change is caused by us now defaulting to literal match vs. regex match as players don't actively know regex, players who relied on this behavior either need to make it `component regex replace` or remove their escapes `\` in simple regex


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
