### PR TITLE
Add effective name support

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
@@ -1,0 +1,41 @@
+package com.shanebeestudios.skbee.elements.text.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import com.shanebeestudios.skbee.api.skript.base.SimplePropertyExpression;
+import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+@Name("TextComponent - Effective Name")
+@Description({"Gets the effective name of an item stack shown to player.",
+    "It takes into account the display name (with italics) from the item meta, the potion effect, translatable name, rarity etc"})
+@Examples("broadcast effective name of player's tool")
+@Since("INSERT VERSION")
+public class ExprEffectiveName extends SimplePropertyExpression<ItemStack, ComponentWrapper> {
+
+    private static final boolean HAS_EFFECTIVE_NAME = Skript.methodExists(ItemStack.class, "effectiveName");
+
+    static {
+        if (HAS_EFFECTIVE_NAME)
+            registerDefault(ExprEffectiveName.class, ComponentWrapper.class, "effective name", "itemstacks");
+    }
+
+    @Override
+    public @Nullable ComponentWrapper convert(ItemStack from) {
+        return ComponentWrapper.fromComponent(from.effectiveName());
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return "effective name";
+    }
+
+    @Override
+    public Class<? extends ComponentWrapper> getReturnType() {
+        return ComponentWrapper.class;
+    }
+}

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
@@ -22,7 +22,7 @@ public class ExprEffectiveName extends SimplePropertyExpression<ItemStack, Compo
 
     static {
         if (HAS_EFFECTIVE_NAME)
-            registerDefault(ExprEffectiveName.class, ComponentWrapper.class, "effective name", "itemstacks");
+            registerDefault(ExprEffectiveName.class, ComponentWrapper.class, "[component] effective name", "itemstacks");
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("TextComponent - Effective Name")
 @Description({"Gets the effective name of an item stack shown to the player.",
-    "It takes into account the display name (with italics) from the item meta, the potion effect, translatable name, rarity etc",
+    "It takes into account the display name (with italics) from the item meta, the potion effect, translatable name, rarity etc.",
     "Requires PaperMC 1.21.4+"})
 @Examples("broadcast effective name of player's tool")
 @Since("INSERT VERSION")
@@ -39,4 +39,5 @@ public class ExprEffectiveName extends SimplePropertyExpression<ItemStack, Compo
     public Class<? extends ComponentWrapper> getReturnType() {
         return ComponentWrapper.class;
     }
+
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
@@ -12,7 +12,8 @@ import org.jetbrains.annotations.Nullable;
 
 @Name("TextComponent - Effective Name")
 @Description({"Gets the effective name of an item stack shown to player.",
-    "It takes into account the display name (with italics) from the item meta, the potion effect, translatable name, rarity etc"})
+    "It takes into account the display name (with italics) from the item meta, the potion effect, translatable name, rarity etc",
+    "Requires PaperMC 1.21.4+"})
 @Examples("broadcast effective name of player's tool")
 @Since("INSERT VERSION")
 public class ExprEffectiveName extends SimplePropertyExpression<ItemStack, ComponentWrapper> {

--- a/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/text/expressions/ExprEffectiveName.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 @Name("TextComponent - Effective Name")
-@Description({"Gets the effective name of an item stack shown to player.",
+@Description({"Gets the effective name of an item stack shown to the player.",
     "It takes into account the display name (with italics) from the item meta, the potion effect, translatable name, rarity etc",
     "Requires PaperMC 1.21.4+"})
 @Examples("broadcast effective name of player's tool")


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->
This PR aims to add support for the effective name of an ItemStack, this method is provided by paper as of 1.21.4.


### Note:
Wasn't sure how viable a test would be for this, as the most we can test for currently is display name and item name not the potion display name or translation name.

---
**Target Minecraft Versions:** 1.21.4+ <!-- 'any' means all supported versions -->  
**Requirements:** Paper <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [ ] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
