### PR TITLE
ExprRayTraceFromLocation.java - Throw runtime error if vector is zero

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/raytrace/expressions/ExprRayTraceFromLocation.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/raytrace/expressions/ExprRayTraceFromLocation.java
@@ -10,8 +10,8 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.base.SimpleExpression;
 import com.shanebeestudios.skbee.api.util.EntityUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
@@ -93,6 +93,10 @@ public class ExprRayTraceFromLocation extends SimpleExpression<RayTraceResult> {
 
         List<RayTraceResult> results = new ArrayList<>();
         for (Vector vector : this.vectors.getArray(event)) {
+            if (vector.isZero()) {
+                error("A ray trace may not trace along a zero vector");
+                continue;
+            }
             RayTraceResult rayTraceResult = world.rayTrace(location, vector, maxDistance,
                 FluidCollisionMode.NEVER, this.ignore, raySize,
                 EntityUtils.filter(null, ignoredEntities), filteredBlocks(ignoredBlocks));


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->

This PR aims to fix an issue when attempting to raytrace from a magnitude of 0, in addition a new runtime error is provided to help players catch this issue in the future.
<img width="946" height="65" alt="image" src="https://github.com/user-attachments/assets/3c2132dc-ba3c-4d33-8434-f1df5be75ae1" />

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** #874 <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
