### PR TITLE
Switch BossBars to Adventure BossBars

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/api/util/BossBarUtils.java
+++ b/src/main/java/com/shanebeestudios/skbee/api/util/BossBarUtils.java
@@ -1,14 +1,26 @@
 package com.shanebeestudios.skbee.api.util;
 
 import ch.njol.skript.util.SkriptColor;
-import org.bukkit.boss.BarColor;
+import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.bossbar.BossBar.Overlay;
+import net.kyori.adventure.key.Key;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Util class for translating BarColor to/from Skript Color
  */
 public class BossBarUtils {
 
-    public static SkriptColor getSkriptColor(BarColor barColor) {
+    private static final Map<Key, BossBar> BARS_BY_KEY = new HashMap<>();
+    private static final Map<BossBar, @Nullable Key> KEYS_BY_BAR = new HashMap<>();
+
+    public static SkriptColor getSkriptColor(BossBar.Color barColor) {
         return switch (barColor) {
             case RED -> SkriptColor.DARK_RED;
             case YELLOW -> SkriptColor.YELLOW;
@@ -20,16 +32,50 @@ public class BossBarUtils {
         };
     }
 
-    public static BarColor getBossBarColor(SkriptColor skriptColor) {
+    public static BossBar.Color getBossBarColor(SkriptColor skriptColor) {
         return switch (skriptColor) {
-            case DARK_GREY, LIGHT_GREY, WHITE -> BarColor.WHITE;
-            case DARK_BLUE, DARK_CYAN, LIGHT_CYAN -> BarColor.BLUE;
-            case DARK_GREEN, LIGHT_GREEN -> BarColor.GREEN;
-            case YELLOW, ORANGE -> BarColor.YELLOW;
-            case DARK_RED -> BarColor.RED;
-            case LIGHT_RED -> BarColor.PINK;
-            default -> BarColor.PURPLE;
+            case DARK_GREY, LIGHT_GREY, WHITE -> BossBar.Color.WHITE;
+            case DARK_BLUE, DARK_CYAN, LIGHT_CYAN -> BossBar.Color.BLUE;
+            case DARK_GREEN, LIGHT_GREEN -> BossBar.Color.GREEN;
+            case YELLOW, ORANGE -> BossBar.Color.YELLOW;
+            case DARK_RED -> BossBar.Color.RED;
+            case LIGHT_RED -> BossBar.Color.PINK;
+            default -> BossBar.Color.PURPLE;
         };
+    }
+
+    public static @Nullable BossBar getByKey(Key key) {
+        return BARS_BY_KEY.get(key);
+    }
+
+    public static @Nullable Key getKey(BossBar bossBar) {
+        return KEYS_BY_BAR.get(bossBar);
+    }
+
+    public static List<BossBar> getAllBossBars() {
+        return new ArrayList<>(KEYS_BY_BAR.keySet());
+    }
+
+    public static void removeBossBar(BossBar bossBar) {
+        KEYS_BY_BAR.remove(bossBar);
+        List<Key> keys = new ArrayList<>();
+        BARS_BY_KEY.forEach((key, bossBar1) -> {
+            if (bossBar1.equals(bossBar)) keys.add(key);
+        });
+        keys.forEach(BARS_BY_KEY::remove);
+    }
+
+    public static BossBar create(Key key, ComponentWrapper title, SkriptColor color, Overlay style, float progress) {
+        BossBar bossBar = BossBar.bossBar(title.getComponent(), progress, getBossBarColor(color), style);
+        BARS_BY_KEY.put(key, bossBar);
+        KEYS_BY_BAR.put(bossBar, key);
+        return bossBar;
+    }
+
+    public static BossBar create(ComponentWrapper title, SkriptColor color, Overlay style, float progress) {
+        BossBar bossBar = BossBar.bossBar(title.getComponent(), progress, getBossBarColor(color), style);
+        KEYS_BY_BAR.put(bossBar, null);
+        return bossBar;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarAll.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarAll.java
@@ -10,8 +10,8 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.Bukkit;
-import org.bukkit.boss.BossBar;
+import com.shanebeestudios.skbee.api.util.BossBarUtils;
+import net.kyori.adventure.bossbar.BossBar;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,21 +27,17 @@ public class ExprBossBarAll extends SimpleExpression<BossBar> {
 
     static {
         Skript.registerExpression(ExprBossBarAll.class, BossBar.class, ExpressionType.SIMPLE,
-                "all boss[ ]bars");
+            "all boss[ ]bars");
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         return true;
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     protected @Nullable BossBar[] get(Event event) {
-        List<BossBar> bars = new ArrayList<>();
-        Bukkit.getBossBars().forEachRemaining(bars::add);
-        return bars.toArray(new BossBar[0]);
+        return BossBarUtils.getAllBossBars().toArray(new BossBar[0]);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarByID.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarByID.java
@@ -10,11 +10,10 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.util.BossBarUtils;
 import com.shanebeestudios.skbee.api.util.Util;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.bossbar.BossBar;
 import org.bukkit.NamespacedKey;
-import org.bukkit.boss.BossBar;
-import org.bukkit.boss.KeyedBossBar;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,21 +33,20 @@ public class ExprBossBarByID extends SimpleExpression<BossBar> {
 
     private Expression<String> key;
 
-    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
         this.key = (Expression<String>) exprs[0];
         return true;
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     protected BossBar @Nullable [] get(Event event) {
         String name = this.key.getSingle(event);
         if (name == null) return null;
         NamespacedKey key = Util.getNamespacedKey(name, true);
         if (key != null) {
-            KeyedBossBar bossBar = Bukkit.getBossBar(key);
+            BossBar bossBar = BossBarUtils.getByKey(key);
             if (bossBar != null) return new BossBar[]{bossBar};
         }
         return null;

--- a/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarEntity.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bossbar/expressions/ExprBossBarEntity.java
@@ -10,8 +10,7 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import org.bukkit.Bukkit;
-import org.bukkit.boss.BossBar;
+import net.kyori.adventure.bossbar.BossBar;
 import org.bukkit.entity.Boss;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -24,50 +23,50 @@ import java.util.List;
 
 @Name("BossBar - Entity/Player")
 @Description({"Get a BossBar from an entity (such as a wither) or all BossBars of players.",
-        "NOTE: BossBars from entities cannot be saved in global variables, as the entity may not be loaded on the",
-        "server when that variable is trying to load. Custom BossBars and BossBars from players can be saved in variables."})
+    "NOTE: BossBars from entities cannot be saved in global variables, as the entity may not be loaded on the",
+    "server when that variable is trying to load. Custom BossBars and BossBars from players can be saved in variables."})
 @Examples({"set {_bar} to boss bar of target entity",
-        "set {_bars::*} to boss bars of player"})
+    "set {_bars::*} to boss bars of player"})
 @Since("2.14.1")
 public class ExprBossBarEntity extends SimpleExpression<BossBar> {
 
     static {
         Skript.registerExpression(ExprBossBarEntity.class, BossBar.class, ExpressionType.COMBINED,
-                "boss[ ]bar of %entity%",
-                "boss[ ]bars of %players%");
+            "boss[ ]bar of %entity%",
+            "boss[ ]bars of %players%");
     }
 
     private int pattern;
     private Expression<Entity> entity;
     private Expression<Player> players;
 
-    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @SuppressWarnings({"unchecked"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-        pattern = matchedPattern;
-        this.entity = pattern == 0 ? (Expression<Entity>) exprs[0] : null;
-        this.players = pattern == 1 ? (Expression<Player>) exprs[0] : null;
+        this.pattern = matchedPattern;
+        if (this.pattern == 0) {
+            Skript.error("Getting the bossbar of an entity is currently broken!");
+            return false;
+        }
+        this.entity = this.pattern == 0 ? (Expression<Entity>) exprs[0] : null;
+        this.players = this.pattern == 1 ? (Expression<Player>) exprs[0] : null;
         return true;
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     protected @Nullable BossBar[] get(Event event) {
-        if (pattern == 0 && this.entity != null) {
+        if (this.pattern == 0 && this.entity != null) {
             Entity entity = this.entity.getSingle(event);
             if (entity instanceof Boss boss) {
-                return new BossBar[]{boss.getBossBar()};
+                //TODO what to do?!?! (Boss doesnt have a method to get an Adventure bossbar)
+                //return new BossBar[]{boss.getBossBar()};
             }
-        } else if (pattern == 1 && this.players != null) {
+        } else if (this.pattern == 1 && this.players != null) {
             List<BossBar> bars = new ArrayList<>();
-            Player[] players = this.players.getArray(event);
-            Bukkit.getBossBars().forEachRemaining(bossBar -> {
-                for (Player player : players) {
-                    if (bossBar.getPlayers().contains(player) && !bars.contains(bossBar)) {
-                        bars.add(bossBar);
-                    }
-                }
-            });
+            for (Player player : this.players.getArray(event)) {
+                player.activeBossBars().forEach(bars::add);
+
+            }
             return bars.toArray(new BossBar[0]);
         }
         return null;
@@ -75,7 +74,7 @@ public class ExprBossBarEntity extends SimpleExpression<BossBar> {
 
     @Override
     public boolean isSingle() {
-        return pattern == 0;
+        return this.pattern == 0;
     }
 
     @Override
@@ -85,7 +84,7 @@ public class ExprBossBarEntity extends SimpleExpression<BossBar> {
 
     @Override
     public @NotNull String toString(@Nullable Event e, boolean d) {
-        if (pattern == 0) return "boss bar of entity " + this.entity.toString(e, d);
+        if (this.pattern == 0) return "boss bar of entity " + this.entity.toString(e, d);
         return "boss bars of players " + this.players.toString(e, d);
     }
 

--- a/src/main/java/com/shanebeestudios/skbee/elements/bossbar/types/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/bossbar/types/Types.java
@@ -3,24 +3,18 @@ package com.shanebeestudios.skbee.elements.bossbar.types;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
-import ch.njol.skript.classes.Serializer;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.util.coll.CollectionUtils;
-import ch.njol.yggdrasil.Fields;
+import com.shanebeestudios.skbee.api.util.BossBarUtils;
 import com.shanebeestudios.skbee.api.util.Util;
+import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import com.shanebeestudios.skbee.api.wrapper.EnumWrapper;
-import org.bukkit.Bukkit;
-import org.bukkit.NamespacedKey;
-import org.bukkit.boss.BarFlag;
-import org.bukkit.boss.BarStyle;
-import org.bukkit.boss.BossBar;
-import org.bukkit.boss.KeyedBossBar;
-import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.StreamCorruptedException;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused")
 public class Types {
@@ -28,148 +22,100 @@ public class Types {
     static {
         if (Classes.getExactClassInfo(BossBar.class) == null) {
             Classes.registerClass(new ClassInfo<>(BossBar.class, "bossbar")
-                    .user("boss ?bars?")
-                    .name("BossBar")
-                    .description("Represents a BossBar. Either from an entity or a custom one.",
-                            "Players can be added to/removed from BossBars.",
-                            "Custom BossBars can be deleted, BossBars of entities cannot be deleted.",
-                            "NOTE: BossBars from entities cannot be saved in global variables, as the entity may not be loaded",
-                            "on the server when that variable is trying to load. Custom BossBars can be saved in variables.")
-                    .examples("set {_bar} to boss bar named \"le-bar\"",
-                            "add all players to {_bar}")
-                    .since("1.16.0")
-                    .parser(new Parser<>() {
+                .user("boss ?bars?")
+                .name("BossBar")
+                .description("Represents a BossBar. Either from an entity or a custom one.",
+                    "Players can be added to/removed from BossBars.",
+                    "Custom BossBars can be deleted, BossBars of entities cannot be deleted.",
+                    "**NOTE**: BossBars cannot be saved in global variables.")
+                .examples("set {_bar} to boss bar named \"le-bar\"",
+                    "add all players to {_bar}")
+                .since("1.16.0")
+                .parser(new Parser<>() {
+                    @Override
+                    public boolean canParse(ParseContext context) {
+                        return false;
+                    }
 
-                        @SuppressWarnings("NullableProblems")
-                        @Override
-                        public boolean canParse(ParseContext context) {
-                            return false;
+                    @Override
+                    public @NotNull String toString(BossBar bossBar, int flags) {
+                        Key key = BossBarUtils.getKey(bossBar);
+                        String name;
+                        if (key == null) {
+                            name = ComponentWrapper.fromComponent(bossBar.name()).toString();
+                        } else {
+                            name = key.toString();
                         }
+                        return "BossBar[" + name + "]";
+                    }
 
-                        @Override
-                        public @NotNull String toString(BossBar bossBar, int flags) {
-                            String bar;
-                            if (bossBar instanceof KeyedBossBar keyedBossBar) {
-                                bar = keyedBossBar.getKey().toString();
-                            } else {
-                                bar = "nokey:" + bossBar.getTitle();
-                            }
-                            return "BossBar[" + bar + "]";
-                        }
+                    @Override
+                    public @NotNull String toVariableNameString(BossBar bossBar) {
+                        return toString(bossBar, 0);
+                    }
+                })
+                .changer(new Changer<>() {
+                    @Override
+                    public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
+                        if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.REMOVE_ALL)
+                            return CollectionUtils.array(Audience[].class);
+                        if (mode == ChangeMode.DELETE) return CollectionUtils.array();
+                        return null;
+                    }
 
-                        @Override
-                        public @NotNull String toVariableNameString(BossBar bossBar) {
-                            return toString(bossBar, 0);
-                        }
-                    })
-                    .changer(new Changer<>() {
-                        @SuppressWarnings("NullableProblems")
-                        @Override
-                        public Class<?> @Nullable [] acceptChange(ChangeMode mode) {
-                            if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.REMOVE_ALL)
-                                return CollectionUtils.array(Player[].class);
-                            if (mode == ChangeMode.DELETE) return CollectionUtils.array();
-                            return null;
-                        }
+                    @SuppressWarnings("ConstantValue")
+                    @Override
+                    public void change(BossBar[] bossBars, @Nullable Object[] delta, ChangeMode mode) {
+                        if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.REMOVE_ALL) {
+                            if (delta == null) return;
 
-                        @SuppressWarnings({"NullableProblems", "ConstantValue"})
-                        @Override
-                        public void change(BossBar[] bossBars, @Nullable Object[] delta, ChangeMode mode) {
-                            if (mode == ChangeMode.ADD || mode == ChangeMode.REMOVE || mode == ChangeMode.REMOVE_ALL) {
-                                if (delta == null) return;
-
-                                for (BossBar bossBar : bossBars) {
-                                    for (Object object : delta) {
-                                        if (object instanceof Player player) {
-                                            if (mode == ChangeMode.ADD) bossBar.addPlayer(player);
-                                            else bossBar.removePlayer(player);
-                                        }
-                                    }
-                                }
-                            }
-                            if (mode == ChangeMode.DELETE) {
-                                for (BossBar bossBar : bossBars) {
-                                    bossBar.removeAll();
-                                    if (bossBar instanceof KeyedBossBar keyedBossBar) {
-                                        Bukkit.removeBossBar(keyedBossBar.getKey());
+                            for (BossBar bossBar : bossBars) {
+                                for (Object object : delta) {
+                                    if (object instanceof Audience audience) {
+                                        if (mode == ChangeMode.ADD) bossBar.addViewer(audience);
+                                        else bossBar.removeViewer(audience);
                                     }
                                 }
                             }
                         }
-                    })
-                    .serializer(new Serializer<>() {
-
-                        @SuppressWarnings("NullableProblems")
-                        @Override
-                        public Fields serialize(BossBar bossBar) {
-                            Fields fields = new Fields();
-                            if (bossBar instanceof KeyedBossBar keyedBossBar) {
-                                NamespacedKey key = keyedBossBar.getKey();
-                                fields.putObject("namespace", key.getNamespace());
-                                fields.putObject("key", key.getKey());
+                        if (mode == ChangeMode.DELETE) {
+                            for (BossBar bossBar : bossBars) {
+                                bossBar.viewers().forEach(bossBarViewer -> {
+                                    if (bossBarViewer instanceof Audience audience) bossBar.removeViewer(audience);
+                                });
+                                BossBarUtils.removeBossBar(bossBar);
                             }
-                            return fields;
                         }
-
-                        @SuppressWarnings("NullableProblems")
-                        @Override
-                        public void deserialize(BossBar o, Fields f) {
-                        }
-
-                        @SuppressWarnings("NullableProblems")
-                        @Override
-                        protected BossBar deserialize(Fields fields) throws StreamCorruptedException {
-                            String name = fields.getObject("namespace", String.class);
-                            String key = fields.getObject("key", String.class);
-
-                            assert name != null;
-                            assert key != null;
-                            NamespacedKey namespacedKey = new NamespacedKey(name, key);
-                            KeyedBossBar bossBar = Bukkit.getBossBar(namespacedKey);
-                            if (bossBar == null) {
-                                throw new StreamCorruptedException("Missing Bossbar: [" + name + ":" + key + "]");
-                            }
-                            return bossBar;
-                        }
-
-                        @Override
-                        public boolean mustSyncDeserialization() {
-                            return false;
-                        }
-
-                        @Override
-                        protected boolean canBeInstantiated() {
-                            return false;
-                        }
-                    }));
+                    }
+                }));
         } else {
             Util.logLoading("&eIt looks like another addon registered 'bossbar' already.");
             Util.logLoading("&eYou may have to use their BossBars in SkBee's BossBar elements.");
         }
 
-        if (Classes.getExactClassInfo(BarStyle.class) == null && Classes.getClassInfoNoError("bossbarstyle") == null) {
-            EnumWrapper<BarStyle> BAR_STYLE_ENUM = new EnumWrapper<>(BarStyle.class);
+        if (Classes.getExactClassInfo(BossBar.Overlay.class) == null && Classes.getClassInfoNoError("bossbarstyle") == null) {
+            EnumWrapper<BossBar.Overlay> BAR_STYLE_ENUM = new EnumWrapper<>(BossBar.Overlay.class);
             // Prevent conflict with Skript's `is solid` condition
             BAR_STYLE_ENUM.replace("solid", "solid bar");
             Classes.registerClass(BAR_STYLE_ENUM.getClassInfo("bossbarstyle")
-                    .user("boss ?bar ?styles?")
-                    .name("BossBar Style")
-                    .description("Represents the style options of a BossBar.")
-                    .examples("set bar style of {_bar} to segmented 20")
-                    .since("1.16.0"));
+                .user("boss ?bar ?styles?")
+                .name("BossBar Style")
+                .description("Represents the style options of a BossBar.")
+                .examples("set bar style of {_bar} to notched_20")
+                .since("1.16.0"));
         } else {
             Util.logLoading("&eIt looks like another addon registered 'boss bar style' already.");
             Util.logLoading("&eYou may have to use their BossBar styles in SkBee's BossBar elements.");
         }
 
-        if (Classes.getExactClassInfo(BarFlag.class) == null && Classes.getClassInfoNoError("bossbarflag") == null) {
-            EnumWrapper<BarFlag> BAR_FLAG_ENUM = new EnumWrapper<>(BarFlag.class);
+        if (Classes.getExactClassInfo(BossBar.Flag.class) == null && Classes.getClassInfoNoError("bossbarflag") == null) {
+            EnumWrapper<BossBar.Flag> BAR_FLAG_ENUM = new EnumWrapper<>(BossBar.Flag.class);
             Classes.registerClass(BAR_FLAG_ENUM.getClassInfo("bossbarflag")
-                    .user("boss ?bar ?flags?")
-                    .name("BossBar Flag")
-                    .description("Represents the flag options of a BossBar.")
-                    .examples("set bar flag darken sky of {_bar} to true")
-                    .since("1.16.0"));
+                .user("boss ?bar ?flags?")
+                .name("BossBar Flag")
+                .description("Represents the flag options of a BossBar.")
+                .examples("set bar flag darken_screen of {_bar} to true")
+                .since("1.16.0"));
         } else {
             Util.logLoading("&eIt looks like another addon registered 'boss bar flag' already.");
             Util.logLoading("&eYou may have to use their BossBar flags in SkBee's BossBar elements.");

--- a/src/test/scripts/general/bossbar.sk
+++ b/src/test/scripts/general/bossbar.sk
@@ -1,32 +1,32 @@
 test "SkBee - Bossbars":
 	set {_size} to size of all bossbars
 	# Creation
-	set {_bar} to new bossbar with id "test_bar" with title "Test Bossbar" with color red with style segmented_6 with progress 50
+	set {_bar} to new bossbar with id "test_bar" with title "Test Bossbar" with color red with style notched_6 with progress 50
 	assert bossbar players of {_bar} is not set with "The bar should have no players"
-	assert bossbar style of {_bar} = segmented_6 with "The bar's style should be segmented_6"
+	assert bossbar style of {_bar} = notched_6 with "The bar's style should be notched_6"
 	assert bossbar title of {_bar} = "Test Bossbar" with "The bar's title should be 'Test Bossbar'"
 	assert bossbar progress of {_bar} = 50 with "The bar's progress should be 50"
-	assert bossbar visibility of {_bar} = true with "The bar should be visible"
 	assert size of all bossbars = ({_size} + 1) with "Size of all bossbars should be 1 higher than before"
 
 	# Flags
-	assert bossbar flag create_fog of {_bar} = false with "The flag should be false by default"
-	assert bossbar flag darken_sky of {_bar} = false with "The flag should be false by default"
+	assert bossbar flag create_world_fog of {_bar} = false with "The flag should be false by default"
+	assert bossbar flag darken_screen of {_bar} = false with "The flag should be false by default"
 	assert bossbar flag play_boss_music of {_bar} = false with "The flag should be false by default"
-	set bossbar flag create_fog of {_bar} to true
-	set bossbar flag darken_sky of {_bar} to true
+	set bossbar flag create_world_fog of {_bar} to true
+	set bossbar flag darken_screen of {_bar} to true
 	set bossbar flag play_boss_music of {_bar} to true
-	assert bossbar flag create_fog of {_bar} = true with "The flag should be true after setting"
-	assert bossbar flag darken_sky of {_bar} = true with "The flag should be true after setting"
+	assert bossbar flag create_world_fog of {_bar} = true with "The flag should be true after setting"
+	assert bossbar flag darken_screen of {_bar} = true with "The flag should be true after setting"
 	assert bossbar flag play_boss_music of {_bar} = true with "The flag should be true after setting"
 
 	# Entity
-	spawn a wither at event-location:
-		set {_e} to entity
-	set {_ebar} to bossbar of {_e}
-	assert {_ebar} is set with "The wither should have a bossbar"
+	# Curently broken, hope to fix
+	#spawn a wither at event-location:
+	#	set {_e} to entity
+	#set {_ebar} to bossbar of {_e}
+	#assert {_ebar} is set with "The wither should have a bossbar"
 
 	# Cleanup
 	delete bossbar with id "test_bar"
-	delete entity within {_e}
+	#delete entity within {_e}
 	assert size of all bossbars = {_size} with "Size of all bossbars should be what we started with"


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
This PR aims to switch from Bukkit BossBars to Adventure BossBars.

Why?
They have better Adventure Component support.
For a while several people have asked for proper adventure component support, mainly to use fonts in the title.

Issues:
- Currently Paper has no way to get an Adventure BossBar from a Boss Entity/Raid. I have made a PR for this
https://github.com/PaperMC/Paper/issues/13541
- Adventure BossBars have no Key, so Im just plopping them in a map to help with that
- Adventure BossBars are not saved to file at all, therefor cannot be serialized
- There is no option to hide/show an Adventure BossBar so the visibility option was removed
- Some of the flags and styles have changed (breaking change):
  - Flag `darken_sky` -> `darken_screen`
  - Flag `create_fog` -> `create_world_fog`
  - Style `segmented_x` -> `notched_x`
  - Style `solid_bar` -> `progress`

Holy crap, I'm starting to think this is a lot of changes just to support a freaking font 🤣 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
