### PR TITLE
Add PlayerClientLoadedWorldEvent

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/events/PaperEvents.java
@@ -394,8 +394,9 @@ public class PaperEvents extends SimpleEvent {
         }, EventValues.TIME_FUTURE);
 
         Skript.registerEvent("Player Client Load World", PaperEvents.class, PlayerClientLoadedWorldEvent.class, "player client load world")
-            .description("Called when the player's client has officially loaded into the world, this is called after the join event.",
-                "This event may also be called when a player timeouts if the player fails to load into the world.")
+            .description("Called when a player is marked as loaded.", "",
+                "This either happens when the player notifies the server after loading the world (closing the downloading terrain screen)",
+                "or when the player has not done so for 60 ticks after joining the server or respawning.")
             .examples("on client load world:", "\tbroadcast \"%player% has loaded into the world%\"")
             .since("INSERT VERSION");
 


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->

This PR aims to add the [`PlayerClientLoadedWorldEvent`](https://jd.papermc.io/paper/1.21.11/io/papermc/paper/event/player/PlayerClientLoadedWorldEvent.html), while there aren't too many uses this has some helpful cases where interacting with a player too early may mean changes don't affect leading to users using `wait a second`

I'm not sold on the event name or pattern I just couldn't think of any that didn't make this feel like I was creating as story.
```
player loads into world:
    broadcast "%player% has started the adventure to kill the demon king!"
```

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
