### PR TITLE
Add a method for converting a blockface to a skript direction

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockfaceDirection.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockfaceDirection.java
@@ -16,9 +16,9 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 @Name("BlockFace - Direction")
-@Description({"Gets a skript direction using a blockface with an optional distance value",
-    "not defining a distance will default it to 0",
-    "**NOTE:** this will not work using the `self_face` block face, as Skript makes it NaN"})
+@Description({"Gets a skript direction using a blockface with an optional distance value.",
+    "Not defining a distance will default it to 0.",
+    "**NOTE:** this will not work using the `self_face` block face, as Skript makes it NaN."})
 @Examples({"set {_raytrace} to raytrace from player with max distance {_maxDistance}",
     "set {_direction} to direction of (hit blockface of {_raytrace})",
     "spawn zombie {_direction} player"})

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockfaceDirection.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/expressions/ExprBlockfaceDirection.java
@@ -1,0 +1,68 @@
+package com.shanebeestudios.skbee.elements.other.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.util.Direction;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.skbee.api.skript.base.SimpleExpression;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("BlockFace - Direction")
+@Description({"Gets a skript direction using a blockface with an optional distance value",
+    "not defining a distance will default it to 0",
+    "**NOTE:** this will not work using the `self_face` block face, as Skript makes it NaN"})
+@Examples({"set {_raytrace} to raytrace from player with max distance {_maxDistance}",
+    "set {_direction} to direction of (hit blockface of {_raytrace})",
+    "spawn zombie {_direction} player"})
+@Since("INSERT VERSION")
+public class ExprBlockfaceDirection extends SimpleExpression<Direction> {
+
+    static {
+        Skript.registerExpression(ExprBlockfaceDirection.class, Direction.class, ExpressionType.COMBINED,
+            "direction of %blockface% [with distance %-number%]");
+    }
+
+    private Expression<BlockFace> blockFace;
+    private Expression<Number> distance;
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+        this.blockFace = (Expression<BlockFace>) expressions[0];
+        this.distance = (Expression<Number>) expressions[1];
+        return true;
+    }
+
+    @Override
+    protected Direction @Nullable [] get(Event event) {
+        BlockFace blockFace = this.blockFace.getSingle(event);
+        Number distance = this.distance != null ? this.distance.getOptionalSingle(event).orElse(0) : 0;
+        if (blockFace == null) return new Direction[0];
+        return new Direction[]{ new Direction(blockFace, distance.doubleValue())};
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public Class<? extends Direction> getReturnType() {
+        return Direction.class;
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        if (this.distance != null)
+            return "direction of " + this.blockFace.toString(event, debug) + " with distance " + this.distance.toString(event, debug);
+        return "direction of " + this.blockFace.toString(event, debug);
+    }
+
+}


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->

This PR aims to add support for converting a blockface into a valid skript direction.
I needed this to help simplify the backend of a system for preventing an entity from spawning inside walls and figured others might find more useful needs.

*image is from older build*
<img width="623" height="183" alt="image" src="https://github.com/user-attachments/assets/caa7fa26-c842-40c4-99a7-00e45fbcd195" />


---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->  
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
