### PR TITLE
Fixes player connection not existing on some versions

### DIFF
--- a/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffFreezePlayerConnection.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/effects/EffFreezePlayerConnection.java
@@ -57,9 +57,10 @@ public class EffFreezePlayerConnection extends Effect {
     private static final Map<UUID, CompletableFuture<Component>> AWAITING_RESPONSE = new ConcurrentHashMap<>();
 
     static {
-        Skript.registerEffect(EffFreezePlayerConnection.class,
-            "freeze connection %playerconnection/audience% [with timeout message %-textcomponent%]",
-            "unfreeze connection %playerconnection/audience% [and disconnect due to %-textcomponent%]");
+        if (Skript.classExists("io.papermc.paper.connection.PlayerConfigurationConnection"))
+            Skript.registerEffect(EffFreezePlayerConnection.class,
+                "freeze connection %playerconnection/audience% [with timeout message %-textcomponent%]",
+                "unfreeze connection %playerconnection/audience% [and disconnect due to %-textcomponent%]");
     }
 
     private boolean freeze;

--- a/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
+++ b/src/main/java/com/shanebeestudios/skbee/elements/other/type/Types.java
@@ -507,17 +507,19 @@ public class Types {
         Classes.registerClass(audienceClassInfo);
         setupUsage(audienceClassInfo);
 
-        if (Classes.getExactClassInfo(PlayerConnection.class) == null) {
-            Classes.registerClass(new ClassInfo<>(PlayerConnection.class, "playerconnection")
-                .user("player ?connections?")
-                .name("Player Connection")
-                .description("Represents the connection of a player in an async connect config event and custom click event.")
-                .defaultExpression(new EventValueExpression<>(PlayerConnection.class))
-                .parser(SkriptUtils.getDefaultParser())
-                .since("3.16.0"));
-        } else {
-            Util.logLoading("It looks like another addon registered 'playerconnection' already.");
-            Util.logLoading("You may have to use their PlayerConnection in SkBee's syntaxes.");
+        if (Skript.classExists("io.papermc.paper.connection.PlayerConnection")) {
+            if (Classes.getExactClassInfo(PlayerConnection.class) == null) {
+                Classes.registerClass(new ClassInfo<>(PlayerConnection.class, "playerconnection")
+                    .user("player ?connections?")
+                    .name("Player Connection")
+                    .description("Represents the connection of a player in an async connect config event and custom click event.")
+                    .defaultExpression(new EventValueExpression<>(PlayerConnection.class))
+                    .parser(SkriptUtils.getDefaultParser())
+                    .since("3.16.0"));
+            } else {
+                Util.logLoading("It looks like another addon registered 'playerconnection' already.");
+                Util.logLoading("You may have to use their PlayerConnection in SkBee's syntaxes.");
+            }
         }
 
         if (Classes.getExactClassInfo(EntityKnockbackEvent.Cause.class) == null) {


### PR DESCRIPTION
The PlayerConnection doesn't exist on versions below 1.21.6 and throws errors on startup resulting in the freeze connection syntax getting a malformed pattern exception.


---
**Target Minecraft Versions:** Below 1.21.6
**Requirements:** none <!-- Any required server software, such as Paper?-->  
**Related Issues:** none <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [x] Tests have been added if necessary
- [x] I have read the [contributing guidelines](https://github.com/ShaneBeee/SkBee/blob/master/.github/contributing.md)
